### PR TITLE
chore: rename from compilerfish to brevwick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Compilerfish JS SDK
+# Brevwick JS SDK
 
 ## Working Style
 
@@ -29,19 +29,19 @@ If CI is failing, **immediately investigate and fix** — do not ask whether to 
 ```bash
 git fetch origin
 # Branch from origin/main, not local main (may be stale)
-git worktree add ../compilerfish-sdk-js-issue-<N> -b feat/issue-<N>-short-desc origin/main
-cd ../compilerfish-sdk-js-issue-<N>
+git worktree add ../brevwick-sdk-js-issue-<N> -b feat/issue-<N>-short-desc origin/main
+cd ../brevwick-sdk-js-issue-<N>
 ```
 
 **Do not remove worktrees** — the user cleans them up.
 
 ## Project Overview
 
-pnpm workspace publishing two npm packages: `compilerfish-sdk` (core, framework-agnostic) and `compilerfish-react` (React bindings).
+pnpm workspace publishing two npm packages: `brevwick-sdk` (core, framework-agnostic) and `brevwick-react` (React bindings).
 
-The canonical SDK contract lives at [`compilerfish-ops/docs/compilerfish-sdd.md` § 12](https://github.com/tatlacas-com/compilerfish-ops/blob/main/docs/compilerfish-sdd.md#12-client-sdk-contracts). Public API changes require an SDD update in the same PR (cross-repo).
+The canonical SDK contract lives at [`brevwick-ops/docs/brevwick-sdd.md` § 12](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts). Public API changes require an SDD update in the same PR (cross-repo).
 
-**GitHub:** https://github.com/tatlacas-com/compilerfish-sdk-js
+**GitHub:** https://github.com/tatlacas-com/brevwick-sdk-js
 
 ## Common Commands
 
@@ -57,13 +57,13 @@ pnpm format
 Per-package:
 
 ```bash
-pnpm --filter compilerfish-sdk build
-pnpm --filter compilerfish-react test
+pnpm --filter brevwick-sdk build
+pnpm --filter brevwick-react test
 ```
 
 ## Bundle Budget — DO NOT EXCEED
 
-- Core `compilerfish-sdk` initial chunk: **< 2 kB gzip**
+- Core `brevwick-sdk` initial chunk: **< 2 kB gzip**
 - On widget open (`modern-screenshot` dynamic-imported): **< 25 kB gzip**
 
 Anything heavy must be dynamic-imported (`await import('modern-screenshot')`) so it doesn't ship until the user clicks the FAB.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# compilerfish-sdk-js
+# brevwick-sdk-js
 
-JS/TS SDK for [Compilerfish](https://github.com/tatlacas-com/compilerfish-ops) — the AI-first QA feedback SaaS.
+JS/TS SDK for [Brevwick](https://github.com/tatlacas-com/brevwick-ops) — the AI-first QA feedback SaaS.
 
 This is a pnpm workspace publishing two packages to npm:
 
-| Package                                  | Purpose                                                        |
-| ---------------------------------------- | -------------------------------------------------------------- |
-| [`compilerfish-sdk`](./packages/sdk)     | Framework-agnostic core. Submit feedback from any browser app. |
-| [`compilerfish-react`](./packages/react) | React provider, floating FAB, `useFeedback` hook.              |
+| Package                              | Purpose                                                        |
+| ------------------------------------ | -------------------------------------------------------------- |
+| [`brevwick-sdk`](./packages/sdk)     | Framework-agnostic core. Submit feedback from any browser app. |
+| [`brevwick-react`](./packages/react) | React provider, floating FAB, `useFeedback` hook.              |
 
-**Canonical contract:** [`compilerfish-ops/docs/compilerfish-sdd.md` § 12](https://github.com/tatlacas-com/compilerfish-ops/blob/main/docs/compilerfish-sdd.md#12-client-sdk-contracts).
+**Canonical contract:** [`brevwick-ops/docs/brevwick-sdd.md` § 12](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts).
 
 ## Quick start (Phase 4 preview)
 
 ```ts
-import { createCompilerfish } from 'compilerfish-sdk';
+import { createBrevwick } from 'brevwick-sdk';
 
-const cf = createCompilerfish({
+const bw = createBrevwick({
   projectKey: 'pk_live_...',
   buildSha: process.env.BUILD_SHA,
 });
 
-const uninstall = cf.install(); // installs console + fetch rings
+const uninstall = bw.install(); // installs console + fetch rings
 
-await cf.submit({
+await bw.submit({
   description: 'Customer modal hangs on second open',
   expected: 'Modal opens with details',
   actual: 'Spinner forever',
@@ -31,12 +31,12 @@ await cf.submit({
 ```
 
 ```tsx
-import { CompilerfishProvider, FeedbackButton } from 'compilerfish-react';
+import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
 
-<CompilerfishProvider config={{ projectKey: 'pk_live_...' }}>
+<BrevwickProvider config={{ projectKey: 'pk_live_...' }}>
   <App />
   <FeedbackButton />
-</CompilerfishProvider>;
+</BrevwickProvider>;
 ```
 
 ## Bundle budget
@@ -58,4 +58,4 @@ pnpm format
 
 ## Status
 
-Phase 0 — scaffolding. The packages publish as `0.0.0` placeholders containing only types and the redaction helpers. Real submit/screenshot/rings land in Phase 4 alongside `compilerfish-api` Phase 2.
+Phase 0 — scaffolding. The packages publish as `0.0.0` placeholders containing only types and the redaction helpers. Real submit/screenshot/rings land in Phase 4 alongside `brevwick-api` Phase 2.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "compilerfish-sdk-js",
+  "name": "brevwick-sdk-js",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "compilerfish-react",
+  "name": "brevwick-react",
   "version": "0.0.0",
-  "description": "Compilerfish React bindings — provider, FAB, useFeedback hook. Drop-in for any React app.",
+  "description": "Brevwick React bindings — provider, FAB, useFeedback hook. Drop-in for any React app.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -27,14 +27,14 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/compilerfish-sdk-js",
+  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tatlacas-com/compilerfish-sdk-js.git",
+    "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",
     "directory": "packages/react"
   },
   "keywords": [
-    "compilerfish",
+    "brevwick",
     "react",
     "qa",
     "feedback",
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "compilerfish-sdk": "workspace:*",
+    "brevwick-sdk": "workspace:*",
     "react": ">=18 <20",
     "react-dom": ">=18 <20"
   },
@@ -53,7 +53,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "compilerfish-sdk": "workspace:*",
+    "brevwick-sdk": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { COMPILERFISH_REACT_VERSION } from './index';
+import { BREVWICK_REACT_VERSION } from './index';
 
-describe('compilerfish-react', () => {
+describe('brevwick-react', () => {
   it('exports a version string', () => {
-    expect(typeof COMPILERFISH_REACT_VERSION).toBe('string');
+    expect(typeof BREVWICK_REACT_VERSION).toBe('string');
   });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * Compilerfish React bindings.
+ * Brevwick React bindings.
  *
  * Phase 0: ships only a placeholder export so the package publishes cleanly.
  * The provider, FAB, and useFeedback hook land in Phase 4 — see
- * compilerfish-ops/docs/compilerfish-sdd.md § 12 for the React contract.
+ * brevwick-ops/docs/brevwick-sdd.md § 12 for the React contract.
  */
 
-export const COMPILERFISH_REACT_VERSION = '0.0.0';
+export const BREVWICK_REACT_VERSION = '0.0.0';

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   sourcemap: true,
   treeshake: true,
   splitting: false,
-  external: ['react', 'react-dom', 'compilerfish-sdk'],
+  external: ['react', 'react-dom', 'brevwick-sdk'],
   target: 'es2020',
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "compilerfish-sdk",
+  "name": "brevwick-sdk",
   "version": "0.0.0",
-  "description": "Compilerfish core SDK — submit feedback reports from any browser app. AI-formatted into clean GitHub-ready issues.",
+  "description": "Brevwick core SDK — submit feedback reports from any browser app. AI-formatted into clean GitHub-ready issues.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -27,14 +27,14 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/compilerfish-sdk-js",
+  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tatlacas-com/compilerfish-sdk-js.git",
+    "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",
     "directory": "packages/sdk"
   },
   "keywords": [
-    "compilerfish",
+    "brevwick",
     "qa",
     "feedback",
     "bug-report",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,14 +1,14 @@
 /**
- * Compilerfish — AI-first QA feedback SDK for browser apps.
+ * Brevwick — AI-first QA feedback SDK for browser apps.
  *
  * Phase 0: types and redaction primitives only. The full client (rings,
- * screenshot, submit) lands in Phase 4 — see compilerfish-ops/docs/compilerfish-sdd.md
+ * screenshot, submit) lands in Phase 4 — see brevwick-ops/docs/brevwick-sdd.md
  * § 12 for the contract.
  */
 
 export type {
-  Compilerfish,
-  CompilerfishConfig,
+  Brevwick,
+  BrevwickConfig,
   Environment,
   FeedbackInput,
   SubmitResult,

--- a/packages/sdk/src/rings/redact.ts
+++ b/packages/sdk/src/rings/redact.ts
@@ -1,5 +1,5 @@
 /**
- * Client-side redaction. Mirrors the server-side sanitiser in compilerfish-api;
+ * Client-side redaction. Mirrors the server-side sanitiser in brevwick-api;
  * we redact early so secrets never even leave the device.
  *
  * Patterns:

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,9 +1,9 @@
 export type Environment = 'dev' | 'stg' | 'prod';
 
-export interface CompilerfishConfig {
+export interface BrevwickConfig {
   /** Public ingest key, e.g. `pk_live_xxx`. */
   projectKey: string;
-  /** Override the default ingest endpoint (https://api.compilerfish.com). */
+  /** Override the default ingest endpoint (https://api.brevwick.com). */
   endpoint?: string;
   environment?: Environment;
   /** Set to false to make every method a no-op. Useful in tests. */
@@ -12,7 +12,7 @@ export interface CompilerfishConfig {
   buildSha?: string;
   /** Resolved at submit time; merged into `user_context`. */
   userContext?: () => Record<string, unknown>;
-  /** Send `X-Compilerfish-Fingerprint-Optout: 1` to skip the salted fingerprint. */
+  /** Send `X-Brevwick-Fingerprint-Optout: 1` to skip the salted fingerprint. */
   fingerprintOptOut?: boolean;
 }
 
@@ -29,7 +29,7 @@ export interface SubmitResult {
   reportId: string;
 }
 
-export interface Compilerfish {
+export interface Brevwick {
   submit(input: FeedbackInput): Promise<SubmitResult>;
   captureScreenshot(): Promise<Blob>;
   /** Installs console + fetch rings. Returns an uninstaller. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      compilerfish-sdk:
+      brevwick-sdk:
         specifier: workspace:*
         version: link:../sdk
       react:


### PR DESCRIPTION
Brand rename: Compilerfish -> Brevwick. Coordinated with the ops ADR for the org-wide rename.

## Changes

- npm package names: `compilerfish-sdk-js` -> `brevwick-sdk-js`, `compilerfish-sdk` -> `brevwick-sdk`, `compilerfish-react` -> `brevwick-react`
- `package.json` `repository.url`, `homepage`, `description`, `keywords` updated for both packages
- TypeScript exports: `Compilerfish` -> `Brevwick`, `CompilerfishConfig` -> `BrevwickConfig`, `COMPILERFISH_REACT_VERSION` -> `BREVWICK_REACT_VERSION`
- Header comments, doc references, and SDD links (`compilerfish-sdd.md` -> `brevwick-sdd.md`, `compilerfish-ops` -> `brevwick-ops`, `compilerfish-api` -> `brevwick-api`)
- README install/usage examples updated
- CLAUDE.md updated (project name, GitHub URL, worktree paths, package filter examples)
- pnpm lockfile regenerated

## NPM publication

Verified neither `compilerfish-sdk-js`, `compilerfish-sdk`, nor `compilerfish-react` are published on the npm registry (404). No deprecation step needed; first publish will go out under the new names.

## Verification

- `pnpm install` clean
- `pnpm type-check` passes
- `pnpm build` passes (both packages)
- `pnpm test` passes (9 tests)
- `pnpm lint` passes
- `pnpm format:check` passes
- `rg -i 'compiler ?fish|cfctl|COMPILERFISH'` returns zero hits across tracked sources