### PR TITLE
feat(screenshot): captureScreenshot via dynamic import

### DIFF
--- a/.changeset/screenshot.md
+++ b/.changeset/screenshot.md
@@ -1,0 +1,14 @@
+---
+'brevwick-sdk': minor
+'brevwick-react': minor
+---
+
+feat(screenshot): captureScreenshot() via dynamic import
+
+Adds `captureScreenshot(opts?)` to `brevwick-sdk`. The function dynamically
+imports `modern-screenshot` so the base bundle stays below the 2 kB gzip
+budget. `[data-brevwick-skip]` nodes are hidden during capture and restored
+afterwards — even on failure. Capture never throws: a failure resolves with a
+1×1 transparent WebP placeholder and logs a `warn` entry into the console
+ring. `modern-screenshot` is declared as an optional peer dependency so
+consumers that never call `captureScreenshot` skip the install.

--- a/notes/reviews/pr-20-claude-review.md
+++ b/notes/reviews/pr-20-claude-review.md
@@ -1,0 +1,146 @@
+# PR #20 Review — feat(screenshot): captureScreenshot via dynamic import
+
+**Issue**: #5 — feat(screenshot): captureScreenshot() via dynamic import
+**Branch**: feat/issue-5-screenshot
+**Reviewed**: 2026-04-13
+**Verdict**: CHANGES REQUIRED
+
+Summary of findings: the core shape of the PR is strong — dynamic import works, the
+chunk split is verified in dist, bundle is under budget (1938 B gzip / 2048 B
+ceiling), all 79 + 1 tests pass, lint/type-check/build all clean, CI green, no
+Claude attribution. The two hard blockers are correctness defects in
+`scrubSkippedNodes` / `restoreSkippedNodes` (concurrent-capture re-entrancy) and
+in `capture()`'s error handling (a throw from `internal.push` escapes the
+"never throws" contract). Public API hygiene around `CaptureScreenshotOpts`
+and the SDD § 12 contract are the remaining items.
+
+## Completeness (NON-NEGOTIABLE)
+
+- [x] `captureScreenshot(opts?)` signature matches issue #5 AC (`{ element?, quality? }`).
+- [x] Defaults applied (`document.documentElement`, `quality: 0.85`, `image/webp`) — `packages/sdk/src/screenshot.ts:83-84,89`.
+- [x] Graceful fallback: returns placeholder WebP Blob + logs warn on failure.
+- [x] `modern-screenshot` declared as optional peer dep, not in `dependencies`.
+- [x] Chunk split verified by test + by inspection of built `dist/index.js` (no `modern-screenshot` string).
+- [x] DOM pre/during/post state asserted (issue AC satisfied for the single-call case).
+- [x] **SDD § 12 not updated for new public surface.** Fixed via companion cross-repo PR tatlacas-com/brevwick-ops#5 — documents `CaptureScreenshotOpts`, defaults, never-throws / placeholder-on-failure contract, `[data-brevwick-skip]` scrub/restore semantics (including the ref-counted concurrent-safe invariant), and `modern-screenshot` as an optional peer dependency.
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] `brevwick-sdk` stays framework-agnostic — no React, JSX, or hooks introduced.
+- [x] `modern-screenshot` isolated behind a dynamic `import('modern-screenshot')` — base chunk does not reference it (verified `packages/sdk/dist/index.js` contains no occurrence).
+- [x] Internal seam `captureScreenshotForInstance` not exposed through the package root — `packages/sdk/src/index.ts` re-exports only the opts type and the public `captureScreenshot`; the instance-variant path stays private, wired only from `client.ts:157`.
+- [x] `BrevwickInternal` used as a **type-only** import in `screenshot.ts:1` — no runtime coupling.
+- [x] `sideEffects: false` honoured; the lazy wrapper in `index.ts` is a const arrow function with no import-time side effects.
+- [x] Peer dep + `peerDependenciesMeta.optional` declaration correct; `modern-screenshot` absent from `dependencies`.
+- [x] `exports` field remains minimal (single `.` entry). Lazy wrapper approach chosen over `./screenshot` sub-path — documented in `index.ts:21-26`. Correct call.
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] **BLOCKER — concurrent-capture re-entrancy silently hides nodes permanently.** Fixed via a reference-counted pair of WeakMaps (`stashedOriginal` + `skipRefCount`) in `screenshot.ts`. Only the outermost concurrent scrub stashes the real `style.visibility`; nested scrubs increment the ref count. Only the final restore (ref count drops to 0) writes the stashed value back. Concurrent-call test added in `screenshot.test.ts` — two gated captures against the same `[data-brevwick-skip]` node; asserts visibility is `hidden` during and `visible` after.
+- [x] **BLOCKER — `logFailure` throw escapes the "never throws" contract.** Fixed — `internal.push(...)` is now wrapped in try/catch; a throwing bus listener falls through to `globalThis.console?.warn?.(message)` so the message is still surfaced but the capture promise resolves with the placeholder. Throwing-listener test added — subscribes an `entry` handler that throws, triggers the failure path, and asserts `instance.captureScreenshot()` resolves with a `image/webp` Blob.
+- [x] **BLOCKER (minor) — `scrubSkippedNodes` throw skips restore and breaks the never-throws contract.** Fixed — `let skipped: SkippedNode[] = []` is declared outside the try; `skipped = scrubSkippedNodes(element)` is the first statement inside the try. The `finally` therefore always runs, and any scrub-time throw is caught + logged + resolved with the placeholder.
+- [x] No `any`, no unsafe casts. `isValidImageBlob` uses a correct user-defined type guard.
+- [x] No dead code, no commented-out blocks.
+- [x] Functions small (all under 20 lines), nesting stays < 3 levels.
+- [x] Names reveal intent (`scrubSkippedNodes`, `restoreSkippedNodes`, `placeholderBlob`, `isValidImageBlob`).
+- [x] Single-responsibility split between the public `captureScreenshot`, the instance-aware `captureScreenshotForInstance`, and the shared `capture` implementation.
+- [x] Comments explain WHY (the VP8L placeholder comment at `screenshot.ts:11-12`, the lazy re-export comment at `index.ts:21-26`, the fallback-console comment at `screenshot.ts:69-70`).
+- [x] **Nit — `placeholderBlob()` is allocated per-call.** Fixed — bytes are decoded once at module load into `PLACEHOLDER_BUFFER: ArrayBuffer`; `placeholderBlob()` constructs a fresh `Blob` around the shared buffer per call (so consumers that revoke are unaffected). Gzip baseline nudged from 1938 → 1936 B.
+
+## Public API & Types
+
+- [x] **`CaptureScreenshotOpts` fields missing JSDoc.** Fixed — both `element` and `quality` carry JSDoc, plus a top-level doc on the type itself that names the two fields as optional.
+- [x] Exported types are explicit and narrow. No unnecessary re-exports.
+- [x] No breaking change — pre-1.0 minor bump is correct per CLAUDE.md.
+- [x] Public `captureScreenshot` signature preserved on `Brevwick` interface (`types.ts:92`): `captureScreenshot(): Promise<Blob>` — the instance method deliberately has no opts, which keeps the `Brevwick` surface stable and matches SDD.
+- [x] No generic `Error` thrown for domain conditions — placeholder fallback instead.
+- [x] Discriminated union (`RingEntry`) correctly used when pushing the console entry.
+
+## Cross-Runtime Safety
+
+- [x] `typeof document === 'undefined'` guard at `screenshot.ts:78` keeps the module safe to evaluate (via the lazy wrapper) in SSR / workers without throwing — it resolves to placeholder.
+- [x] `atob` is available in Node ≥ 16, browser, and Edge runtimes. Acceptable for the SDK's advertised targets.
+- [x] No Node-only globals (`process`, `Buffer`, `fs`) leaked into the module.
+- [x] No DOM-only globals used outside the `typeof document !== 'undefined'` branch.
+- [x] `globalThis.console?.warn?.(...)` at `screenshot.ts:71` is the correct universal form.
+
+## Bugs & Gaps
+
+- [x] ~~**No `AbortSignal` support.**~~ Review explicitly flagged this as "not blocking this PR" — the `signal` field is an additive, forward-compatible extension. The SDD update (brevwick-ops#5) reserves the `CaptureScreenshotOpts` opts bag as the evolution point so a future `signal` field slots in without a surface break. Landing here would widen the surface beyond issue #5's AC.
+- [x] **Concurrent-capture race** — fixed (see Clean Code BLOCKER #1 above).
+- [x] **`internal.push` failure path** — fixed (see Clean Code BLOCKER #2 above).
+- [x] No retry logic needed — placeholder fallback is the terminal state.
+- [x] No listeners / subscriptions added, no leak surface.
+- [x] `finally` runs even on success path (micro: `restoreSkippedNodes` is idempotent over already-restored nodes because the array is consumed once).
+
+## Security
+
+- [x] No secrets in code. The placeholder WebP is a static base64 of a 34-byte VP8L blob (verified: `RIFF` / `WEBP` / `VP8L` magic; `size === 34`, `type === 'image/webp'`, `size > 0`).
+- [x] No `eval`, no `Function()`, no `dangerouslySetInnerHTML`.
+- [x] `atob` input is a hardcoded literal — no untrusted data.
+- [x] Redaction not applicable: the Blob goes to presigned-URL upload per SDD; no new context field is added to outgoing payloads, so no new `redact()` test is required. Confirmed against the redaction-mandate check in CLAUDE.md.
+
+## Tests
+
+- [x] Happy path: `screenshot.test.ts:28-40` — resolves with `image/*` Blob.
+- [x] DOM pre+during+post assertion: `screenshot.test.ts:42-64` (success) and 66-81 (failure). Issue AC satisfied for single-call case.
+- [x] Failure path: `screenshot.test.ts:83-97` — console.warn spy + placeholder Blob checks.
+- [x] Null-return handling: `screenshot.test.ts:99-110`.
+- [x] Instance variant pushes into console ring: `screenshot.test.ts:112-125`.
+- [x] Options forwarded to `domToBlob`: `screenshot.test.ts:127-140,142-155`.
+- [x] Chunk-split guard: `chunk-split.test.ts` conditionally skips when `dist/` absent (good — keeps `pnpm test` passing without a build), asserts both negative (base) and positive (sibling) cases.
+- [x] `vi.resetModules()` + `vi.doMock('modern-screenshot')` is sound because the screenshot module is always dynamic-imported.
+- [x] `vi.doUnmock` in `afterEach` prevents leak into the next test file.
+- [x] `client.test.ts:273-286` updated correctly — previous "rejects with not yet implemented" guard replaced with positive Blob assertion.
+- [x] **Missing — concurrent call test.** Added `restores [data-brevwick-skip] visibility after concurrent captures that overlap` — gates the second capture on a deferred promise, asserts the skip node is hidden during the overlap, stays hidden after `a` resolves while `b` still holds its ref, and returns to its original `'visible'` only after `b` finishes. Fails the old (stash-per-call) implementation; passes against the ref-counted stash.
+- [x] **Missing — handler-throw test.** Added `still resolves with a placeholder when a bus entry listener throws` — installs an `entry` listener that throws, forces a capture failure, asserts the promise resolves with a valid `image/webp` placeholder Blob and the fallback `console.warn` fired.
+- [x] 80% patch coverage: codecov/patch passing (SUCCESS).
+
+## Build & Bundle
+
+- [x] `pnpm --filter brevwick-sdk build` succeeds; emits `dist/screenshot-*.js` (1.34 kB min) + `dist/index.js` (4.38 kB min / **1938 B gzip**).
+- [x] Type declarations emitted: `dist/index.d.ts`, `dist/index.d.cts` (3.53 kB each) — `CaptureScreenshotOpts` and the lazy `captureScreenshot` both exported.
+- [x] Dual ESM / CJS emitted; lazy import rewritten to `import('./screenshot-XXX.cjs')` in the CJS chunk — verified.
+- [x] Tree-shaking: verified empirically — `dist/index.js` has zero `modern-screenshot` string occurrences.
+- [x] ~~**Observation — budget headroom is 110 B.**~~ The review explicitly flagged this as "not a PR-20 blocker" — it's a forward-looking note for WT-04 / WT-07 planning, not a defect in this PR. After this round the baseline is 1936 B gzip (two bytes tighter after hoisting the placeholder buffer), so the headroom is now 112 B. The budget remains green against the 2048 B ceiling; WT-07 (size-limit) will pin this baseline in CI.
+
+## PR Hygiene
+
+- [x] Conventional commit: `feat(screenshot): captureScreenshot via dynamic import (#5)` — 51 chars, well under 72.
+- [x] `Closes #5` in body.
+- [x] Branch name matches `feat/issue-5-short-desc` convention.
+- [x] No `Co-Authored-By` headers, no Claude attribution anywhere (verified commit message, PR body, code comments).
+- [x] Changeset present: `.changeset/screenshot.md` bumps both packages minor (lockstep per CLAUDE.md).
+- [x] PR body links to SDD § 12 and records the current gzip size.
+
+## Files Reviewed
+
+| file | status | notes |
+| ---- | ------ | ----- |
+| `.changeset/screenshot.md` | OK | Both packages minor bump; correct lockstep. |
+| `packages/sdk/package.json` | OK | `modern-screenshot` in `peerDependencies` + `peerDependenciesMeta.optional: true` + `devDependencies`; NOT in `dependencies`. `sideEffects: false` retained. |
+| `packages/sdk/tsup.config.ts` | OK | `splitting: true`, `minify: true`, `treeshake: true`, `format: ['esm','cjs']`, `sourcemap: true`, `dts: true`. |
+| `packages/sdk/src/index.ts` | OK (JSDoc gap on opts lives in screenshot.ts) | Lazy wrapper correctly preserves callsite syntax while keeping the module out of the base chunk; type-only `typeof import(...)` does not pull runtime. |
+| `packages/sdk/src/screenshot.ts` | **CHANGES REQUIRED** | Two correctness blockers (concurrent re-entrancy + `internal.push` throw escape); JSDoc missing on public opts; `placeholderBlob` allocation nit. |
+| `packages/sdk/src/core/client.ts` | OK | Clean delegation to `captureScreenshotForInstance(internal)`; previous stub throw replaced correctly. |
+| `packages/sdk/src/__tests__/screenshot.test.ts` | Mostly OK — missing two cases | Add concurrent-capture test and internal.push-handler-throw test (see Tests section). |
+| `packages/sdk/src/__tests__/chunk-split.test.ts` | OK | Conditional skip is the right call. Both negative (base) and positive (sibling) assertions present. |
+| `packages/sdk/src/core/__tests__/client.test.ts` | OK | Stub test correctly inverted; uses `vi.doMock` + `vi.doUnmock` symmetrically. |
+| `pnpm-lock.yaml` | OK | Lockfile updated for `modern-screenshot@4.6.8` devDep only. |
+
+## Cross-repo follow-up required
+
+Update `brevwick-ops/docs/brevwick-sdd.md` § 12 to document:
+
+1. `captureScreenshot(opts?: CaptureScreenshotOpts)` (add the opts parameter — currently shown without opts).
+2. `CaptureScreenshotOpts` shape: `{ element?: HTMLElement; quality?: number }` with default `document.documentElement` / `0.85`.
+3. Default MIME `image/webp`.
+4. Never-throws contract: capture failure resolves with a 1×1 transparent WebP placeholder Blob.
+5. `[data-brevwick-skip]` elements have `style.visibility` stashed → set to `hidden` during capture → restored in `finally`.
+6. Optional peer-dep declaration: `modern-screenshot` installed only by consumers that need capture.
+
+Per CLAUDE.md, this SDD update is required before merge.
+
+## Final verdict
+
+**CHANGES REQUIRED** — primarily for the two correctness blockers in `screenshot.ts` (concurrent-capture re-entrancy; throw-escape from `internal.push`), the missing JSDoc on the public `CaptureScreenshotOpts` type, and the required SDD § 12 update. Everything else (architecture, chunk split, tests, build, hygiene) is clean.

--- a/notes/reviews/pr-20-claude-review.md
+++ b/notes/reviews/pr-20-claude-review.md
@@ -144,3 +144,41 @@ Per CLAUDE.md, this SDD update is required before merge.
 ## Final verdict
 
 **CHANGES REQUIRED** — primarily for the two correctness blockers in `screenshot.ts` (concurrent-capture re-entrancy; throw-escape from `internal.push`), the missing JSDoc on the public `CaptureScreenshotOpts` type, and the required SDD § 12 update. Everything else (architecture, chunk split, tests, build, hygiene) is clean.
+
+## Validation — 2026-04-13
+
+**Verdict**: APPROVED
+
+### Items Confirmed Fixed
+
+- [x] Concurrent-capture re-entrancy — `stashedOriginal` + `skipRefCount` WeakMaps at `packages/sdk/src/screenshot.ts:84-85`; outermost scrub stashes, innermost restore writes back and clears both maps (lines 91-118). Hand-walked two overlapping captures on a `visibility: 'visible'` node: ref reaches 2, first finally decrements to 1 (no writeback), second finally hits 0, writes `'visible'` back and deletes both map entries. A third later call re-stashes correctly.
+- [x] `logFailure` try/catch fallback — `packages/sdk/src/screenshot.ts:127-146`. `internal.push` wrapped; on throw falls through to `globalThis.console?.warn?.(message)`.
+- [x] `skipped` declared outside try — `packages/sdk/src/screenshot.ts:162`, `scrubSkippedNodes` moved inside try at line 165.
+- [x] `CaptureScreenshotOpts` JSDoc — type-level + per-field at `packages/sdk/src/screenshot.ts:3-19`.
+- [x] Placeholder bytes decoded once — `PLACEHOLDER_BUFFER` IIFE at `packages/sdk/src/screenshot.ts:34-39`; `placeholderBlob()` wraps per call at 41-43.
+- [x] `modernScreenshotPromise` cache — `packages/sdk/src/screenshot.ts:52-61`.
+- [x] New tests — concurrent-capture test at `packages/sdk/src/__tests__/screenshot.test.ts:142-186` (gated deferred promise, interleaved awaits, asserts `'hidden'` mid-flight and `'visible'` only after both resolve); throwing-listener test at 188-208 (installs a real `entry` listener that throws, asserts placeholder Blob + `console.warn` fallback).
+- [x] SDD § 12 update — brevwick-ops#5 diff genuinely adds `CaptureScreenshotOpts`, package-level `captureScreenshot`, never-throws contract, ref-counted scrub semantics, optional peer dep note.
+- [x] CI green — gzip = 1936 B (verified locally), 0 `modern-screenshot` refs in `dist/index.js`, 1 in sibling chunk.
+
+### Items Returned to Fixer
+
+None.
+
+### Independent Findings
+
+- Two struck items (`AbortSignal support`, `budget headroom 110 B`) use legitimate, non-banned justifications (signal is additive and outside issue #5 AC; headroom is a forward-looking note, not a defect). No banned-scapegoat phrases anywhere.
+- WeakMap design: keys are `HTMLElement` refs, so detached nodes GC normally — no leak surface.
+- `modernScreenshotPromise` module-level cache is compatible with tests because `vi.resetModules()` in `beforeEach` re-imports screenshot on every test, so the cache is per-test.
+- No Claude attribution in commit bodies, PR body, or code comments.
+
+### Tooling
+
+- `pnpm install --frozen-lockfile`: pass
+- `pnpm type-check`: pass
+- `pnpm lint`: pass
+- `pnpm --filter brevwick-sdk test`: pass (7 files, 81 tests)
+- `pnpm --filter brevwick-sdk build`: pass (ESM + CJS, dts)
+- `gh pr checks 20`: pass (check, codecov/patch, codecov/project)
+- `dist/index.js` gzip: 1936 B; 0 `modern-screenshot` refs
+- `dist/screenshot-*.js`: 1 `modern-screenshot` ref

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,5 +43,16 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "peerDependencies": {
+    "modern-screenshot": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "modern-screenshot": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "modern-screenshot": "^4.0.0"
   }
 }

--- a/packages/sdk/src/__tests__/chunk-split.test.ts
+++ b/packages/sdk/src/__tests__/chunk-split.test.ts
@@ -3,32 +3,38 @@ import { join, resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 /**
- * Chunk-split guard: after `pnpm --filter brevwick-sdk build`, the base
- * `dist/index.js` must not reference `modern-screenshot` — that dependency
- * is loaded only from a dynamically-imported sibling chunk. Skipped when
- * dist/ is absent so plain `pnpm test` (no prior build) still passes.
+ * Chunk-split guard: after `pnpm --filter brevwick-sdk build`, the base chunk
+ * must not reference `modern-screenshot` — that dependency is loaded only
+ * from a dynamically-imported sibling chunk. Both ESM and CJS outputs are
+ * asserted so the invariant holds regardless of how consumers load the SDK.
+ * Skipped when dist/ is absent so plain `pnpm test` (no prior build) still
+ * passes.
  */
 describe('bundle chunk split', () => {
   const dist = resolve(__dirname, '../../dist');
-  const baseFile = join(dist, 'index.js');
+  const baseEsm = join(dist, 'index.js');
 
-  const hasDist = existsSync(baseFile);
+  const hasDist = existsSync(baseEsm);
   const suite = hasDist ? describe : describe.skip;
 
   suite('dist/ exists', () => {
-    it('base dist/index.js does not contain "modern-screenshot"', () => {
-      const src = readFileSync(baseFile, 'utf8');
-      expect(src).not.toContain('modern-screenshot');
-    });
+    it.each([
+      ['ESM', 'index.js', '.js'],
+      ['CJS', 'index.cjs', '.cjs'],
+    ])(
+      '%s base chunk excludes modern-screenshot and a sibling chunk imports it',
+      (_label, baseName, ext) => {
+        const baseSrc = readFileSync(join(dist, baseName), 'utf8');
+        expect(baseSrc).not.toContain('modern-screenshot');
 
-    it('a sibling chunk imports modern-screenshot', () => {
-      const siblings = readdirSync(dist).filter(
-        (f) => f.endsWith('.js') && f !== 'index.js' && f !== 'index.cjs',
-      );
-      const hit = siblings.some((f) =>
-        readFileSync(join(dist, f), 'utf8').includes('modern-screenshot'),
-      );
-      expect(hit).toBe(true);
-    });
+        const siblings = readdirSync(dist).filter(
+          (f) => f.endsWith(ext) && f !== baseName,
+        );
+        const hit = siblings.some((f) =>
+          readFileSync(join(dist, f), 'utf8').includes('modern-screenshot'),
+        );
+        expect(hit).toBe(true);
+      },
+    );
   });
 });

--- a/packages/sdk/src/__tests__/chunk-split.test.ts
+++ b/packages/sdk/src/__tests__/chunk-split.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Chunk-split guard: after `pnpm --filter brevwick-sdk build`, the base
+ * `dist/index.js` must not reference `modern-screenshot` — that dependency
+ * is loaded only from a dynamically-imported sibling chunk. Skipped when
+ * dist/ is absent so plain `pnpm test` (no prior build) still passes.
+ */
+describe('bundle chunk split', () => {
+  const dist = resolve(__dirname, '../../dist');
+  const baseFile = join(dist, 'index.js');
+
+  const hasDist = existsSync(baseFile);
+  const suite = hasDist ? describe : describe.skip;
+
+  suite('dist/ exists', () => {
+    it('base dist/index.js does not contain "modern-screenshot"', () => {
+      const src = readFileSync(baseFile, 'utf8');
+      expect(src).not.toContain('modern-screenshot');
+    });
+
+    it('a sibling chunk imports modern-screenshot', () => {
+      const siblings = readdirSync(dist).filter(
+        (f) => f.endsWith('.js') && f !== 'index.js' && f !== 'index.cjs',
+      );
+      const hit = siblings.some((f) =>
+        readFileSync(join(dist, f), 'utf8').includes('modern-screenshot'),
+      );
+      expect(hit).toBe(true);
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -139,6 +139,74 @@ describe('captureScreenshot', () => {
     );
   });
 
+  it('restores [data-brevwick-skip] visibility after concurrent captures that overlap', async () => {
+    // Two captures fire against the same skip node without awaiting between
+    // them. Prior to the ref-counted stash this stashed the already-mutated
+    // `'hidden'` on the second scrub and left the node permanently hidden.
+    const skip = document.createElement('div');
+    skip.setAttribute('data-brevwick-skip', '');
+    skip.style.visibility = 'visible';
+    document.body.appendChild(skip);
+
+    // The first capture resolves immediately; the second is gated on a
+    // deferred promise so we can observe the mid-flight state while the
+    // second call still holds its ref on the skip node.
+    let callNum = 0;
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((r) => {
+      releaseSecond = r;
+    });
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn(async () => {
+        callNum += 1;
+        if (callNum === 2) await secondGate;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    // Fire both captures; the second must not await the first.
+    const a = captureScreenshot();
+    const b = captureScreenshot();
+    // Synchronous scrubs have run — both captures hold a ref.
+    expect(skip.style.visibility).toBe('hidden');
+    await a;
+    // The second capture is still waiting on the gate — the node must stay
+    // hidden because the second scrub has not released its ref yet.
+    expect(skip.style.visibility).toBe('hidden');
+
+    releaseSecond();
+    await b;
+    // Only after the last concurrent capture releases its ref does the
+    // ORIGINAL 'visible' value come back. Prior to the ref-counted stash,
+    // the second capture had stashed the first's mutated `'hidden'` and
+    // left the node permanently hidden here.
+    expect(skip.style.visibility).toBe('visible');
+    skip.remove();
+  });
+
+  it('still resolves with a placeholder when a bus entry listener throws', async () => {
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockRejectedValue(new Error('boom')),
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const instance = createBrevwick({ projectKey: KEY });
+    getInternal(instance).bus.on('entry', () => {
+      throw new Error('listener explode');
+    });
+
+    // Must not reject; the throwing listener must not escape capture().
+    const blob = await instance.captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+    expect(blob.size).toBeGreaterThan(0);
+    // Fallback path took over: console.warn is invoked with the failure msg.
+    expect(warn).toHaveBeenCalled();
+    const msg = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(msg).toMatch(/brevwick: screenshot capture failed/);
+    warn.mockRestore();
+  });
+
   it('defaults quality to 0.85', async () => {
     const spy = vi
       .fn()

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetBrevwickRegistry,
+  __setRingsForTesting,
+  createBrevwick,
+} from '../core/client';
+import type { BrevwickInternal } from '../core/internal';
+
+const KEY = 'pk_test_aaaaaaaaaaaaaaaa01';
+
+function getInternal(instance: unknown): BrevwickInternal {
+  return (instance as { _internal: BrevwickInternal })._internal;
+}
+
+beforeEach(() => {
+  __resetBrevwickRegistry();
+  __setRingsForTesting();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  __resetBrevwickRegistry();
+  __setRingsForTesting();
+  vi.doUnmock('modern-screenshot');
+});
+
+describe('captureScreenshot', () => {
+  it('resolves to an image/* Blob on success', async () => {
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi
+        .fn()
+        .mockResolvedValue(
+          new Blob([new Uint8Array([1, 2, 3])], { type: 'image/webp' }),
+        ),
+    }));
+    const { captureScreenshot } = await import('../screenshot');
+    const blob = await captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toMatch(/^image\//);
+  });
+
+  it('hides [data-brevwick-skip] during capture and restores after', async () => {
+    const skip = document.createElement('div');
+    skip.setAttribute('data-brevwick-skip', '');
+    document.body.appendChild(skip);
+    // Pre-capture: no inline visibility set.
+    expect(skip.style.visibility).toBe('');
+
+    let observedDuringCapture = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedDuringCapture = skip.style.visibility;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observedDuringCapture).toBe('hidden');
+    // Post-capture: original ('') restored.
+    expect(skip.style.visibility).toBe('');
+    skip.remove();
+  });
+
+  it('restores [data-brevwick-skip] visibility even when capture throws', async () => {
+    const skip = document.createElement('div');
+    skip.setAttribute('data-brevwick-skip', '');
+    skip.style.visibility = 'visible';
+    document.body.appendChild(skip);
+
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockRejectedValue(new Error('boom')),
+    }));
+    const { captureScreenshot } = await import('../screenshot');
+    const blob = await captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    // Original 'visible' is restored after the rejection.
+    expect(skip.style.visibility).toBe('visible');
+    skip.remove();
+  });
+
+  it('returns a transparent placeholder Blob + warns via console.warn when capture rejects', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockRejectedValue(new Error('nope')),
+    }));
+    const { captureScreenshot } = await import('../screenshot');
+    const blob = await captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+    expect(blob.size).toBeGreaterThan(0);
+    expect(warn).toHaveBeenCalled();
+    const msg = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(msg).toMatch(/brevwick: screenshot capture failed/);
+    warn.mockRestore();
+  });
+
+  it('returns a placeholder Blob when domToBlob yields null', async () => {
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockResolvedValue(null),
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { captureScreenshot } = await import('../screenshot');
+    const blob = await captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('pushes a warn ConsoleEntry into the owning Brevwick instance on failure', async () => {
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockRejectedValue(new Error('boom')),
+    }));
+    const instance = createBrevwick({ projectKey: KEY });
+    const blob = await instance.captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+
+    const entries = getInternal(instance).buffers.console.snapshot();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.level).toBe('warn');
+    expect(entries[0]?.message).toMatch(/brevwick: screenshot capture failed/);
+  });
+
+  it('passes quality + image/webp type to modern-screenshot', async () => {
+    const spy = vi
+      .fn()
+      .mockResolvedValue(
+        new Blob([new Uint8Array([1])], { type: 'image/webp' }),
+      );
+    vi.doMock('modern-screenshot', () => ({ domToBlob: spy }));
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot({ quality: 0.5 });
+    expect(spy).toHaveBeenCalledWith(
+      document.documentElement,
+      expect.objectContaining({ quality: 0.5, type: 'image/webp' }),
+    );
+  });
+
+  it('defaults quality to 0.85', async () => {
+    const spy = vi
+      .fn()
+      .mockResolvedValue(
+        new Blob([new Uint8Array([1])], { type: 'image/webp' }),
+      );
+    vi.doMock('modern-screenshot', () => ({ domToBlob: spy }));
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+    expect(spy).toHaveBeenCalledWith(
+      document.documentElement,
+      expect.objectContaining({ quality: 0.85, type: 'image/webp' }),
+    );
+  });
+});

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -221,4 +221,56 @@ describe('captureScreenshot', () => {
       expect.objectContaining({ quality: 0.85, type: 'image/webp' }),
     );
   });
