### PR TITLE
chore: codecov, deploy-branch guard, ways-of-working rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/guard-deploy-branches.yml
+++ b/.github/workflows/guard-deploy-branches.yml
@@ -1,0 +1,15 @@
+name: Guard deploy branches
+
+on:
+  pull_request:
+    branches: [beta, stable]
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only allow merges from main
+        if: github.head_ref != 'main'
+        run: |
+          echo "::error::Only the 'main' branch can be merged into '${{ github.base_ref }}'. Got '${{ github.head_ref }}'."
+          exit 1

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+pnpm-lock.yaml
+node_modules
+**/dist
+coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,38 @@
 
 ## Working Style
 
-Critical thinking, no rubber-stamping, no shortcuts. Auto-commit + push + PR on branches without asking.
+Never blindly implement a suggestion. Apply critical thinking — push back when something is wrong, over-engineered, or has a better alternative. Ask clarifying questions. Offer alternatives. Collaborative, not a rubber stamp.
 
-**Never commit and push directly to `main`.**
+**No shortcuts or temporary fixes.** Do not implement workarounds or "for now" solutions that paper over a real problem. If the proper fix belongs in a different repo or requires upstream work, say so and stop. Every fix must address the root cause.
+
+**Never commit and push directly to `main`.** `main` is protected — all changes go through a PR. No exceptions.
+
+**Auto-commit, push, and open PR on branches.** When working on a `feat/fix/chore` branch, commit, push, **and create a PR with `gh pr create`** without asking. Every push to a branch must result in a PR. If a PR already exists, just push.
+
+**Never remove worktrees locally.** The user manages worktree lifecycle — do not run `git worktree remove` or instruct sub-agents to do so.
+
+**No Claude attribution anywhere.** Do not add `Co-Authored-By: Claude` headers, and do not mention Claude in commit messages, PR titles, PR descriptions, or code comments.
+
+## Check PR/CI
+
+When asked to "check PR" or "check CI":
+
+1. `gh pr status` — open PRs
+2. `gh pr checks <number>` — CI status for a PR
+3. `gh pr view <number>` — PR details
+
+If CI is failing, **immediately investigate and fix** — do not ask whether to investigate. Fetch failure details, find the root cause, start fixing.
+
+## Worktree Workflow
+
+```bash
+git fetch origin
+# Branch from origin/main, not local main (may be stale)
+git worktree add ../compilerfish-sdk-js-issue-<N> -b feat/issue-<N>-short-desc origin/main
+cd ../compilerfish-sdk-js-issue-<N>
+```
+
+**Do not remove worktrees** — the user cleans them up.
 
 ## Project Overview
 
@@ -50,14 +79,31 @@ Pre-1.0 (`0.x.y`):
 - patch: bug fixes, internal refactors
 - minor: anything else (no SemVer guarantee in 0.x)
 
-## Branching
+## Branching & PR Workflow
 
 ```
 main (protected)
   └── feat/<short-description>
   └── fix/<short-description>
+  └── chore/<short-description>
 ```
 
-- Conventional commits
+### Workflow steps
+1. `git fetch origin` then create branch from `origin/main` (never from local `main`).
+2. Make changes, commit with conventional commits.
+3. Push branch, create PR with `gh pr create`.
+4. PR body references the issue (`Closes #<number>`) where applicable; link the SDD § 12 contract for public API changes.
+5. Wait for CI to pass. Squash-merge into `main` (the only allowed merge method).
+
+### Rules
+- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
 - Subject ≤ 72 chars
