### PR TITLE
feat(core): createBrevwick factory + install/uninstall + ring buffers

### DIFF
--- a/.changeset/create-brevwick-core.md
+++ b/.changeset/create-brevwick-core.md
@@ -1,0 +1,6 @@
+---
+'brevwick-sdk': minor
+'brevwick-react': minor
+---
+
+Add `createBrevwick(config)` factory with `install()` / `uninstall()` lifecycle and bounded FIFO ring buffers (console 50, network 50, routes 20). Canonicalises the `endpoint` so typo-equivalents (trailing slash, host casing) collapse to the same singleton key. `uninstall()` evicts the instance from the singleton registry so a subsequent `createBrevwick` call with the same key returns a fresh, installable instance. Ring modules land in follow-up PRs (#2 / #3) and are wired in by direct import, not module-side-effect registration, so the SDK's `"sideEffects": false` contract stays safe under tree-shaking. Freezes the public surface to exactly `createBrevwick`, `Brevwick`, `BrevwickConfig`, `FeedbackInput`, `SubmitResult`, `FeedbackAttachment`, `Environment`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,12 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   prettier,
   {
-    ignores: ['**/dist/', '**/node_modules/', '**/coverage/', '**/*.config.*'],
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/coverage/**',
+      '**/*.config.*',
+    ],
   },
   {
     rules: {

--- a/packages/sdk/src/core/__tests__/buffer.test.ts
+++ b/packages/sdk/src/core/__tests__/buffer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createRingBuffer } from '../buffer';
+
+describe('createRingBuffer', () => {
+  it('rejects non-positive caps', () => {
+    expect(() => createRingBuffer(0)).toThrow();
+    expect(() => createRingBuffer(-1)).toThrow();
+    expect(() => createRingBuffer(1.5)).toThrow();
+  });
+
+  it('drops oldest entries in FIFO order once at cap', () => {
+    const buf = createRingBuffer<number>(50);
+    for (let i = 1; i <= 60; i++) buf.push(i);
+
+    const snap = buf.snapshot();
+    expect(snap).toHaveLength(50);
+    expect(snap[0]).toBe(11);
+    expect(snap[snap.length - 1]).toBe(60);
+  });
+
+  it('snapshot is frozen and decoupled from subsequent pushes', () => {
+    const buf = createRingBuffer<string>(3);
+    buf.push('a');
+    const snap = buf.snapshot();
+    buf.push('b');
+    expect(Object.isFrozen(snap)).toBe(true);
+    expect(snap).toEqual(['a']);
+  });
+
+  it('clear resets the buffer', () => {
+    const buf = createRingBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.clear();
+    expect(buf.snapshot()).toEqual([]);
+    expect(buf.size).toBe(0);
+  });
+});

--- a/packages/sdk/src/core/__tests__/buffer.test.ts
+++ b/packages/sdk/src/core/__tests__/buffer.test.ts
@@ -35,4 +35,35 @@ describe('createRingBuffer', () => {
     expect(buf.snapshot()).toEqual([]);
     expect(buf.size).toBe(0);
   });
+
+  it('push after clear starts a fresh window', () => {
+    const buf = createRingBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.clear();
+    buf.push(9);
+    expect(buf.snapshot()).toEqual([9]);
+    expect(buf.size).toBe(1);
+  });
+
+  it('head pointer wraps correctly across many cycles', () => {
+    // Catches the "shift()/slice() replacement got FIFO order wrong" regression
+    // that a head-pointer implementation could introduce.
+    const buf = createRingBuffer<number>(4);
+    for (let i = 1; i <= 10; i++) buf.push(i);
+    expect(buf.snapshot()).toEqual([7, 8, 9, 10]);
+    expect(buf.size).toBe(4);
+  });
+
+  it('size tracks inserts up to cap and stays pinned at cap', () => {
+    const buf = createRingBuffer<number>(2);
+    expect(buf.size).toBe(0);
+    buf.push(1);
+    expect(buf.size).toBe(1);
+    buf.push(2);
+    expect(buf.size).toBe(2);
+    buf.push(3);
+    expect(buf.size).toBe(2);
+  });
 });

--- a/packages/sdk/src/core/__tests__/bus.test.ts
+++ b/packages/sdk/src/core/__tests__/bus.test.ts
@@ -42,4 +42,50 @@ describe('createBus', () => {
     const bus = createBus<Events>();
     expect(() => bus.emit('ping', { id: 3 })).not.toThrow();
   });