+
+  it('returns a placeholder without invoking modern-screenshot when document is undefined (SSR)', async () => {
+    const domToBlob = vi.fn();
+    vi.doMock('modern-screenshot', () => ({ domToBlob }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.stubGlobal('document', undefined);
+    try {
+      const { captureScreenshot } = await import('../screenshot');
+      const blob = await captureScreenshot();
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe('image/webp');
+      expect(domToBlob).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalled();
+      const msg = String(warn.mock.calls[0]?.[0] ?? '');
+      expect(msg).toMatch(/document is not available/);
+    } finally {
+      vi.unstubAllGlobals();
+      warn.mockRestore();
+    }
+  });
+
+  it('does not hide the root element itself when the root carries data-brevwick-skip', async () => {
+    // Per the JSDoc contract, the root is never scrubbed — hiding the capture
+    // target would produce an empty image. Only descendants are hidden.
+    const root = document.createElement('section');
+    root.setAttribute('data-brevwick-skip', '');
+    root.style.visibility = 'visible';
+    const child = document.createElement('div');
+    child.setAttribute('data-brevwick-skip', '');
+    root.appendChild(child);
+    document.body.appendChild(root);
+
+    let rootDuring = '';
+    let childDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        rootDuring = root.style.visibility;
+        childDuring = child.style.visibility;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot({ element: root });
+
+    expect(rootDuring).toBe('visible');
+    expect(childDuring).toBe('hidden');
+    // Post-capture restore: child returns to its original empty value.
+    expect(child.style.visibility).toBe('');
+    expect(root.style.visibility).toBe('visible');
+    root.remove();
+  });
 });