-- No `Co-Authored-By` headers
+- No `Co-Authored-By` headers — no Claude attribution anywhere
+
+### Branch protection (`main`)
+- Squash-merge only; no direct push, no force-push, no deletion.
+- Required status checks: `check`, `codecov/patch`, `codecov/project`.
+- Stale reviews dismissed on new push.
+
+### Deploy branches
+- `beta` and `stable` (if/when introduced) are deploy branches. PRs to them must originate from `main` (enforced by `guard-deploy-branches.yml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ pnpm format
 ```
 
 Per-package:
+
 ```bash
 pnpm --filter compilerfish-sdk build
 pnpm --filter compilerfish-react test
@@ -76,6 +77,7 @@ Every payload that leaves the device runs through `redact()` first. Adding a new
 Both packages move together for now (kept in lockstep). Once Phase 4 ships and the API is stable, they may diverge — at that point introduce changesets.
 
 Pre-1.0 (`0.x.y`):
+
 - patch: bug fixes, internal refactors
 - minor: anything else (no SemVer guarantee in 0.x)
 
@@ -89,6 +91,7 @@ main (protected)
 ```
 
 ### Workflow steps
+
 1. `git fetch origin` then create branch from `origin/main` (never from local `main`).
 2. Make changes, commit with conventional commits.
 3. Push branch, create PR with `gh pr create`.
@@ -96,14 +99,17 @@ main (protected)
 5. Wait for CI to pass. Squash-merge into `main` (the only allowed merge method).
 
 ### Rules
+
 - Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
 - Subject ≤ 72 chars
 - No `Co-Authored-By` headers — no Claude attribution anywhere
 
 ### Branch protection (`main`)
+
 - Squash-merge only; no direct push, no force-push, no deletion.
 - Required status checks: `check`, `codecov/patch`, `codecov/project`.
 - Stale reviews dismissed on new push.
 
 ### Deploy branches
+
 - `beta` and `stable` (if/when introduced) are deploy branches. PRs to them must originate from `main` (enforced by `guard-deploy-branches.yml`).

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ JS/TS SDK for [Compilerfish](https://github.com/tatlacas-com/compilerfish-ops) โ
 
 This is a pnpm workspace publishing two packages to npm:
 
-| Package | Purpose |
-|---------|---------|
-| [`compilerfish-sdk`](./packages/sdk) | Framework-agnostic core. Submit feedback from any browser app. |
-| [`compilerfish-react`](./packages/react) | React provider, floating FAB, `useFeedback` hook. |
+| Package                                  | Purpose                                                        |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| [`compilerfish-sdk`](./packages/sdk)     | Framework-agnostic core. Submit feedback from any browser app. |
+| [`compilerfish-react`](./packages/react) | React provider, floating FAB, `useFeedback` hook.              |
 
 **Canonical contract:** [`compilerfish-ops/docs/compilerfish-sdd.md` ยง 12](https://github.com/tatlacas-com/compilerfish-ops/blob/main/docs/compilerfish-sdd.md#12-client-sdk-contracts).
 
@@ -21,7 +21,7 @@ const cf = createCompilerfish({
   buildSha: process.env.BUILD_SHA,
 });
 
-const uninstall = cf.install();   // installs console + fetch rings
+const uninstall = cf.install(); // installs console + fetch rings
 
 await cf.submit({
   description: 'Customer modal hangs on second open',
@@ -36,7 +36,7 @@ import { CompilerfishProvider, FeedbackButton } from 'compilerfish-react';
 <CompilerfishProvider config={{ projectKey: 'pk_live_...' }}>
   <App />
   <FeedbackButton />
-</CompilerfishProvider>
+</CompilerfishProvider>;
 ```
 
 ## Bundle budget

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - '**/dist/**'
+  - '**/*.d.ts'
+  - '**/index.ts'
+  - '**/test/**'
+  - '**/__tests__/**'
+  - '**/*.config.*'
+
+comment:
+  layout: 'reach,diff,flags,files'
+  require_changes: true

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,11 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -29,7 +33,13 @@
     "url": "git+https://github.com/tatlacas-com/compilerfish-sdk-js.git",
     "directory": "packages/react"
   },
-  "keywords": ["compilerfish", "react", "qa", "feedback", "bug-report"],
+  "keywords": [
+    "compilerfish",
+    "react",
+    "qa",
+    "feedback",
+    "bug-report"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,7 +14,11 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -29,7 +33,13 @@
     "url": "git+https://github.com/tatlacas-com/compilerfish-sdk-js.git",
     "directory": "packages/sdk"
   },
-  "keywords": ["compilerfish", "qa", "feedback", "bug-report", "ai"],
+  "keywords": [
+    "compilerfish",
+    "qa",
+    "feedback",
+    "bug-report",
+    "ai"
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary

Align `compilerfish-sdk-js` with tradekit repo hygiene:

- **`codecov.yml`** — project auto/threshold 5%, patch target 80%, ignores for `dist/`, `.d.ts`, index barrels, test fixtures, config files.
- **`.github/workflows/guard-deploy-branches.yml`** — enforces that PRs into `beta`/`stable` originate from `main`.
- **`CLAUDE.md` ways-of-working** — no shortcuts, root-cause-only, never delete worktrees locally, no Claude attribution, auto-open PRs on branches, fix failing CI without asking. Documents `main` branch protection (squash-only; required checks: `check`, `codecov/patch`, `codecov/project`).

Branch protection ruleset `main-protection` applied out-of-band.

## Test plan

- [ ] CI `check` job passes
- [ ] Codecov comment posts (requires `CODECOV_TOKEN` secret + repo registered at codecov.io)