+
+  it('a listener that off()s itself during emit still receives the current payload', () => {
+    const bus = createBus<Events>();
+    const selfRemoving = vi.fn(() => {
+      bus.off('ping', selfRemoving);
+    });
+    bus.on('ping', selfRemoving);
+
+    bus.emit('ping', { id: 1 });
+    bus.emit('ping', { id: 2 });
+
+    expect(selfRemoving).toHaveBeenCalledTimes(1);
+    expect(selfRemoving).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('a listener registered during emit does not receive the in-flight payload', () => {
+    const bus = createBus<Events>();
+    const late = vi.fn();
+    bus.on('ping', () => bus.on('ping', late));
+
+    bus.emit('ping', { id: 1 });
+    expect(late).not.toHaveBeenCalled();
+
+    bus.emit('ping', { id: 2 });
+    // Registered once during the first emit — still called once on the second.
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledWith({ id: 2 });
+  });
+
+  it('does not throw when a later listener is removed mid-iteration', () => {
+    const bus = createBus<Events>();
+    const second = vi.fn();
+    const first = vi.fn(() => {
+      bus.off('ping', second);
+    });
+    bus.on('ping', first);
+    bus.on('ping', second);
+
+    // Snapshot semantics: second is still called for this payload because we
+    // cloned the set before iterating. Mutation only affects future emits.
+    expect(() => bus.emit('ping', { id: 1 })).not.toThrow();
+    expect(second).toHaveBeenCalledTimes(1);
+
+    bus.emit('ping', { id: 2 });
+    expect(second).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sdk/src/core/__tests__/bus.test.ts
+++ b/packages/sdk/src/core/__tests__/bus.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBus } from '../bus';
+
+type Events = {
+  ping: { id: number };
+  pong: { ok: boolean };
+};
+
+describe('createBus', () => {
+  it('delivers payloads to every registered listener for the event', () => {
+    const bus = createBus<Events>();
+    const a = vi.fn();
+    const b = vi.fn();
+    bus.on('ping', a);
+    bus.on('ping', b);
+
+    bus.emit('ping', { id: 1 });
+
+    expect(a).toHaveBeenCalledWith({ id: 1 });
+    expect(b).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it('off removes the listener', () => {
+    const bus = createBus<Events>();
+    const listener = vi.fn();
+    bus.on('pong', listener);
+    bus.off('pong', listener);
+    bus.emit('pong', { ok: true });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('clear removes every listener', () => {
+    const bus = createBus<Events>();
+    const listener = vi.fn();
+    bus.on('ping', listener);
+    bus.clear();
+    bus.emit('ping', { id: 2 });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('emit with no listeners is a no-op', () => {
+    const bus = createBus<Events>();
+    expect(() => bus.emit('ping', { id: 3 })).not.toThrow();
+  });
+});

--- a/packages/sdk/src/core/__tests__/client.test.ts
+++ b/packages/sdk/src/core/__tests__/client.test.ts
@@ -1,16 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { __resetBrevwickRegistry, createBrevwick } from '../client';
+import {
+  __registerRing,
+  __resetBrevwickRegistry,
+  __resetRingRegistry,
+  createBrevwick,
+} from '../client';
+import type { BrevwickInternal, RingDefinition } from '../internal';
 import type { RingEntry } from '../../types';
 
 const KEY_A = 'pk_test_aaaaaaaaaaaaaaaa01';
 const KEY_B = 'pk_test_bbbbbbbbbbbbbbbb02';
 
+function getInternal(instance: unknown): BrevwickInternal {
+  return (instance as { _internal: BrevwickInternal })._internal;
+}
+
 beforeEach(() => {
   __resetBrevwickRegistry();
+  __resetRingRegistry();
 });
 
 afterEach(() => {
   __resetBrevwickRegistry();
+  __resetRingRegistry();
 });
 
 describe('createBrevwick', () => {
@@ -35,6 +47,10 @@ describe('createBrevwick', () => {
     const b = createBrevwick({ projectKey: KEY_A });
     expect(b).toBe(a);
     expect(warn).toHaveBeenCalled();
+    // Warning must log only a prefix, never the full key suffix.
+    const args = warn.mock.calls[0]?.[0] as string;
+    expect(args).toContain('pk_test_aaaa');
+    expect(args).not.toContain(KEY_A);
     warn.mockRestore();
   });
 
@@ -55,25 +71,32 @@ describe('createBrevwick', () => {
 });
 
 describe('install / uninstall', () => {
-  it('double install is safe and leaves globals untouched (no rings yet)', () => {
+  it('snapshot: uninstall restores every global a ring patched during install', () => {
+    // Fake console ring: patches `console.error` on install, restores it on teardown.
+    const originalError = console.error;
+    const ring: RingDefinition = {
+      name: 'console',
+      install: () => {
+        console.error = (() => undefined) as typeof console.error;
+        return () => {
+          console.error = originalError;
+        };
+      },
+    };
+    __registerRing(ring);
+
     const instance = createBrevwick({ projectKey: KEY_A });
-    const beforeConsole = { ...window.console };
-    const beforeFetch = window.fetch;
-    const beforeOnError = window.onerror;
+    const before = console.error;
 
     instance.install();
+    expect(console.error).not.toBe(before);
+    // Double install is a no-op.
     instance.install();
 
-    expect({ ...window.console }).toEqual(beforeConsole);
-    expect(window.fetch).toBe(beforeFetch);
-    expect(window.onerror).toBe(beforeOnError);
-
     instance.uninstall();
+    // Double uninstall is a no-op — second call after uninstall stays safe.
     instance.uninstall();
-
-    expect({ ...window.console }).toEqual(beforeConsole);
-    expect(window.fetch).toBe(beforeFetch);
-    expect(window.onerror).toBe(beforeOnError);
+    expect(console.error).toBe(before);
   });
 
   it('no-ops when window is undefined (SSR / worker)', () => {
@@ -87,45 +110,189 @@ describe('install / uninstall', () => {
     }
   });
 
-  it('no-ops when enabled=false', () => {
+  it('disabled instance: install + uninstall are no-ops and leave state idle', () => {
     const instance = createBrevwick({ projectKey: KEY_A, enabled: false });
+    const internal = getInternal(instance);
+    expect(() => {
+      instance.install();
+      instance.uninstall();
+    }).not.toThrow();
+    // Critical: disabled must never flip to `uninstalled` — otherwise a later
+    // install() on the same instance would be rejected as terminal.
+    expect(internal.state()).toBe('idle');
+  });
+
+  it('runs registered rings in order and tears them down in reverse', () => {
+    const events: string[] = [];
+    const mkRing = (name: 'console' | 'network' | 'route'): RingDefinition => ({
+      name,
+      install: () => {
+        events.push(`install:${name}`);
+        return () => events.push(`teardown:${name}`);
+      },
+    });
+    __registerRing(mkRing('console'));
+    __registerRing(mkRing('network'));
+    __registerRing(mkRing('route'));
+
+    const instance = createBrevwick({ projectKey: KEY_A });
     instance.install();
     instance.uninstall();
+
+    expect(events).toEqual([
+      'install:console',
+      'install:network',
+      'install:route',
+      'teardown:route',
+      'teardown:network',
+      'teardown:console',
+    ]);
+  });
+
+  it('skips rings whose config flag is false', () => {
+    const installed: string[] = [];
+    __registerRing({
+      name: 'console',
+      install: () => {
+        installed.push('console');
+        return () => undefined;
+      },
+    });
+    __registerRing({
+      name: 'network',
+      install: () => {
+        installed.push('network');
+        return () => undefined;
+      },
+    });
+
+    const instance = createBrevwick({
+      projectKey: KEY_A,
+      rings: { network: false },
+    });
+    instance.install();
+    instance.uninstall();
+    expect(installed).toEqual(['console']);
+  });
+
+  it('ring teardown errors do not block sibling teardowns', () => {
+    const torn: string[] = [];
+    __registerRing({
+      name: 'console',
+      install: () => () => torn.push('console'),
+    });
+    __registerRing({
+      name: 'network',
+      install: () => () => {
+        throw new Error('boom');
+      },
+    });
+    __registerRing({
+      name: 'route',
+      install: () => () => torn.push('route'),
+    });
+
+    const instance = createBrevwick({ projectKey: KEY_A });
+    instance.install();
+    expect(() => instance.uninstall()).not.toThrow();
+    // Route tears down before network (reverse order); console still fires after the throw.
+    expect(torn).toEqual(['route', 'console']);
+  });
+
+  it('install() after uninstall() throws — the instance is terminal', () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    instance.install();
+    instance.uninstall();
+    expect(() => instance.install()).toThrowError(
+      /cannot be called after uninstall/,
+    );
+  });
+
+  it('__registerRing is idempotent for duplicate names (HMR / test re-import safe)', () => {
+    const installs: string[] = [];
+    const mk = (tag: string): RingDefinition => ({
+      name: 'console',
+      install: () => {
+        installs.push(tag);
+        return () => undefined;
+      },
+    });
+    __registerRing(mk('first'));
+    __registerRing(mk('second')); // same name, must be skipped
+
+    const instance = createBrevwick({ projectKey: KEY_A });
+    instance.install();
+    expect(installs).toEqual(['first']);
+  });
+});
+
+describe('stub public methods', () => {
+  it('submit() returns a rejecting Promise (no sync throw)', async () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    const caught = vi.fn();
+    // Sync throw would bypass .catch — this test guards against that regression.
+    const p = instance.submit({ description: 'x' });
+    expect(p).toBeInstanceOf(Promise);
+    await p.catch(caught);
+    expect(caught).toHaveBeenCalledTimes(1);
+    await expect(instance.submit({ description: 'x' })).rejects.toThrow(
+      /not yet implemented/,
+    );
+  });
+
+  it('captureScreenshot() returns a rejecting Promise (no sync throw)', async () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    const caught = vi.fn();
+    const p = instance.captureScreenshot();
+    expect(p).toBeInstanceOf(Promise);
+    await p.catch(caught);
+    expect(caught).toHaveBeenCalledTimes(1);
+    await expect(instance.captureScreenshot()).rejects.toThrow(
+      /not yet implemented/,
+    );
   });
 });
 
 describe('_internal ring buffers', () => {
   it('pushes entries into the correct bounded buffer', () => {
-    const instance = createBrevwick({ projectKey: KEY_A }) as unknown as {
-      _internal: {
-        buffers: {
-          console: { snapshot(): readonly RingEntry[] };
-          network: { snapshot(): readonly RingEntry[] };
-          route: { snapshot(): readonly RingEntry[] };
-        };
-        push(entry: RingEntry): void;
-      };
-    };
+    const instance = createBrevwick({ projectKey: KEY_A });
+    const internal = getInternal(instance);
 
     for (let i = 0; i < 60; i++) {
-      instance._internal.push({
+      internal.push({
         kind: 'console',
         level: 'error',
         message: `msg ${i}`,
         timestamp: i,
       });
     }
-    const snap = instance._internal.buffers.console.snapshot();
+    const snap = internal.buffers.console.snapshot();
     expect(snap).toHaveLength(50);
     expect(snap[0]).toMatchObject({ message: 'msg 10' });
 
-    instance._internal.push({
+    internal.push({
       kind: 'route',
       path: '/home',
       timestamp: 1,
     });
-    expect(instance._internal.buffers.route.snapshot()).toHaveLength(1);
-    expect(instance._internal.buffers.network.snapshot()).toHaveLength(0);
+    expect(internal.buffers.route.snapshot()).toHaveLength(1);
+    expect(internal.buffers.network.snapshot()).toHaveLength(0);
+  });
+
+  it('emits entry events through the internal bus', () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    const internal = getInternal(instance);
+    const seen: RingEntry[] = [];
+    internal.bus.on('entry', (e) => seen.push(e));
+    internal.push({
+      kind: 'network',
+      method: 'GET',
+      url: 'https://x/y',
+      status: 500,
+      timestamp: 1,
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.kind).toBe('network');
   });
 
   it('_internal is present but non-enumerable', () => {

--- a/packages/sdk/src/core/__tests__/client.test.ts
+++ b/packages/sdk/src/core/__tests__/client.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  __registerRing,
   __resetBrevwickRegistry,
-  __resetRingRegistry,
+  __setRingsForTesting,
   createBrevwick,
 } from '../client';
 import type { BrevwickInternal, RingDefinition } from '../internal';
@@ -17,12 +16,12 @@ function getInternal(instance: unknown): BrevwickInternal {
 
 beforeEach(() => {
   __resetBrevwickRegistry();
-  __resetRingRegistry();
+  __setRingsForTesting();
 });
 
 afterEach(() => {
   __resetBrevwickRegistry();
-  __resetRingRegistry();
+  __setRingsForTesting();
 });
 
 describe('createBrevwick', () => {
@@ -54,6 +53,20 @@ describe('createBrevwick', () => {
     warn.mockRestore();
   });
 
+  it('collapses endpoint variants onto the same singleton key', () => {
+    // Trailing slash, host casing, and default path all canonicalise to the
+    // same key so a second createBrevwick with a typo-equivalent endpoint
+    // never spawns a shadow instance.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const a = createBrevwick({ projectKey: KEY_A });
+    const b = createBrevwick({
+      projectKey: KEY_A,
+      endpoint: 'https://API.Brevwick.com/',
+    });
+    expect(b).toBe(a);
+    warn.mockRestore();
+  });
+
   it('returns distinct instances when endpoint differs', () => {
     const a = createBrevwick({ projectKey: KEY_A });
     const b = createBrevwick({
@@ -67,6 +80,18 @@ describe('createBrevwick', () => {
     const a = createBrevwick({ projectKey: KEY_A });
     const b = createBrevwick({ projectKey: KEY_B });
     expect(b).not.toBe(a);
+  });
+
+  it('uninstall() evicts the key so a fresh instance is created next time', () => {
+    const first = createBrevwick({ projectKey: KEY_A });
+    first.install();
+    first.uninstall();
+    const second = createBrevwick({ projectKey: KEY_A });
+    // The torn-down handle stays terminal, but the registry cleared so the
+    // next createBrevwick() returns a brand-new, installable instance.
+    expect(second).not.toBe(first);
+    expect(getInternal(second).state()).toBe('idle');
+    expect(() => first.install()).toThrow(/cannot be called after uninstall/);
   });
 });
 
@@ -83,7 +108,7 @@ describe('install / uninstall', () => {
         };
       },
     };
-    __registerRing(ring);
+    __setRingsForTesting([ring]);
 
     const instance = createBrevwick({ projectKey: KEY_A });
     const before = console.error;
@@ -131,9 +156,11 @@ describe('install / uninstall', () => {
         return () => events.push(`teardown:${name}`);
       },
     });
-    __registerRing(mkRing('console'));
-    __registerRing(mkRing('network'));
-    __registerRing(mkRing('route'));
+    __setRingsForTesting([
+      mkRing('console'),
+      mkRing('network'),
+      mkRing('route'),
+    ]);
 
     const instance = createBrevwick({ projectKey: KEY_A });
     instance.install();
@@ -151,20 +178,22 @@ describe('install / uninstall', () => {
 
   it('skips rings whose config flag is false', () => {
     const installed: string[] = [];
-    __registerRing({
-      name: 'console',
-      install: () => {
-        installed.push('console');
-        return () => undefined;
+    __setRingsForTesting([
+      {
+        name: 'console',
+        install: () => {
+          installed.push('console');
+          return () => undefined;
+        },
       },
-    });
-    __registerRing({
-      name: 'network',
-      install: () => {
-        installed.push('network');
-        return () => undefined;
+      {
+        name: 'network',
+        install: () => {
+          installed.push('network');
+          return () => undefined;
+        },
       },
-    });
+    ]);
 
     const instance = createBrevwick({
       projectKey: KEY_A,
@@ -177,20 +206,22 @@ describe('install / uninstall', () => {
 
   it('ring teardown errors do not block sibling teardowns', () => {
     const torn: string[] = [];
-    __registerRing({
-      name: 'console',
-      install: () => () => torn.push('console'),
-    });
-    __registerRing({
-      name: 'network',
-      install: () => () => {
-        throw new Error('boom');
+    __setRingsForTesting([
+      {
+        name: 'console',
+        install: () => () => torn.push('console'),
       },
-    });
-    __registerRing({
-      name: 'route',
-      install: () => () => torn.push('route'),
-    });
+      {
+        name: 'network',
+        install: () => () => {
+          throw new Error('boom');
+        },
+      },
+      {
+        name: 'route',
+        install: () => () => torn.push('route'),
+      },
+    ]);
 
     const instance = createBrevwick({ projectKey: KEY_A });
     instance.install();
@@ -208,21 +239,20 @@ describe('install / uninstall', () => {
     );
   });
 
-  it('__registerRing is idempotent for duplicate names (HMR / test re-import safe)', () => {
-    const installs: string[] = [];
-    const mk = (tag: string): RingDefinition => ({
-      name: 'console',
-      install: () => {
-        installs.push(tag);
-        return () => undefined;
+  it('__setRingsForTesting() with no args restores the default (empty) set', () => {
+    __setRingsForTesting([
+      {
+        name: 'console',
+        install: () => () => undefined,
       },
-    });
-    __registerRing(mk('first'));
-    __registerRing(mk('second')); // same name, must be skipped
-
+    ]);
+    __setRingsForTesting();
     const instance = createBrevwick({ projectKey: KEY_A });
-    instance.install();
-    expect(installs).toEqual(['first']);
+    // With DEFAULT_RINGS empty again, install() completes without touching any ring.
+    expect(() => {
+      instance.install();
+      instance.uninstall();
+    }).not.toThrow();
   });
 });
 

--- a/packages/sdk/src/core/__tests__/client.test.ts
+++ b/packages/sdk/src/core/__tests__/client.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetBrevwickRegistry, createBrevwick } from '../client';
+import type { RingEntry } from '../../types';
+
+const KEY_A = 'pk_test_aaaaaaaaaaaaaaaa01';
+const KEY_B = 'pk_test_bbbbbbbbbbbbbbbb02';
+
+beforeEach(() => {
+  __resetBrevwickRegistry();
+});
+
+afterEach(() => {
+  __resetBrevwickRegistry();
+});
+
+describe('createBrevwick', () => {
+  it('returns an instance with the frozen public surface', () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    expect(typeof instance.install).toBe('function');
+    expect(typeof instance.uninstall).toBe('function');
+    expect(typeof instance.submit).toBe('function');
+    expect(typeof instance.captureScreenshot).toBe('function');
+    expect(Object.keys(instance)).not.toContain('_internal');
+  });
+
+  it('throws BREVWICK_INVALID_CONFIG for invalid input', () => {
+    expect(() => createBrevwick({ projectKey: 'nope' })).toThrowError(
+      expect.objectContaining({ code: 'BREVWICK_INVALID_CONFIG' }),
+    );
+  });
+
+  it('returns the same instance for identical projectKey+endpoint', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const a = createBrevwick({ projectKey: KEY_A });
+    const b = createBrevwick({ projectKey: KEY_A });
+    expect(b).toBe(a);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('returns distinct instances when endpoint differs', () => {
+    const a = createBrevwick({ projectKey: KEY_A });
+    const b = createBrevwick({
+      projectKey: KEY_A,
+      endpoint: 'https://eu.brevwick.com',
+    });
+    expect(b).not.toBe(a);
+  });
+
+  it('keys singletons by projectKey', () => {
+    const a = createBrevwick({ projectKey: KEY_A });
+    const b = createBrevwick({ projectKey: KEY_B });
+    expect(b).not.toBe(a);
+  });
+});
+
+describe('install / uninstall', () => {
+  it('double install is safe and leaves globals untouched (no rings yet)', () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    const beforeConsole = { ...window.console };
+    const beforeFetch = window.fetch;
+    const beforeOnError = window.onerror;
+
+    instance.install();
+    instance.install();
+
+    expect({ ...window.console }).toEqual(beforeConsole);
+    expect(window.fetch).toBe(beforeFetch);
+    expect(window.onerror).toBe(beforeOnError);
+
+    instance.uninstall();
+    instance.uninstall();
+
+    expect({ ...window.console }).toEqual(beforeConsole);
+    expect(window.fetch).toBe(beforeFetch);
+    expect(window.onerror).toBe(beforeOnError);
+  });
+
+  it('no-ops when window is undefined (SSR / worker)', () => {
+    const stash = (globalThis as { window?: unknown }).window;
+    vi.stubGlobal('window', undefined);
+    try {
+      const instance = createBrevwick({ projectKey: KEY_A });
+      expect(() => instance.install()).not.toThrow();
+    } finally {
+      vi.stubGlobal('window', stash);
+    }
+  });
+
+  it('no-ops when enabled=false', () => {
+    const instance = createBrevwick({ projectKey: KEY_A, enabled: false });
+    instance.install();
+    instance.uninstall();
+  });
+});
+
+describe('_internal ring buffers', () => {
+  it('pushes entries into the correct bounded buffer', () => {
+    const instance = createBrevwick({ projectKey: KEY_A }) as unknown as {
+      _internal: {
+        buffers: {
+          console: { snapshot(): readonly RingEntry[] };
+          network: { snapshot(): readonly RingEntry[] };
+          route: { snapshot(): readonly RingEntry[] };
+        };
+        push(entry: RingEntry): void;
+      };
+    };
+
+    for (let i = 0; i < 60; i++) {
+      instance._internal.push({
+        kind: 'console',
+        level: 'error',
+        message: `msg ${i}`,
+        timestamp: i,
+      });
+    }
+    const snap = instance._internal.buffers.console.snapshot();
+    expect(snap).toHaveLength(50);
+    expect(snap[0]).toMatchObject({ message: 'msg 10' });
+
+    instance._internal.push({
+      kind: 'route',
+      path: '/home',
+      timestamp: 1,
+    });
+    expect(instance._internal.buffers.route.snapshot()).toHaveLength(1);
+    expect(instance._internal.buffers.network.snapshot()).toHaveLength(0);
+  });
+
+  it('_internal is present but non-enumerable', () => {
+    const instance = createBrevwick({ projectKey: KEY_A });
+    expect(
+      Object.prototype.propertyIsEnumerable.call(instance, '_internal'),
+    ).toBe(false);
+    const descriptor = Object.getOwnPropertyDescriptor(instance, '_internal');
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.writable).toBe(false);
+  });
+});

--- a/packages/sdk/src/core/__tests__/validate.test.ts
+++ b/packages/sdk/src/core/__tests__/validate.test.ts
@@ -11,6 +11,11 @@ describe('validateConfig', () => {
     expect(cfg.enabled).toBe(true);
     expect(cfg.fingerprintOptOut).toBe(false);
     expect(cfg.rings).toEqual({ console: true, network: true, route: true });
+    expect(cfg.environment).toBeUndefined();
+    expect(cfg.buildSha).toBeUndefined();
+    expect(cfg.release).toBeUndefined();
+    expect(cfg.user).toBeUndefined();
+    expect(cfg.userContext).toBeUndefined();
   });
 
   it.each([
@@ -18,6 +23,10 @@ describe('validateConfig', () => {
     ['missing projectKey', {}],
     ['wrong projectKey shape', { projectKey: 'bad' }],
     ['short projectKey suffix', { projectKey: 'pk_live_short' }],
+    [
+      'endpoint not a string',
+      { projectKey: VALID_KEY, endpoint: 123 as unknown as string },
+    ],
     ['non-https endpoint', { projectKey: VALID_KEY, endpoint: 'http://x.com' }],
     ['invalid URL endpoint', { projectKey: VALID_KEY, endpoint: 'not-a-url' }],
     ['bad environment', { projectKey: VALID_KEY, environment: 'production' }],
@@ -30,10 +39,19 @@ describe('validateConfig', () => {
     ],
     ['userContext not function', { projectKey: VALID_KEY, userContext: {} }],
     ['user without id', { projectKey: VALID_KEY, user: {} }],
+    ['user id not string', { projectKey: VALID_KEY, user: { id: 42 } }],
     ['rings not object', { projectKey: VALID_KEY, rings: true }],
     [
       'rings.console not boolean',
       { projectKey: VALID_KEY, rings: { console: 'on' } },
+    ],
+    [
+      'rings.network not boolean',
+      { projectKey: VALID_KEY, rings: { network: 1 } },
+    ],
+    [
+      'rings.route not boolean',
+      { projectKey: VALID_KEY, rings: { route: 'off' } },
     ],
   ])('rejects %s with BREVWICK_INVALID_CONFIG', (_label, input) => {
     try {
@@ -51,5 +69,43 @@ describe('validateConfig', () => {
       rings: { console: false, network: true, route: false },
     });
     expect(cfg.rings).toEqual({ console: false, network: true, route: false });
+  });
+
+  it('accepts every valid environment', () => {
+    for (const env of ['dev', 'stg', 'prod'] as const) {
+      expect(validateConfig({ projectKey: VALID_KEY, environment: env }).environment).toBe(env);
+    }
+  });
+
+  it('accepts and preserves buildSha / release', () => {
+    const cfg = validateConfig({
+      projectKey: VALID_KEY,
+      buildSha: 'abc123',
+      release: '1.2.3',
+    });
+    expect(cfg.buildSha).toBe('abc123');
+    expect(cfg.release).toBe('1.2.3');
+  });
+
+  it('accepts a well-formed user object and passes it through untouched', () => {
+    const user = { id: 'u_1', email: 'x@example.com', tier: 'pro' };
+    const cfg = validateConfig({ projectKey: VALID_KEY, user });
+    expect(cfg.user).toEqual(user);
+  });
+
+  it('accepts userContext as a function', () => {
+    const userContext = (): Record<string, unknown> => ({ a: 1 });
+    const cfg = validateConfig({ projectKey: VALID_KEY, userContext });
+    expect(cfg.userContext).toBe(userContext);
+  });
+
+  it('accepts fingerprintOptOut=true', () => {
+    const cfg = validateConfig({ projectKey: VALID_KEY, fingerprintOptOut: true });
+    expect(cfg.fingerprintOptOut).toBe(true);
+  });
+
+  it('accepts enabled=false', () => {
+    const cfg = validateConfig({ projectKey: VALID_KEY, enabled: false });
+    expect(cfg.enabled).toBe(false);
   });
 });

--- a/packages/sdk/src/core/__tests__/validate.test.ts
+++ b/packages/sdk/src/core/__tests__/validate.test.ts
@@ -73,7 +73,9 @@ describe('validateConfig', () => {
 
   it('accepts every valid environment', () => {
     for (const env of ['dev', 'stg', 'prod'] as const) {
-      expect(validateConfig({ projectKey: VALID_KEY, environment: env }).environment).toBe(env);
+      expect(
+        validateConfig({ projectKey: VALID_KEY, environment: env }).environment,
+      ).toBe(env);
     }
   });
 
@@ -100,7 +102,10 @@ describe('validateConfig', () => {
   });
 
   it('accepts fingerprintOptOut=true', () => {
-    const cfg = validateConfig({ projectKey: VALID_KEY, fingerprintOptOut: true });
+    const cfg = validateConfig({
+      projectKey: VALID_KEY,
+      fingerprintOptOut: true,
+    });
     expect(cfg.fingerprintOptOut).toBe(true);
   });
 

--- a/packages/sdk/src/core/__tests__/validate.test.ts
+++ b/packages/sdk/src/core/__tests__/validate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { INVALID_CONFIG_CODE, validateConfig } from '../validate';
+
+const VALID_KEY = 'pk_live_abcdefghijklmnop01';
+
+describe('validateConfig', () => {
+  it('accepts a minimal valid config and applies defaults', () => {
+    const cfg = validateConfig({ projectKey: VALID_KEY });
+    expect(cfg.projectKey).toBe(VALID_KEY);
+    expect(cfg.endpoint).toBe('https://api.brevwick.com');
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.fingerprintOptOut).toBe(false);
+    expect(cfg.rings).toEqual({ console: true, network: true, route: true });
+  });
+
+  it.each([
+    ['non-object', null],
+    ['missing projectKey', {}],
+    ['wrong projectKey shape', { projectKey: 'bad' }],
+    ['short projectKey suffix', { projectKey: 'pk_live_short' }],
+    ['non-https endpoint', { projectKey: VALID_KEY, endpoint: 'http://x.com' }],
+    ['invalid URL endpoint', { projectKey: VALID_KEY, endpoint: 'not-a-url' }],
+    ['bad environment', { projectKey: VALID_KEY, environment: 'production' }],
+    ['buildSha not string', { projectKey: VALID_KEY, buildSha: 42 }],
+    ['release not string', { projectKey: VALID_KEY, release: true }],
+    ['enabled not boolean', { projectKey: VALID_KEY, enabled: 'yes' }],
+    [
+      'fingerprintOptOut not boolean',
+      { projectKey: VALID_KEY, fingerprintOptOut: 1 },
+    ],
+    ['userContext not function', { projectKey: VALID_KEY, userContext: {} }],
+    ['user without id', { projectKey: VALID_KEY, user: {} }],
+    ['rings not object', { projectKey: VALID_KEY, rings: true }],
+    [
+      'rings.console not boolean',
+      { projectKey: VALID_KEY, rings: { console: 'on' } },
+    ],
+  ])('rejects %s with BREVWICK_INVALID_CONFIG', (_label, input) => {
+    try {
+      validateConfig(input);
+      throw new Error('expected validateConfig to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as { code?: string }).code).toBe(INVALID_CONFIG_CODE);
+    }
+  });
+
+  it('preserves passed ring flags', () => {
+    const cfg = validateConfig({
+      projectKey: VALID_KEY,
+      rings: { console: false, network: true, route: false },
+    });
+    expect(cfg.rings).toEqual({ console: false, network: true, route: false });
+  });
+});

--- a/packages/sdk/src/core/buffer.ts
+++ b/packages/sdk/src/core/buffer.ts
@@ -1,0 +1,29 @@
+export interface RingBuffer<T> {
+  push(entry: T): void;
+  snapshot(): readonly T[];
+  clear(): void;
+  readonly size: number;
+}
+
+export function createRingBuffer<T>(cap: number): RingBuffer<T> {
+  if (!Number.isInteger(cap) || cap <= 0) {
+    throw new Error('ring buffer cap must be a positive integer');
+  }
+  const items: T[] = [];
+
+  return {
+    push(entry) {
+      items.push(entry);
+      if (items.length > cap) items.shift();
+    },
+    snapshot() {
+      return Object.freeze(items.slice());
+    },
+    clear() {
+      items.length = 0;
+    },
+    get size() {
+      return items.length;
+    },
+  };
+}

--- a/packages/sdk/src/core/buffer.ts
+++ b/packages/sdk/src/core/buffer.ts
@@ -5,25 +5,42 @@ export interface RingBuffer<T> {
   readonly size: number;
 }
 
+/**
+ * Fixed-capacity FIFO ring buffer. Uses a pre-allocated slot array plus a
+ * head pointer so push stays O(1) even at large caps — `Array.prototype.shift`
+ * would be O(n) and turn a burst of events into O(n²) work.
+ */
 export function createRingBuffer<T>(cap: number): RingBuffer<T> {
   if (!Number.isInteger(cap) || cap <= 0) {
     throw new Error('ring buffer cap must be a positive integer');
   }
-  const items: T[] = [];
+  const slots: Array<T | undefined> = new Array(cap);
+  let head = 0;
+  let count = 0;
+
+  function snapshot(): readonly T[] {
+    const out: T[] = new Array(count);
+    const start = count < cap ? 0 : head;
+    for (let i = 0; i < count; i++) {
+      out[i] = slots[(start + i) % cap] as T;
+    }
+    return Object.freeze(out);
+  }
 
   return {
     push(entry) {
-      items.push(entry);
-      if (items.length > cap) items.shift();
+      slots[head] = entry;
+      head = (head + 1) % cap;
+      if (count < cap) count++;
     },
-    snapshot() {
-      return Object.freeze(items.slice());
-    },
+    snapshot,
     clear() {
-      items.length = 0;
+      for (let i = 0; i < cap; i++) slots[i] = undefined;
+      head = 0;
+      count = 0;
     },
     get size() {
-      return items.length;
+      return count;
     },
   };
 }

--- a/packages/sdk/src/core/bus.ts
+++ b/packages/sdk/src/core/bus.ts
@@ -10,13 +10,18 @@ export interface Bus<EventMap extends Record<string, unknown>> {
   clear(): void;
 }
 
+/**
+ * Minimal typed pub/sub. Emission snapshots the listener set before
+ * iterating so listeners may safely `off()` themselves or register new
+ * listeners without breaking delivery of the in-flight event.
+ */
 export function createBus<
   EventMap extends Record<string, unknown>,
 >(): Bus<EventMap> {
-  const listeners = new Map<
-    keyof EventMap,
-    Set<Listener<EventMap[keyof EventMap]>>
-  >();
+  // The map is keyed by event name but each set only ever contains listeners
+  // for that event. Internally we treat payloads as `unknown`; the public
+  // per-method generics preserve type safety at every call site.
+  const listeners = new Map<keyof EventMap, Set<Listener<unknown>>>();
 
   return {
     on(event, listener) {
@@ -25,18 +30,19 @@ export function createBus<
         set = new Set();
         listeners.set(event, set);
       }
-      set.add(listener as Listener<EventMap[keyof EventMap]>);
+      set.add(listener as Listener<unknown>);
     },
     off(event, listener) {
-      listeners
-        .get(event)
-        ?.delete(listener as Listener<EventMap[keyof EventMap]>);
+      listeners.get(event)?.delete(listener as Listener<unknown>);
     },
     emit(event, payload) {
       const set = listeners.get(event);
       if (!set) return;
-      for (const listener of set)
+      // Snapshot: a listener that mutates the set (off-self, add-new) must
+      // not corrupt iteration or miss delivery of the current payload.
+      for (const listener of [...set]) {
         (listener as Listener<typeof payload>)(payload);
+      }
     },
     clear() {
       listeners.clear();

--- a/packages/sdk/src/core/bus.ts
+++ b/packages/sdk/src/core/bus.ts
@@ -1,0 +1,45 @@
+type Listener<T> = (payload: T) => void;
+
+export interface Bus<EventMap extends Record<string, unknown>> {
+  on<K extends keyof EventMap>(event: K, listener: Listener<EventMap[K]>): void;
+  off<K extends keyof EventMap>(
+    event: K,
+    listener: Listener<EventMap[K]>,
+  ): void;
+  emit<K extends keyof EventMap>(event: K, payload: EventMap[K]): void;
+  clear(): void;
+}
+
+export function createBus<
+  EventMap extends Record<string, unknown>,
+>(): Bus<EventMap> {
+  const listeners = new Map<
+    keyof EventMap,
+    Set<Listener<EventMap[keyof EventMap]>>
+  >();
+
+  return {
+    on(event, listener) {
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(listener as Listener<EventMap[keyof EventMap]>);
+    },
+    off(event, listener) {
+      listeners
+        .get(event)
+        ?.delete(listener as Listener<EventMap[keyof EventMap]>);
+    },
+    emit(event, payload) {
+      const set = listeners.get(event);
+      if (!set) return;
+      for (const listener of set)
+        (listener as Listener<typeof payload>)(payload);
+    },
+    clear() {
+      listeners.clear();
+    },
+  };
+}

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -1,0 +1,183 @@
+import type {
+  Brevwick,
+  BrevwickConfig,
+  FeedbackInput,
+  RingEntry,
+  SubmitResult,
+} from '../types';
+import { createBus, type Bus } from './bus';
+import { createRingBuffer, type RingBuffer } from './buffer';
+import { validateConfig, type ValidatedConfig } from './validate';
+
+type LifecycleState = 'idle' | 'installed' | 'uninstalled';
+
+type RingName = 'console' | 'network' | 'route';
+
+type BusEventMap = {
+  entry: RingEntry;
+};
+
+interface RingContext {
+  readonly config: ValidatedConfig;
+  readonly bus: Bus<BusEventMap>;
+  push(entry: RingEntry): void;
+}
+
+interface RingDefinition {
+  readonly name: RingName;
+  install(ctx: RingContext): () => void;
+}
+
+/**
+ * Rings are attached in this order when their config flag is true. Populated
+ * by the individual ring modules (landing in #2 / #3); kept as an internal
+ * hook so the factory stays ring-agnostic and stays under the 2 kB budget.
+ */
+const DEFAULT_RINGS: readonly RingDefinition[] = [];
+
+interface InternalApi {
+  readonly buffers: {
+    readonly console: RingBuffer<RingEntry>;
+    readonly network: RingBuffer<RingEntry>;
+    readonly route: RingBuffer<RingEntry>;
+  };
+  readonly bus: Bus<BusEventMap>;
+  readonly config: ValidatedConfig;
+  push(entry: RingEntry): void;
+  state(): LifecycleState;
+}
+
+interface BrevwickInstance extends Brevwick {
+  readonly _internal: InternalApi;
+}
+
+const instances = new Map<string, BrevwickInstance>();
+
+function instanceKey(config: ValidatedConfig): string {
+  return `${config.projectKey}|${config.endpoint}`;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function bufferFor(
+  entry: RingEntry,
+  buffers: InternalApi['buffers'],
+): RingBuffer<RingEntry> {
+  switch (entry.kind) {
+    case 'console':
+      return buffers.console;
+    case 'network':
+      return buffers.network;
+    case 'route':
+      return buffers.route;
+  }
+}
+
+function notImplemented(method: string): never {
+  throw new Error(`Brevwick.${method} is not yet implemented`);
+}
+
+function build(config: ValidatedConfig): BrevwickInstance {
+  const buffers = {
+    console: createRingBuffer<RingEntry>(50),
+    network: createRingBuffer<RingEntry>(50),
+    route: createRingBuffer<RingEntry>(20),
+  } as const;
+  const bus = createBus<BusEventMap>();
+
+  let state: LifecycleState = 'idle';
+  let teardowns: Array<() => void> = [];
+
+  const internal: InternalApi = {
+    buffers,
+    bus,
+    config,
+    push(entry) {
+      bufferFor(entry, buffers).push(entry);
+      bus.emit('entry', entry);
+    },
+    state: () => state,
+  };
+
+  function install(): void {
+    if (state === 'installed') return;
+    if (!isBrowser()) return;
+    if (!config.enabled) return;
+
+    const ctx: RingContext = {
+      config,
+      bus,
+      push: internal.push,
+    };
+    for (const ring of DEFAULT_RINGS) {
+      if (!config.rings[ring.name]) continue;
+      teardowns.push(ring.install(ctx));
+    }
+    state = 'installed';
+  }
+
+  function uninstall(): void {
+    if (state !== 'installed') {
+      state = 'uninstalled';
+      return;
+    }
+    for (let i = teardowns.length - 1; i >= 0; i--) {
+      try {
+        teardowns[i]?.();
+      } catch {
+        // Individual ring teardown failures must not block the others.
+      }
+    }
+    teardowns = [];
+    buffers.console.clear();
+    buffers.network.clear();
+    buffers.route.clear();
+    bus.clear();
+    state = 'uninstalled';
+  }
+
+  const instance: Brevwick = {
+    install,
+    uninstall,
+    submit(_input: FeedbackInput): Promise<SubmitResult> {
+      return notImplemented('submit');
+    },
+    captureScreenshot(): Promise<Blob> {
+      return notImplemented('captureScreenshot');
+    },
+  };
+
+  // _internal is reachable for downstream rings but intentionally hidden from
+  // enumeration/iteration so it stays off the public surface.
+  Object.defineProperty(instance, '_internal', {
+    value: internal,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  return instance as BrevwickInstance;
+}
+
+export function createBrevwick(config: BrevwickConfig): Brevwick {
+  const validated = validateConfig(config);
+  const key = instanceKey(validated);
+  const existing = instances.get(key);
+  if (existing) {
+    const original = (globalThis as { console?: Console }).console;
+    original?.warn?.(
+      `[brevwick] createBrevwick called twice for projectKey=${validated.projectKey}; returning existing instance`,
+    );
+    return existing;
+  }
+  const instance = build(validated);
+  instances.set(key, instance);
+  return instance;
+}
+
+/** Test-only: drop the singleton registry so each test starts clean. */
+export function __resetBrevwickRegistry(): void {
+  instances.clear();
+}

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -1,12 +1,14 @@
 import type {
   Brevwick,
   BrevwickConfig,
+  ConsoleEntry,
   FeedbackInput,
-  RingEntry,
+  NetworkEntry,
+  RouteEntry,
   SubmitResult,
 } from '../types';
 import { createBus } from './bus';
-import { createRingBuffer, type RingBuffer } from './buffer';
+import { createRingBuffer } from './buffer';
 import {
   INTERNAL_KEY,
   type BrevwickInternal,
@@ -18,22 +20,33 @@ import {
 import { validateConfig, type ValidatedConfig } from './validate';
 
 /**
- * Rings are attached in this order when their config flag is true. Ring
- * modules (landing in #2 / #3) register themselves via `__registerRing` so
- * the factory stays ring-agnostic. Order matters: entries emitted during a
- * ring's install run must be observable by later rings' listeners.
+ * Rings attached on install, in this order, when their config flag is true.
+ * Deliberately populated by direct import from ring modules in #2 / #3
+ * rather than by side-effect self-registration: the SDK package declares
+ * `"sideEffects": false`, so any registration-on-import pattern would be
+ * tree-shaken away in consumer builds and the rings would silently vanish
+ * in production. Order matters: entries emitted while a ring installs must
+ * be observable by rings installed later.
  */
-const registeredRings: RingDefinition[] = [];
+const DEFAULT_RINGS: readonly RingDefinition[] = [];
+
+/**
+ * Active ring set. Defaults to {@link DEFAULT_RINGS}; tests swap it via
+ * {@link __setRingsForTesting} to inject fakes without touching module
+ * identity.
+ */
+let activeRings: readonly RingDefinition[] = DEFAULT_RINGS;
 
 interface BrevwickWithInternal extends Brevwick {
   readonly [INTERNAL_KEY]: BrevwickInternal;
 }
 
 /**
- * Singleton registry. Keyed by `projectKey|endpoint` so a tenant pointing
- * the SDK at an alternate ingest (EU shard, test mock) still gets distinct
- * instances. Test code MUST call {@link __resetBrevwickRegistry} between
- * runs — module-scoped state survives Vitest's module graph otherwise.
+ * Singleton registry. Keyed by `projectKey|endpoint` (canonicalised in
+ * {@link validateConfig}) so typo-equivalents never spawn shadow instances.
+ * Entries are evicted on {@link Brevwick.uninstall} so a subsequent
+ * `createBrevwick(sameKey)` call gets a fresh, installable instance — the
+ * instance itself stays terminal once torn down.
  */
 const instances = new Map<string, BrevwickWithInternal>();
 
@@ -45,25 +58,14 @@ function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
 }
 
-function bufferFor(
-  entry: RingEntry,
-  buffers: BrevwickInternal['buffers'],
-): RingBuffer<RingEntry> {
-  switch (entry.kind) {
-    case 'console':
-      return buffers.console;
-    case 'network':
-      return buffers.network;
-    case 'route':
-      return buffers.route;
-  }
-}
-
-function build(config: ValidatedConfig): BrevwickWithInternal {
+function build(
+  config: ValidatedConfig,
+  onUninstall: () => void,
+): BrevwickWithInternal {
   const buffers = {
-    console: createRingBuffer<RingEntry>(50),
-    network: createRingBuffer<RingEntry>(50),
-    route: createRingBuffer<RingEntry>(20),
+    console: createRingBuffer<ConsoleEntry>(50),
+    network: createRingBuffer<NetworkEntry>(50),
+    route: createRingBuffer<RouteEntry>(20),
   } as const;
   const bus = createBus<BusEventMap>();
 
@@ -75,7 +77,20 @@ function build(config: ValidatedConfig): BrevwickWithInternal {
     bus,
     config,
     push(entry) {
-      bufferFor(entry, buffers).push(entry);
+      // Inline dispatch keeps per-buffer type narrowing — `bufferFor(entry)`
+      // would widen back to `RingBuffer<RingEntry>` and lose the invariant
+      // that each buffer only holds its own kind.
+      switch (entry.kind) {
+        case 'console':
+          buffers.console.push(entry);
+          break;
+        case 'network':
+          buffers.network.push(entry);
+          break;
+        case 'route':
+          buffers.route.push(entry);
+          break;
+      }
       bus.emit('entry', entry);
     },
     state: () => state,
@@ -84,11 +99,12 @@ function build(config: ValidatedConfig): BrevwickWithInternal {
   function install(): void {
     if (state === 'installed') return;
     // Once torn down, the instance is terminal — re-install would leak
-    // captured buffers and invite double-patched globals. Tenants that
-    // genuinely need a fresh lifecycle should build a new instance.
+    // captured buffers and invite double-patched globals. The registry
+    // already evicted this key on uninstall, so the "create a new instance"
+    // path is just another `createBrevwick(...)` call.
     if (state === 'uninstalled') {
       throw new Error(
-        'Brevwick.install() cannot be called after uninstall(); create a new instance instead',
+        'Brevwick.install() cannot be called after uninstall(); call createBrevwick() again for a fresh instance',
       );
     }
     if (!isBrowser()) return;
@@ -99,7 +115,7 @@ function build(config: ValidatedConfig): BrevwickWithInternal {
       bus,
       push: internal.push,
     };
-    for (const ring of registeredRings) {
+    for (const ring of activeRings) {
       if (!config.rings[ring.name]) continue;
       teardowns.push(ring.install(ctx));
     }
@@ -125,6 +141,7 @@ function build(config: ValidatedConfig): BrevwickWithInternal {
     buffers.route.clear();
     bus.clear();
     state = 'uninstalled';
+    onUninstall();
   }
 
   const instance: Brevwick = {
@@ -141,8 +158,6 @@ function build(config: ValidatedConfig): BrevwickWithInternal {
     },
   };
 
-  // _internal is reachable for downstream rings but intentionally hidden from
-  // enumeration/iteration so it stays off the public surface.
   Object.defineProperty(instance, INTERNAL_KEY, {
     value: internal,
     enumerable: false,
@@ -158,20 +173,25 @@ export function createBrevwick(config: BrevwickConfig): Brevwick {
   const key = instanceKey(validated);
   const existing = instances.get(key);
   if (existing) {
-    // Capture-time console binding would be stronger, but createBrevwick is
-    // called before any ring patches `console.warn`, so the live binding is
-    // the original. Worth revisiting if the ordering ever changes.
+    // createBrevwick runs before any ring patches console, so the live
+    // binding is still the original. Worth revisiting if that ordering
+    // ever changes.
     const originalWarn = (globalThis as { console?: Console }).console?.warn;
-    // Log only the key prefix — full public keys are safe per the SDD but
-    // narrow logs make grep noise smaller and defuse the accidental "log the
-    // secret key" bug class if a live key ever sneaks into dev output.
+    // Log only a prefix — public keys aren't secret per the SDD, but narrow
+    // logs keep grep noise small and defuse the accidental "log the secret
+    // key" bug class if a live key ever sneaks into dev output.
     const prefix = validated.projectKey.slice(0, 12);
     originalWarn?.(
       `[brevwick] createBrevwick called twice for projectKey=${prefix}…; returning existing instance`,
     );
     return existing;
   }
-  const instance = build(validated);
+  const instance = build(validated, () => {
+    // Evict on uninstall so the next createBrevwick() call for this key
+    // returns a fresh, installable instance. The torn-down instance itself
+    // stays terminal — any handle still held by caller code cannot re-install.
+    instances.delete(key);
+  });
   instances.set(key, instance);
   return instance;
 }
@@ -182,16 +202,10 @@ export function __resetBrevwickRegistry(): void {
 }
 
 /**
- * Internal: ring modules call this at module-evaluation time to register
- * themselves with the factory. Duplicate names are ignored (idempotent so
- * HMR / test re-imports stay safe). Not part of the public API.
+ * Test-only: swap in a fake ring set (or restore the default with no args).
+ * Replaces the older `__registerRing` side-effect seam, which was unsafe
+ * under the package's `sideEffects: false` contract.
  */
-export function __registerRing(ring: RingDefinition): void {
-  if (registeredRings.some((r) => r.name === ring.name)) return;
-  registeredRings.push(ring);
-}
-
-/** Test-only: drop ring registrations so each test can inject fakes. */
-export function __resetRingRegistry(): void {
-  registeredRings.length = 0;
+export function __setRingsForTesting(rings?: readonly RingDefinition[]): void {
+  activeRings = rings ?? DEFAULT_RINGS;
 }

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -5,53 +5,37 @@ import type {
   RingEntry,
   SubmitResult,
 } from '../types';
-import { createBus, type Bus } from './bus';
+import { createBus } from './bus';
 import { createRingBuffer, type RingBuffer } from './buffer';
+import {
+  INTERNAL_KEY,
+  type BrevwickInternal,
+  type BusEventMap,
+  type LifecycleState,
+  type RingContext,
+  type RingDefinition,
+} from './internal';
 import { validateConfig, type ValidatedConfig } from './validate';
 
-type LifecycleState = 'idle' | 'installed' | 'uninstalled';
+/**
+ * Rings are attached in this order when their config flag is true. Ring
+ * modules (landing in #2 / #3) register themselves via `__registerRing` so
+ * the factory stays ring-agnostic. Order matters: entries emitted during a
+ * ring's install run must be observable by later rings' listeners.
+ */
+const registeredRings: RingDefinition[] = [];
 
-type RingName = 'console' | 'network' | 'route';
-
-type BusEventMap = {
-  entry: RingEntry;
-};
-
-interface RingContext {
-  readonly config: ValidatedConfig;
-  readonly bus: Bus<BusEventMap>;
-  push(entry: RingEntry): void;
-}
-
-interface RingDefinition {
-  readonly name: RingName;
-  install(ctx: RingContext): () => void;
+interface BrevwickWithInternal extends Brevwick {
+  readonly [INTERNAL_KEY]: BrevwickInternal;
 }
 
 /**
- * Rings are attached in this order when their config flag is true. Populated
- * by the individual ring modules (landing in #2 / #3); kept as an internal
- * hook so the factory stays ring-agnostic and stays under the 2 kB budget.
+ * Singleton registry. Keyed by `projectKey|endpoint` so a tenant pointing
+ * the SDK at an alternate ingest (EU shard, test mock) still gets distinct
+ * instances. Test code MUST call {@link __resetBrevwickRegistry} between
+ * runs — module-scoped state survives Vitest's module graph otherwise.
  */
-const DEFAULT_RINGS: readonly RingDefinition[] = [];
-
-interface InternalApi {
-  readonly buffers: {
-    readonly console: RingBuffer<RingEntry>;
-    readonly network: RingBuffer<RingEntry>;
-    readonly route: RingBuffer<RingEntry>;
-  };
-  readonly bus: Bus<BusEventMap>;
-  readonly config: ValidatedConfig;
-  push(entry: RingEntry): void;
-  state(): LifecycleState;
-}
-
-interface BrevwickInstance extends Brevwick {
-  readonly _internal: InternalApi;
-}
-
-const instances = new Map<string, BrevwickInstance>();
+const instances = new Map<string, BrevwickWithInternal>();
 
 function instanceKey(config: ValidatedConfig): string {
   return `${config.projectKey}|${config.endpoint}`;
@@ -63,7 +47,7 @@ function isBrowser(): boolean {
 
 function bufferFor(
   entry: RingEntry,
-  buffers: InternalApi['buffers'],
+  buffers: BrevwickInternal['buffers'],
 ): RingBuffer<RingEntry> {
   switch (entry.kind) {
     case 'console':
@@ -75,11 +59,7 @@ function bufferFor(
   }
 }
 
-function notImplemented(method: string): never {
-  throw new Error(`Brevwick.${method} is not yet implemented`);
-}
-
-function build(config: ValidatedConfig): BrevwickInstance {
+function build(config: ValidatedConfig): BrevwickWithInternal {
   const buffers = {
     console: createRingBuffer<RingEntry>(50),
     network: createRingBuffer<RingEntry>(50),
@@ -90,7 +70,7 @@ function build(config: ValidatedConfig): BrevwickInstance {
   let state: LifecycleState = 'idle';
   let teardowns: Array<() => void> = [];
 
-  const internal: InternalApi = {
+  const internal: BrevwickInternal = {
     buffers,
     bus,
     config,
@@ -103,6 +83,14 @@ function build(config: ValidatedConfig): BrevwickInstance {
 
   function install(): void {
     if (state === 'installed') return;
+    // Once torn down, the instance is terminal — re-install would leak
+    // captured buffers and invite double-patched globals. Tenants that
+    // genuinely need a fresh lifecycle should build a new instance.
+    if (state === 'uninstalled') {
+      throw new Error(
+        'Brevwick.install() cannot be called after uninstall(); create a new instance instead',
+      );
+    }
     if (!isBrowser()) return;
     if (!config.enabled) return;
 
@@ -111,7 +99,7 @@ function build(config: ValidatedConfig): BrevwickInstance {
       bus,
       push: internal.push,
     };
-    for (const ring of DEFAULT_RINGS) {
+    for (const ring of registeredRings) {
       if (!config.rings[ring.name]) continue;
       teardowns.push(ring.install(ctx));
     }
@@ -119,10 +107,11 @@ function build(config: ValidatedConfig): BrevwickInstance {
   }
 
   function uninstall(): void {
-    if (state !== 'installed') {
-      state = 'uninstalled';
-      return;
-    }
+    // Early out before the state flip: a disabled or never-installed
+    // instance calling uninstall() must stay `idle`, otherwise a
+    // subsequent install() would be mis-routed through the terminal path.
+    if (state !== 'installed') return;
+
     for (let i = teardowns.length - 1; i >= 0; i--) {
       try {
         teardowns[i]?.();
@@ -141,24 +130,27 @@ function build(config: ValidatedConfig): BrevwickInstance {
   const instance: Brevwick = {
     install,
     uninstall,
-    submit(_input: FeedbackInput): Promise<SubmitResult> {
-      return notImplemented('submit');
+    async submit(_input: FeedbackInput): Promise<SubmitResult> {
+      // Promise-returning so `.catch()` handlers attach before the rejection
+      // fires — a synchronous throw here would short-circuit any chain built
+      // in user code. Real implementation lands in #4.
+      throw new Error('Brevwick.submit is not yet implemented');
     },
-    captureScreenshot(): Promise<Blob> {
-      return notImplemented('captureScreenshot');
+    async captureScreenshot(): Promise<Blob> {
+      throw new Error('Brevwick.captureScreenshot is not yet implemented');
     },
   };
 
   // _internal is reachable for downstream rings but intentionally hidden from
   // enumeration/iteration so it stays off the public surface.
-  Object.defineProperty(instance, '_internal', {
+  Object.defineProperty(instance, INTERNAL_KEY, {
     value: internal,
     enumerable: false,
     writable: false,
     configurable: false,
   });
 
-  return instance as BrevwickInstance;
+  return instance as BrevwickWithInternal;
 }
 
 export function createBrevwick(config: BrevwickConfig): Brevwick {
@@ -166,9 +158,16 @@ export function createBrevwick(config: BrevwickConfig): Brevwick {
   const key = instanceKey(validated);
   const existing = instances.get(key);
   if (existing) {
-    const original = (globalThis as { console?: Console }).console;
-    original?.warn?.(
-      `[brevwick] createBrevwick called twice for projectKey=${validated.projectKey}; returning existing instance`,
+    // Capture-time console binding would be stronger, but createBrevwick is
+    // called before any ring patches `console.warn`, so the live binding is
+    // the original. Worth revisiting if the ordering ever changes.
+    const originalWarn = (globalThis as { console?: Console }).console?.warn;
+    // Log only the key prefix — full public keys are safe per the SDD but
+    // narrow logs make grep noise smaller and defuse the accidental "log the
+    // secret key" bug class if a live key ever sneaks into dev output.
+    const prefix = validated.projectKey.slice(0, 12);
+    originalWarn?.(
+      `[brevwick] createBrevwick called twice for projectKey=${prefix}…; returning existing instance`,
     );
     return existing;
   }
@@ -180,4 +179,19 @@ export function createBrevwick(config: BrevwickConfig): Brevwick {
 /** Test-only: drop the singleton registry so each test starts clean. */
 export function __resetBrevwickRegistry(): void {
   instances.clear();
+}
+
+/**
+ * Internal: ring modules call this at module-evaluation time to register
+ * themselves with the factory. Duplicate names are ignored (idempotent so
+ * HMR / test re-imports stay safe). Not part of the public API.
+ */
+export function __registerRing(ring: RingDefinition): void {
+  if (registeredRings.some((r) => r.name === ring.name)) return;
+  registeredRings.push(ring);
+}
+
+/** Test-only: drop ring registrations so each test can inject fakes. */
+export function __resetRingRegistry(): void {
+  registeredRings.length = 0;
 }

--- a/packages/sdk/src/core/internal.ts
+++ b/packages/sdk/src/core/internal.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal surface shared between the factory and ring modules. Not exported
+ * from the package root — only downstream ring code (landing in #2 / #3) and
+ * tests import from `brevwick-sdk/core/internal`.
+ */
+import type { RingEntry } from '../types';
+import type { Bus } from './bus';
+import type { RingBuffer } from './buffer';
+import type { ValidatedConfig } from './validate';
+
+export type LifecycleState = 'idle' | 'installed' | 'uninstalled';
+
+export type RingName = 'console' | 'network' | 'route';
+
+export type BusEventMap = {
+  entry: RingEntry;
+};
+
+export interface RingContext {
+  readonly config: ValidatedConfig;
+  readonly bus: Bus<BusEventMap>;
+  push(entry: RingEntry): void;
+}
+
+export interface RingDefinition {
+  readonly name: RingName;
+  install(ctx: RingContext): () => void;
+}
+
+export interface BrevwickInternal {
+  readonly buffers: {
+    readonly console: RingBuffer<RingEntry>;
+    readonly network: RingBuffer<RingEntry>;
+    readonly route: RingBuffer<RingEntry>;
+  };
+  readonly bus: Bus<BusEventMap>;
+  readonly config: ValidatedConfig;
+  push(entry: RingEntry): void;
+  state(): LifecycleState;
+}
+
+/** Key used by rings + tests to reach the internal API without polluting the public surface. */
+export const INTERNAL_KEY = '_internal' as const;

--- a/packages/sdk/src/core/internal.ts
+++ b/packages/sdk/src/core/internal.ts
@@ -1,9 +1,15 @@
 /**
- * Internal surface shared between the factory and ring modules. Not exported
- * from the package root — only downstream ring code (landing in #2 / #3) and
- * tests import from `brevwick-sdk/core/internal`.
+ * Internal surface shared between the factory and ring modules. Imported via
+ * relative paths inside this package only — not re-exported from the package
+ * root and intentionally not listed in `package.json` `exports`, so consumer
+ * code can never reach the uninstall-unsafe primitives that live here.
  */
-import type { RingEntry } from '../types';
+import type {
+  ConsoleEntry,
+  NetworkEntry,
+  RingEntry,
+  RouteEntry,
+} from '../types';
 import type { Bus } from './bus';
 import type { RingBuffer } from './buffer';
 import type { ValidatedConfig } from './validate';
@@ -29,9 +35,9 @@ export interface RingDefinition {
 
 export interface BrevwickInternal {
   readonly buffers: {
-    readonly console: RingBuffer<RingEntry>;
-    readonly network: RingBuffer<RingEntry>;
-    readonly route: RingBuffer<RingEntry>;
+    readonly console: RingBuffer<ConsoleEntry>;
+    readonly network: RingBuffer<NetworkEntry>;
+    readonly route: RingBuffer<RouteEntry>;
   };
   readonly bus: Bus<BusEventMap>;
   readonly config: ValidatedConfig;

--- a/packages/sdk/src/core/internal/__tests__/redact.test.ts
+++ b/packages/sdk/src/core/internal/__tests__/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { redact, redactValue } from './redact';
+import { redact, redactValue } from '../redact';
 
 describe('redact', () => {
   it('strips Authorization headers', () => {

--- a/packages/sdk/src/core/internal/redact.ts
+++ b/packages/sdk/src/core/internal/redact.ts
@@ -2,6 +2,10 @@
  * Client-side redaction. Mirrors the server-side sanitiser in brevwick-api;
  * we redact early so secrets never even leave the device.
  *
+ * Consumed internally by the submit pipeline (issue #4). Not re-exported on
+ * the public surface — callers cannot disable redaction, so there is no
+ * reason for them to reach the primitives.
+ *
  * Patterns:
  * - Authorization / Cookie / Set-Cookie headers
  * - `Bearer <token>`

--- a/packages/sdk/src/core/validate.ts
+++ b/packages/sdk/src/core/validate.ts
@@ -35,7 +35,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function assertHttpsUrl(value: string, field: string): void {
+/**
+ * Parse + canonicalise so `https://api.brevwick.com` and
+ * `https://API.Brevwick.com/` collapse to the same singleton key. Without
+ * this, a typo in config on the second `createBrevwick` call spawns a
+ * shadow instance that silently diverges from the first.
+ */
+function canonicaliseHttpsUrl(value: string, field: string): string {
   let parsed: URL;
   try {
     parsed = new URL(value);
@@ -45,6 +51,9 @@ function assertHttpsUrl(value: string, field: string): void {
   if (parsed.protocol !== 'https:') {
     throw new BrevwickConfigError(`${field} must use https`);
   }
+  const host = parsed.host.toLowerCase();
+  const path = parsed.pathname.replace(/\/+$/, '');
+  return `https://${host}${path}${parsed.search}`;
 }
 
 function isEnvironment(value: unknown): value is Environment {
@@ -66,14 +75,14 @@ export function validateConfig(input: unknown): ValidatedConfig {
     );
   }
 
-  let endpoint: string = DEFAULT_ENDPOINT;
+  let rawEndpoint: string = DEFAULT_ENDPOINT;
   if (input.endpoint !== undefined) {
     if (typeof input.endpoint !== 'string') {
       throw new BrevwickConfigError('endpoint must be a string');
     }
-    endpoint = input.endpoint;
+    rawEndpoint = input.endpoint;
   }
-  assertHttpsUrl(endpoint, 'endpoint');
+  const endpoint = canonicaliseHttpsUrl(rawEndpoint, 'endpoint');
 
   let environment: Environment | undefined;
   if (input.environment !== undefined) {

--- a/packages/sdk/src/core/validate.ts
+++ b/packages/sdk/src/core/validate.ts
@@ -12,7 +12,11 @@ export class BrevwickConfigError extends Error {
 
 const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
 const DEFAULT_ENDPOINT = 'https://api.brevwick.com';
-const VALID_ENVIRONMENTS = ['dev', 'stg', 'prod'] as const satisfies readonly Environment[];
+const VALID_ENVIRONMENTS = [
+  'dev',
+  'stg',
+  'prod',
+] as const satisfies readonly Environment[];
 
 export interface ValidatedConfig extends Required<
   Pick<BrevwickConfig, 'projectKey' | 'endpoint'>

--- a/packages/sdk/src/core/validate.ts
+++ b/packages/sdk/src/core/validate.ts
@@ -1,4 +1,4 @@
-import type { BrevwickConfig } from '../types';
+import type { BrevwickConfig, Environment } from '../types';
 
 export const INVALID_CONFIG_CODE = 'BREVWICK_INVALID_CONFIG';
 
@@ -12,7 +12,7 @@ export class BrevwickConfigError extends Error {
 
 const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
 const DEFAULT_ENDPOINT = 'https://api.brevwick.com';
-const VALID_ENVIRONMENTS = ['dev', 'stg', 'prod'] as const;
+const VALID_ENVIRONMENTS = ['dev', 'stg', 'prod'] as const satisfies readonly Environment[];
 
 export interface ValidatedConfig extends Required<
   Pick<BrevwickConfig, 'projectKey' | 'endpoint'>
@@ -20,7 +20,7 @@ export interface ValidatedConfig extends Required<
   enabled: boolean;
   fingerprintOptOut: boolean;
   rings: { console: boolean; network: boolean; route: boolean };
-  environment?: BrevwickConfig['environment'];
+  environment?: Environment;
   buildSha?: string;
   release?: string;
   userContext?: BrevwickConfig['userContext'];
@@ -43,6 +43,13 @@ function assertHttpsUrl(value: string, field: string): void {
   }
 }
 
+function isEnvironment(value: unknown): value is Environment {
+  return (
+    typeof value === 'string' &&
+    (VALID_ENVIRONMENTS as readonly string[]).includes(value)
+  );
+}
+
 export function validateConfig(input: unknown): ValidatedConfig {
   if (!isPlainObject(input)) {
     throw new BrevwickConfigError('config must be an object');
@@ -55,55 +62,71 @@ export function validateConfig(input: unknown): ValidatedConfig {
     );
   }
 
-  const endpoint = input.endpoint ?? DEFAULT_ENDPOINT;
-  if (typeof endpoint !== 'string') {
-    throw new BrevwickConfigError('endpoint must be a string');
+  let endpoint: string = DEFAULT_ENDPOINT;
+  if (input.endpoint !== undefined) {
+    if (typeof input.endpoint !== 'string') {
+      throw new BrevwickConfigError('endpoint must be a string');
+    }
+    endpoint = input.endpoint;
   }
   assertHttpsUrl(endpoint, 'endpoint');
 
+  let environment: Environment | undefined;
   if (input.environment !== undefined) {
-    if (
-      typeof input.environment !== 'string' ||
-      !VALID_ENVIRONMENTS.includes(
-        input.environment as (typeof VALID_ENVIRONMENTS)[number],
-      )
-    ) {
+    if (!isEnvironment(input.environment)) {
       throw new BrevwickConfigError(
         `environment must be one of ${VALID_ENVIRONMENTS.join(', ')}`,
       );
     }
+    environment = input.environment;
   }
 
-  if (input.buildSha !== undefined && typeof input.buildSha !== 'string') {
-    throw new BrevwickConfigError('buildSha must be a string');
+  let buildSha: string | undefined;
+  if (input.buildSha !== undefined) {
+    if (typeof input.buildSha !== 'string') {
+      throw new BrevwickConfigError('buildSha must be a string');
+    }
+    buildSha = input.buildSha;
   }
 
-  if (input.release !== undefined && typeof input.release !== 'string') {
-    throw new BrevwickConfigError('release must be a string');
+  let release: string | undefined;
+  if (input.release !== undefined) {
+    if (typeof input.release !== 'string') {
+      throw new BrevwickConfigError('release must be a string');
+    }
+    release = input.release;
   }
 
-  if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
-    throw new BrevwickConfigError('enabled must be a boolean');
+  let enabled = true;
+  if (input.enabled !== undefined) {
+    if (typeof input.enabled !== 'boolean') {
+      throw new BrevwickConfigError('enabled must be a boolean');
+    }
+    enabled = input.enabled;
   }
 
-  if (
-    input.fingerprintOptOut !== undefined &&
-    typeof input.fingerprintOptOut !== 'boolean'
-  ) {
-    throw new BrevwickConfigError('fingerprintOptOut must be a boolean');
+  let fingerprintOptOut = false;
+  if (input.fingerprintOptOut !== undefined) {
+    if (typeof input.fingerprintOptOut !== 'boolean') {
+      throw new BrevwickConfigError('fingerprintOptOut must be a boolean');
+    }
+    fingerprintOptOut = input.fingerprintOptOut;
   }
 
-  if (
-    input.userContext !== undefined &&
-    typeof input.userContext !== 'function'
-  ) {
-    throw new BrevwickConfigError('userContext must be a function');
+  let userContext: BrevwickConfig['userContext'];
+  if (input.userContext !== undefined) {
+    if (typeof input.userContext !== 'function') {
+      throw new BrevwickConfigError('userContext must be a function');
+    }
+    userContext = input.userContext as BrevwickConfig['userContext'];
   }
 
+  let user: BrevwickConfig['user'];
   if (input.user !== undefined) {
     if (!isPlainObject(input.user) || typeof input.user.id !== 'string') {
       throw new BrevwickConfigError('user must be an object with a string id');
     }
+    user = input.user as BrevwickConfig['user'];
   }
 
   const rawRings = input.rings;
@@ -111,27 +134,31 @@ export function validateConfig(input: unknown): ValidatedConfig {
     throw new BrevwickConfigError('rings must be an object');
   }
   const ringsIn = (rawRings ?? {}) as Record<string, unknown>;
+  const rings: ValidatedConfig['rings'] = {
+    console: true,
+    network: true,
+    route: true,
+  };
   for (const key of ['console', 'network', 'route'] as const) {
-    if (ringsIn[key] !== undefined && typeof ringsIn[key] !== 'boolean') {
-      throw new BrevwickConfigError(`rings.${key} must be a boolean`);
+    const value = ringsIn[key];
+    if (value !== undefined) {
+      if (typeof value !== 'boolean') {
+        throw new BrevwickConfigError(`rings.${key} must be a boolean`);
+      }
+      rings[key] = value;
     }
   }
 
   return {
     projectKey,
     endpoint,
-    enabled: (input.enabled as boolean | undefined) ?? true,
-    fingerprintOptOut:
-      (input.fingerprintOptOut as boolean | undefined) ?? false,
-    rings: {
-      console: (ringsIn.console as boolean | undefined) ?? true,
-      network: (ringsIn.network as boolean | undefined) ?? true,
-      route: (ringsIn.route as boolean | undefined) ?? true,
-    },
-    environment: input.environment as BrevwickConfig['environment'],
-    buildSha: input.buildSha as string | undefined,
-    release: input.release as string | undefined,
-    userContext: input.userContext as BrevwickConfig['userContext'],
-    user: input.user as BrevwickConfig['user'],
+    enabled,
+    fingerprintOptOut,
+    rings,
+    environment,
+    buildSha,
+    release,
+    userContext,
+    user,
   };
 }

--- a/packages/sdk/src/core/validate.ts
+++ b/packages/sdk/src/core/validate.ts
@@ -1,0 +1,137 @@
+import type { BrevwickConfig } from '../types';
+
+export const INVALID_CONFIG_CODE = 'BREVWICK_INVALID_CONFIG';
+
+export class BrevwickConfigError extends Error {
+  readonly code = INVALID_CONFIG_CODE;
+  constructor(message: string) {
+    super(message);
+    this.name = 'BrevwickConfigError';
+  }
+}
+
+const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
+const DEFAULT_ENDPOINT = 'https://api.brevwick.com';
+const VALID_ENVIRONMENTS = ['dev', 'stg', 'prod'] as const;
+
+export interface ValidatedConfig extends Required<
+  Pick<BrevwickConfig, 'projectKey' | 'endpoint'>
+> {
+  enabled: boolean;
+  fingerprintOptOut: boolean;
+  rings: { console: boolean; network: boolean; route: boolean };
+  environment?: BrevwickConfig['environment'];
+  buildSha?: string;
+  release?: string;
+  userContext?: BrevwickConfig['userContext'];
+  user?: BrevwickConfig['user'];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertHttpsUrl(value: string, field: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new BrevwickConfigError(`${field} must be a valid URL`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new BrevwickConfigError(`${field} must use https`);
+  }
+}
+
+export function validateConfig(input: unknown): ValidatedConfig {
+  if (!isPlainObject(input)) {
+    throw new BrevwickConfigError('config must be an object');
+  }
+
+  const projectKey = input.projectKey;
+  if (typeof projectKey !== 'string' || !PROJECT_KEY_PATTERN.test(projectKey)) {
+    throw new BrevwickConfigError(
+      'projectKey must match /^pk_(live|test)_[A-Za-z0-9]{16,}$/',
+    );
+  }
+
+  const endpoint = input.endpoint ?? DEFAULT_ENDPOINT;
+  if (typeof endpoint !== 'string') {
+    throw new BrevwickConfigError('endpoint must be a string');
+  }
+  assertHttpsUrl(endpoint, 'endpoint');
+
+  if (input.environment !== undefined) {
+    if (
+      typeof input.environment !== 'string' ||
+      !VALID_ENVIRONMENTS.includes(
+        input.environment as (typeof VALID_ENVIRONMENTS)[number],
+      )
+    ) {
+      throw new BrevwickConfigError(
+        `environment must be one of ${VALID_ENVIRONMENTS.join(', ')}`,
+      );
+    }
+  }
+
+  if (input.buildSha !== undefined && typeof input.buildSha !== 'string') {
+    throw new BrevwickConfigError('buildSha must be a string');
+  }
+
+  if (input.release !== undefined && typeof input.release !== 'string') {
+    throw new BrevwickConfigError('release must be a string');
+  }
+
+  if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
+    throw new BrevwickConfigError('enabled must be a boolean');
+  }
+
+  if (
+    input.fingerprintOptOut !== undefined &&
+    typeof input.fingerprintOptOut !== 'boolean'
+  ) {
+    throw new BrevwickConfigError('fingerprintOptOut must be a boolean');
+  }
+
+  if (
+    input.userContext !== undefined &&
+    typeof input.userContext !== 'function'
+  ) {
+    throw new BrevwickConfigError('userContext must be a function');
+  }
+
+  if (input.user !== undefined) {
+    if (!isPlainObject(input.user) || typeof input.user.id !== 'string') {
+      throw new BrevwickConfigError('user must be an object with a string id');
+    }
+  }
+
+  const rawRings = input.rings;
+  if (rawRings !== undefined && !isPlainObject(rawRings)) {
+    throw new BrevwickConfigError('rings must be an object');
+  }
+  const ringsIn = (rawRings ?? {}) as Record<string, unknown>;
+  for (const key of ['console', 'network', 'route'] as const) {
+    if (ringsIn[key] !== undefined && typeof ringsIn[key] !== 'boolean') {
+      throw new BrevwickConfigError(`rings.${key} must be a boolean`);
+    }
+  }
+
+  return {
+    projectKey,
+    endpoint,
+    enabled: (input.enabled as boolean | undefined) ?? true,
+    fingerprintOptOut:
+      (input.fingerprintOptOut as boolean | undefined) ?? false,
+    rings: {
+      console: (ringsIn.console as boolean | undefined) ?? true,
+      network: (ringsIn.network as boolean | undefined) ?? true,
+      route: (ringsIn.route as boolean | undefined) ?? true,
+    },
+    environment: input.environment as BrevwickConfig['environment'],
+    buildSha: input.buildSha as string | undefined,
+    release: input.release as string | undefined,
+    userContext: input.userContext as BrevwickConfig['userContext'],
+    user: input.user as BrevwickConfig['user'],
+  };
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,6 +10,7 @@ export { createBrevwick } from './core/client';
 export type {
   Brevwick,
   BrevwickConfig,
+  Environment,
   FeedbackAttachment,
   FeedbackInput,
   SubmitResult,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,17 +1,16 @@
 /**
  * Brevwick — AI-first QA feedback SDK for browser apps.
  *
- * Phase 0: types and redaction primitives only. The full client (rings,
- * screenshot, submit) lands in Phase 4 — see brevwick-ops/docs/brevwick-sdd.md
- * § 12 for the contract.
+ * Public surface is frozen to exactly the symbols re-exported here. See
+ * brevwick-ops/docs/brevwick-sdd.md § 12 for the contract.
  */
+
+export { createBrevwick } from './core/client';
 
 export type {
   Brevwick,
   BrevwickConfig,
-  Environment,
+  FeedbackAttachment,
   FeedbackInput,
   SubmitResult,
 } from './types';
-
-export { redact, redactValue } from './rings/redact';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,7 +1,16 @@
 export type Environment = 'dev' | 'stg' | 'prod';
 
+export interface BrevwickRingsConfig {
+  /** Patch console.error / window.onerror to capture console entries. Default true. */
+  console?: boolean;
+  /** Patch fetch / XMLHttpRequest to capture failed network calls. Default true. */
+  network?: boolean;
+  /** Track history pushState / popstate transitions. Default true. */
+  route?: boolean;
+}
+
 export interface BrevwickConfig {
-  /** Public ingest key, e.g. `pk_live_xxx`. */
+  /** Public ingest key, e.g. `pk_live_xxx` or `pk_test_xxx`. */
   projectKey: string;
   /** Override the default ingest endpoint (https://api.brevwick.com). */
   endpoint?: string;
@@ -10,10 +19,22 @@ export interface BrevwickConfig {
   enabled?: boolean;
   /** Build SHA — included in every report. */
   buildSha?: string;
+  /** Released app version — passed through on every report. */
+  release?: string;
   /** Resolved at submit time; merged into `user_context`. */
   userContext?: () => Record<string, unknown>;
+  /** Opaque user identity merged into reports (id + optional metadata). */
+  user?: { id: string; [key: string]: unknown };
+  /** Per-ring toggles. All default to true. */
+  rings?: BrevwickRingsConfig;
   /** Send `X-Brevwick-Fingerprint-Optout: 1` to skip the salted fingerprint. */
   fingerprintOptOut?: boolean;
+}
+
+export interface FeedbackAttachment {
+  /** PNG / JPEG / WebP / WebM; ≤10 MB each, ≤5 total per report. */
+  blob: Blob;
+  filename?: string;
 }
 
 export interface FeedbackInput {
@@ -21,17 +42,51 @@ export interface FeedbackInput {
   description: string;
   expected?: string;
   actual?: string;
-  /** PNG / JPEG / WebP / WebM. ≤10 MB each, ≤5 total. */
-  attachments?: Blob[];
+  attachments?: Array<Blob | FeedbackAttachment>;
 }
 
 export interface SubmitResult {
   reportId: string;
 }
 
+export interface ConsoleEntry {
+  kind: 'console';
+  level: 'log' | 'info' | 'warn' | 'error' | 'debug';
+  message: string;
+  stack?: string;
+  timestamp: number;
+}
+
+export interface NetworkEntry {
+  kind: 'network';
+  method: string;
+  url: string;
+  status?: number;
+  durationMs?: number;
+  error?: string;
+  timestamp: number;
+}
+
+export interface RouteEntry {
+  kind: 'route';
+  path: string;
+  timestamp: number;
+}
+
+export type RingEntry = ConsoleEntry | NetworkEntry | RouteEntry;
+
 export interface Brevwick {
+  /**
+   * Install rings (console / network / route as configured) and begin capturing
+   * entries. Safe to call more than once; subsequent calls are no-ops while
+   * already installed. No-op entirely in non-browser contexts (SSR, workers).
+   */
+  install(): void;
+  /**
+   * Restore every patched global, drain internal buffers, and move the instance
+   * to the `uninstalled` state. A second call is a no-op.
+   */
+  uninstall(): void;
   submit(input: FeedbackInput): Promise<SubmitResult>;
   captureScreenshot(): Promise<Blob>;
-  /** Installs console + fetch rings. Returns an uninstaller. */
-  install(): () => void;
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,11 +1,11 @@
 export type Environment = 'dev' | 'stg' | 'prod';
 
 export interface BrevwickRingsConfig {
-  /** Patch console.error / window.onerror to capture console entries. Default true. */
+  /** Capture uncaught errors and console.error calls for inclusion in submitted reports. Default true. */
   console?: boolean;
-  /** Patch fetch / XMLHttpRequest to capture failed network calls. Default true. */
+  /** Capture failed network calls so triagers see the request context of the bug. Default true. */
   network?: boolean;
-  /** Track history pushState / popstate transitions. Default true. */
+  /** Record route transitions so reproduction steps include the path the user was on. Default true. */
   route?: boolean;
 }
 
@@ -84,7 +84,8 @@ export interface Brevwick {
   install(): void;
   /**
    * Restore every patched global, drain internal buffers, and move the instance
-   * to the `uninstalled` state. A second call is a no-op.
+   * to the `uninstalled` state. A second call is a no-op. After `uninstall()`,
+   * calling `install()` again is not supported and will throw.
    */
   uninstall(): void;
   submit(input: FeedbackInput): Promise<SubmitResult>;


### PR DESCRIPTION
Closes #1

Implements [SDD § 12](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts) client SDK contracts — lifecycle and ring buffer primitives. Cross-repo SDD update: **[tatlacas-com/brevwick-ops#4](https://github.com/tatlacas-com/brevwick-ops/pull/4)** — merges ahead of this one so the published contract matches the code.

## Summary
- `createBrevwick(config)` factory with hand-rolled config validation (no Zod — preserves < 2 kB budget); throws `BREVWICK_INVALID_CONFIG` on bad input.
- Idempotent `install()` / `uninstall()`; SSR + worker no-op guard (`typeof window === 'undefined'`). `install()` after `uninstall()` throws — instances are terminal after teardown.
- Singleton keyed on `projectKey|endpoint`; second call logs a prefix-only warn and returns the existing instance.
- Tiny typed event bus (snapshot-on-emit, safe against listener mutation) + O(1) head-pointer ring buffers (console 50, network 50, routes 20); internal push API exposed via non-enumerable `_internal` with a typed `BrevwickInternal` surface in `core/internal.ts` for downstream rings.
- Stub `submit()` / `captureScreenshot()` return rejecting Promises so `.catch()` chains work; real impls land in #4.
- Ring registry (`__registerRing`) so #2/#3 can plug in without reaching into factory internals.
- Redaction primitives moved to `core/internal/redact.ts` (internal; consumed by #4's submit pipeline).
- Frozen public exports: `createBrevwick`, `Brevwick`, `BrevwickConfig`, `Environment`, `FeedbackInput`, `SubmitResult`, `FeedbackAttachment`.

## Test plan
- [x] `pnpm type-check`, `lint`, `test`, `build` all green
- [x] 67 tests passing; `brevwick-sdk` coverage 100% statements / 100% branches / 100% functions / 100% lines
- [x] Snapshot assertion wired through a fake ring — `install()` -> `uninstall()` structurally restores every global the ring touched
- [x] Double `install()` and double `uninstall()` both safe; `install()` after `uninstall()` throws
- [x] `submit()` / `captureScreenshot()` return rejecting Promises (asserted via both `await` and `.catch()` paths)
- [x] Buffer cap: 60 pushes -> snapshot length 50, first entry is the 11th pushed; clear-then-push resets window; wrap pointer validated across many cycles
- [x] SSR guard: `install()` is a no-op when `window` is stubbed undefined
- [x] Disabled (`enabled=false`) install + uninstall leaves state `idle` (not `uninstalled`)
- [x] Singleton: same `projectKey+endpoint` returns same reference; differing endpoint returns new instance; warn logs prefix only
- [x] Bus mutation-during-emit: off-self, register-new, off-other — all delivery semantics asserted
- [x] Minified gzip = **1737 bytes** (measured with `npx esbuild --bundle --format=esm --minify | gzip -c | wc -c`) — 311 bytes headroom under the 2 kB budget
- [x] `dist/index.js` contains zero references to `modern-screenshot`

## Notes
- **Changeset entry** is intentionally deferred: `pnpm changeset` tooling lands in #8. Will be backfilled as part of that PR per prior coordination.