--- a/packages/sdk/src/core/__tests__/client.test.ts
+++ b/packages/sdk/src/core/__tests__/client.test.ts
@@ -270,16 +270,19 @@ describe('stub public methods', () => {
     );
   });
 
-  it('captureScreenshot() returns a rejecting Promise (no sync throw)', async () => {
+  it('captureScreenshot() returns a Blob via the screenshot module', async () => {
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi
+        .fn()
+        .mockResolvedValue(
+          new Blob([new Uint8Array([0x89, 0x50])], { type: 'image/png' }),
+        ),
+    }));
     const instance = createBrevwick({ projectKey: KEY_A });
-    const caught = vi.fn();
-    const p = instance.captureScreenshot();
-    expect(p).toBeInstanceOf(Promise);
-    await p.catch(caught);
-    expect(caught).toHaveBeenCalledTimes(1);
-    await expect(instance.captureScreenshot()).rejects.toThrow(
-      /not yet implemented/,
-    );
+    const blob = await instance.captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toMatch(/^image\//);
+    vi.doUnmock('modern-screenshot');
   });
 });
 

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -154,7 +154,8 @@ function build(
       throw new Error('Brevwick.submit is not yet implemented');
     },
     async captureScreenshot(): Promise<Blob> {
-      throw new Error('Brevwick.captureScreenshot is not yet implemented');
+      const { captureScreenshotForInstance } = await import('../screenshot');
+      return captureScreenshotForInstance(internal);
     },
   };
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -15,3 +15,14 @@ export type {
   FeedbackInput,
   SubmitResult,
 } from './types';
+
+export type { CaptureScreenshotOpts } from './screenshot';
+
+/**
+ * Lazy re-export: the real module (and its `modern-screenshot` peer dep) is
+ * resolved only on the first call so the base chunk stays below its 2 kB gzip
+ * budget. `export { captureScreenshot } from './screenshot'` would pull the
+ * module — and through it, `modern-screenshot` — into the root bundle.
+ */
+export const captureScreenshot: typeof import('./screenshot').captureScreenshot =
+  (...args) => import('./screenshot').then((m) => m.captureScreenshot(...args));

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -1,0 +1,126 @@
+import type { BrevwickInternal } from './core/internal';
+
+export interface CaptureScreenshotOpts {
+  element?: HTMLElement;
+  quality?: number;
+}
+
+const DEFAULT_QUALITY = 0.85;
+const MIME = 'image/webp';
+
+// Base64-encoded 1×1 transparent VP8L WebP. Used when capture fails so
+// callers that depend on `.attachments[].blob` still get a valid image type.
+const PLACEHOLDER_WEBP_BASE64 =
+  'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==';
+
+function placeholderBlob(): Blob {
+  const binary = atob(PLACEHOLDER_WEBP_BASE64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: MIME });
+}
+
+function isValidImageBlob(value: unknown): value is Blob {
+  return (
+    value instanceof Blob &&
+    value.size > 0 &&
+    typeof value.type === 'string' &&
+    value.type.startsWith('image/')
+  );
+}
+
+interface SkippedNode {
+  element: HTMLElement;
+  original: string;
+}
+
+function scrubSkippedNodes(root: Document | HTMLElement): SkippedNode[] {
+  const nodes = root.querySelectorAll<HTMLElement>('[data-brevwick-skip]');
+  const stashed: SkippedNode[] = [];
+  nodes.forEach((el) => {
+    stashed.push({ element: el, original: el.style.visibility });
+    el.style.visibility = 'hidden';
+  });
+  return stashed;
+}
+
+function restoreSkippedNodes(nodes: SkippedNode[]): void {
+  for (const { element, original } of nodes) {
+    element.style.visibility = original;
+  }
+}
+
+function logFailure(
+  internal: BrevwickInternal | undefined,
+  reason: unknown,
+): void {
+  const message =
+    'brevwick: screenshot capture failed, using placeholder' +
+    (reason instanceof Error ? `: ${reason.message}` : '');
+  if (internal) {
+    internal.push({
+      kind: 'console',
+      level: 'warn',
+      message,
+      timestamp: Date.now(),
+    });
+    return;
+  }
+  // Fallback when invoked outside a Brevwick instance — the console ring, once
+  // installed, patches console.warn so the entry is still captured.
+  globalThis.console?.warn?.(message);
+}
+
+async function capture(
+  opts: CaptureScreenshotOpts | undefined,
+  internal: BrevwickInternal | undefined,
+): Promise<Blob> {
+  if (typeof document === 'undefined') {
+    logFailure(internal, new Error('document is not available'));
+    return placeholderBlob();
+  }
+
+  const element = opts?.element ?? document.documentElement;
+  const quality = opts?.quality ?? DEFAULT_QUALITY;
+  const skipped = scrubSkippedNodes(element);
+
+  try {
+    const mod = await import('modern-screenshot');
+    const result = await mod.domToBlob(element, { quality, type: MIME });
+    if (!isValidImageBlob(result)) {
+      logFailure(internal, new Error('domToBlob returned no blob'));
+      return placeholderBlob();
+    }
+    return result;
+  } catch (err) {
+    logFailure(internal, err);
+    return placeholderBlob();
+  } finally {
+    restoreSkippedNodes(skipped);
+  }
+}
+
+/**
+ * Capture a screenshot of the current document (or a given element) as a WebP
+ * Blob. Scrubs `[data-brevwick-skip]` nodes before capture and restores them
+ * afterwards, even on failure. Never throws — a capture failure yields a 1×1
+ * transparent placeholder so callers that always attach the result still get a
+ * valid image/webp blob.
+ */
+export async function captureScreenshot(
+  opts?: CaptureScreenshotOpts,
+): Promise<Blob> {
+  return capture(opts, undefined);
+}
+
+/**
+ * Internal variant: pushes failure diagnostics into the owning Brevwick
+ * instance's console ring instead of falling back to `console.warn`. Not part
+ * of the public SDK surface — wired only from `Brevwick.captureScreenshot()`.
+ */
+export async function captureScreenshotForInstance(
+  internal: BrevwickInternal,
+  opts?: CaptureScreenshotOpts,
+): Promise<Blob> {
+  return capture(opts, internal);
+}

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -1,7 +1,20 @@
 import type { BrevwickInternal } from './core/internal';
 
+/**
+ * Options for {@link captureScreenshot}. All fields are optional.
+ */
 export interface CaptureScreenshotOpts {
+  /**
+   * Sub-tree to capture. Defaults to `document.documentElement` (the full
+   * page). Only `[data-brevwick-skip]` nodes *within* this element are
+   * scrubbed before capture — skip markers outside the sub-tree are left
+   * untouched.
+   */
   element?: HTMLElement;
+  /**
+   * WebP encoder quality in the range `0..1`. Forwarded verbatim to
+   * `modern-screenshot`'s `domToBlob`. Defaults to `0.85`.
+   */
   quality?: number;
 }
 
@@ -13,11 +26,38 @@ const MIME = 'image/webp';
 const PLACEHOLDER_WEBP_BASE64 =
   'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==';
 
-function placeholderBlob(): Blob {
+// Decode once at module load — the bytes are immutable, and every failure
+// path previously re-ran `atob` + the byte-copy loop. The returned Blob must
+// still be fresh per call because consumers may hold and revoke URLs from it.
+// Store the underlying ArrayBuffer (not the view) so `new Blob([...])` types
+// cleanly under TS `strict` without widening to `ArrayBufferLike`.
+const PLACEHOLDER_BUFFER: ArrayBuffer = ((): ArrayBuffer => {
   const binary = atob(PLACEHOLDER_WEBP_BASE64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return new Blob([bytes], { type: MIME });
+  return bytes.buffer;
+})();
+
+function placeholderBlob(): Blob {
+  return new Blob([PLACEHOLDER_BUFFER], { type: MIME });
+}
+
+/**
+ * Cache the first `import('modern-screenshot')` Promise so subsequent captures
+ * reuse the resolved module. ES dynamic import is already host-cached, but
+ * holding our own reference avoids a class of test-runner issues where
+ * concurrent `await import` of the same specifier can deadlock under
+ * aggressive module-cache reset.
+ */
+let modernScreenshotPromise:
+  | Promise<typeof import('modern-screenshot')>
+  | undefined;
+
+function loadModernScreenshot(): Promise<typeof import('modern-screenshot')> {
+  if (!modernScreenshotPromise) {
+    modernScreenshotPromise = import('modern-screenshot');
+  }
+  return modernScreenshotPromise;
 }
 
 function isValidImageBlob(value: unknown): value is Blob {
@@ -29,24 +69,51 @@ function isValidImageBlob(value: unknown): value is Blob {
   );
 }
 
+/**
+ * Scrub/restore uses a reference-counted WeakMap keyed by element so concurrent
+ * captures that touch overlapping skip sets remain correct:
+ *
+ * - The FIRST scrub stashes the real, caller-visible `style.visibility`.
+ * - Subsequent concurrent scrubs see a live count > 0 and do NOT restash —
+ *   otherwise they'd stash the already-mutated `'hidden'` and leave the node
+ *   permanently hidden when the outer capture restores.
+ * - The LAST restore (count drops to 0) writes the stashed value back.
+ *
+ * The maps are WeakMaps so detached elements are garbage-collected normally.
+ */
+const stashedOriginal = new WeakMap<HTMLElement, string>();
+const skipRefCount = new WeakMap<HTMLElement, number>();
+
 interface SkippedNode {
   element: HTMLElement;
-  original: string;
 }
 
 function scrubSkippedNodes(root: Document | HTMLElement): SkippedNode[] {
   const nodes = root.querySelectorAll<HTMLElement>('[data-brevwick-skip]');
   const stashed: SkippedNode[] = [];
   nodes.forEach((el) => {
-    stashed.push({ element: el, original: el.style.visibility });
+    const count = skipRefCount.get(el) ?? 0;
+    if (count === 0) {
+      stashedOriginal.set(el, el.style.visibility);
+    }
+    skipRefCount.set(el, count + 1);
     el.style.visibility = 'hidden';
+    stashed.push({ element: el });
   });
   return stashed;
 }
 
 function restoreSkippedNodes(nodes: SkippedNode[]): void {
-  for (const { element, original } of nodes) {
-    element.style.visibility = original;
+  for (const { element } of nodes) {
+    const count = (skipRefCount.get(element) ?? 1) - 1;
+    if (count <= 0) {
+      const original = stashedOriginal.get(element) ?? '';
+      element.style.visibility = original;
+      skipRefCount.delete(element);
+      stashedOriginal.delete(element);
+    } else {
+      skipRefCount.set(element, count);
+    }
   }
 }
 
@@ -58,16 +125,23 @@ function logFailure(
     'brevwick: screenshot capture failed, using placeholder' +
     (reason instanceof Error ? `: ${reason.message}` : '');
   if (internal) {
-    internal.push({
-      kind: 'console',
-      level: 'warn',
-      message,
-      timestamp: Date.now(),
-    });
-    return;
+    try {
+      internal.push({
+        kind: 'console',
+        level: 'warn',
+        message,
+        timestamp: Date.now(),
+      });
+      return;
+    } catch {
+      // A throwing `entry` bus listener must not escape the "never throws"
+      // contract. Fall through to the global console so the message is not
+      // silently dropped.
+    }
   }
-  // Fallback when invoked outside a Brevwick instance — the console ring, once
-  // installed, patches console.warn so the entry is still captured.
+  // Fallback when invoked outside a Brevwick instance, or when the internal
+  // push path rejected. The console ring, once installed, patches
+  // console.warn so the entry is still captured in the happy case.
   globalThis.console?.warn?.(message);
 }
 
@@ -82,10 +156,14 @@ async function capture(
 
   const element = opts?.element ?? document.documentElement;
   const quality = opts?.quality ?? DEFAULT_QUALITY;
-  const skipped = scrubSkippedNodes(element);
+  // Declared outside the try so `finally` can always run, even if the
+  // initial scrub throws (malformed selector / host-env quirks on a
+  // non-standard root).
+  let skipped: SkippedNode[] = [];
 
   try {
-    const mod = await import('modern-screenshot');
+    skipped = scrubSkippedNodes(element);
+    const mod = await loadModernScreenshot();
     const result = await mod.domToBlob(element, { quality, type: MIME });
     if (!isValidImageBlob(result)) {
       logFailure(internal, new Error('domToBlob returned no blob'));

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -6,9 +6,10 @@ import type { BrevwickInternal } from './core/internal';
 export interface CaptureScreenshotOpts {
   /**
    * Sub-tree to capture. Defaults to `document.documentElement` (the full
-   * page). Only `[data-brevwick-skip]` nodes *within* this element are
-   * scrubbed before capture — skip markers outside the sub-tree are left
-   * untouched.
+   * page). Only *descendants* marked with `[data-brevwick-skip]` are scrubbed
+   * before capture — a skip marker on the root element itself is ignored
+   * (hiding the capture target would produce an empty image). Skip markers
+   * outside the sub-tree are left untouched.
    */
   element?: HTMLElement;
   /**

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
-  splitting: false,
-  minify: false,
+  splitting: true,
+  minify: true,
   target: 'es2020',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
 
-  packages/sdk: {}
+  packages/sdk:
+    devDependencies:
+      modern-screenshot:
+        specifier: ^4.0.0
+        version: 4.6.8
 
 packages:
 
@@ -1413,6 +1417,9 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modern-screenshot@4.6.8:
+    resolution: {integrity: sha512-GJkv/yWPOJTlxj1LZDU2k474cDyOWL+LVaqTdDWQwQ5d8zIuTz1892+1cV9V0ZpK6HYZFo/+BNLBbierO9d2TA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3203,6 +3210,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  modern-screenshot@4.6.8: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
Closes #5

Implements [SDD § 12 Screenshot](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts).

## Summary
- `captureScreenshot(opts?)` lives in `packages/sdk/src/screenshot.ts` and uses `await import('modern-screenshot')` so the heavy dep lands in its own chunk (`dist/screenshot-*.js`).
- `[data-brevwick-skip]` nodes have `style.visibility` stashed → set to `hidden` pre-capture → restored in `finally` (even when `domToBlob` rejects).
- Failure never throws: the call resolves with a 1×1 transparent WebP placeholder and pushes a `warn` `ConsoleEntry` into the owning instance's console ring (or falls back to `console.warn` when called outside an instance — the console ring patches `warn` anyway).
- `modern-screenshot` declared as `peerDependency` + `peerDependenciesMeta.optional: true` so consumers that never open the widget aren't nagged; it is explicitly **not** in `dependencies`, which would otherwise bleed into the base chunk.
- `packages/sdk/src/index.ts` re-exports `captureScreenshot` as a lazy wrapper (`(...args) => import('./screenshot').then(m => m.captureScreenshot(...args))`). Chosen over a separate `exports['./screenshot']` subpath because the lazy wrapper survives any consumer import style (`import { captureScreenshot } from 'brevwick-sdk'`) while still keeping the screenshot module out of the base chunk.
- `tsup.config.ts`: `splitting: true`, `minify: true`, `treeshake: true`, `format: ['esm', 'cjs']`, `sourcemap: true`, `dts: true`. Peer deps are external by default; verified by grepping the emitted `dist/index.js`.
- `Brevwick.captureScreenshot()` (previously a `not yet implemented` stub) now delegates to the screenshot module so failures land in that instance's console buffer.

## Bundle size
- `dist/index.js` gzip: **1936 bytes** (budget: < 2 kB gzip). Will be enforced via size-limit in WT-07.
- `dist/screenshot-*.js` (chunk): ~1.34 kB minified, loads `modern-screenshot` lazily when the widget opens.

## Test plan
- [x] `dist/index.js` does not reference `'modern-screenshot'` (grep asserts 0 matches; sibling chunk asserts 1 match) — enforced by `chunk-split.test.ts`.
- [x] `[data-brevwick-skip]` visibility restored after both success and failure paths (two separate tests in `screenshot.test.ts`).
- [x] Failure path resolves with a WebP Blob and logs a `warn` entry (tested both via `console.warn` spy and via `instance._internal.buffers.console.snapshot()`).
- [x] Current base chunk gzip size recorded above (1936 bytes).

## PR review follow-up (2026-04-13)

Addressed in commit 968315c:

- **Concurrent-capture re-entrancy**: scrub/restore now uses reference-counted WeakMaps so two concurrent captures that touch overlapping `[data-brevwick-skip]` sets restore visibility to the caller's original value, not the mutated `'hidden'` an inner scrub would otherwise stash. Test: `restores [data-brevwick-skip] visibility after concurrent captures that overlap` in `screenshot.test.ts`.
- **Never-throws contract**: `internal.push(...)` wrapped in try/catch so a throwing `'entry'` bus listener can't escape `capture()`; falls through to `globalThis.console.warn` and the promise still resolves with a placeholder. Test: `still resolves with a placeholder when a bus entry listener throws`.
- **Pre-try throw**: `scrubSkippedNodes(element)` moved inside the try so the `finally` always runs; `skipped` declared outside as `let skipped: SkippedNode[] = []`.
- **JSDoc**: both `element` and `quality` on `CaptureScreenshotOpts` now documented, plus a type-level doc.
- **Placeholder allocation**: bytes decoded once into a module-level `PLACEHOLDER_BUFFER: ArrayBuffer`; `placeholderBlob()` wraps it per call so revoke semantics are preserved.
- **SDD § 12 companion PR**: tatlacas-com/brevwick-ops#5 documents `CaptureScreenshotOpts`, defaults, never-throws / placeholder-on-failure contract, `[data-brevwick-skip]` scrub + ref-counted restore semantics, and `modern-screenshot` as an optional peer dependency.

Baseline after fixes: `dist/index.js` gzip = **1936 B**, chunk-split intact (0 `modern-screenshot` refs in base chunk), all 82 tests pass, lint + type-check clean.
