### PR TITLE
feat(react): BrevwickProvider + useFeedback + FeedbackButton

### DIFF
--- a/.changeset/react-bindings.md
+++ b/.changeset/react-bindings.md
@@ -1,0 +1,23 @@
+---
+'brevwick-react': minor
+'brevwick-sdk': minor
+---
+
+feat(react): BrevwickProvider + useFeedback + FeedbackButton
+
+Ships the React bindings per SDD § 12:
+
+- `<BrevwickProvider config>` — memoises `createBrevwick(config)` keyed on
+  config identity, installs on mount, uninstalls on unmount.
+- `useFeedback()` → `{ submit, captureScreenshot, status, reset }` with a
+  four-state machine `'idle' | 'submitting' | 'success' | 'error'`.
+- `<FeedbackButton>` — drop-in FAB + dialog with attachments, screenshot
+  capture, double-submit guard, and unmount-safe async handlers. Props:
+  `position`, `disabled`, `hidden`, `className`, `label`, `onSubmit`.
+- `"use client"` banner preserved in both ESM and CJS bundles for Next.js
+  App Router.
+- `data-brevwick-skip` applied to FAB, overlay, and dialog so captured
+  screenshots exclude Brevwick's own UI.
+
+The `brevwick-sdk` bump is the lockstep pre-1.0 version (no code change in
+the SDK for this PR).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
       - run: pnpm lint
+      # Build brevwick-sdk first so brevwick-react's tsc + vitest can resolve
+      # the workspace dep via its published "types"/"import" export entries
+      # (packages/sdk/dist/index.d.ts etc.). Without this, a clean CI checkout
+      # fails type-check with TS2307 on every `from 'brevwick-sdk'` import.
+      - run: pnpm --filter brevwick-sdk build
       - run: pnpm type-check
       - run: pnpm test:cover
       - run: pnpm build

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,5 +57,8 @@
     "brevwick-sdk": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15"
   }
 }

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -301,4 +301,48 @@ describe('<FeedbackButton>', () => {
     // No thumbnail was rendered
     expect(screen.queryByAltText(/screenshot preview/i)).toBeNull();
   });
+
+  it('derives the screenshot attachment extension from its MIME type', async () => {
+    const blob = new Blob(['x'], { type: 'image/webp' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ext' });
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+    const titleInput = screen.getAllByRole('textbox')[0]!;
+    fireEvent.change(titleInput, { target: { value: 'with screenshot' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    const input = submit.mock.calls[0]![0] as {
+      attachments: Array<{ blob: Blob; filename: string }>;
+    };
+    expect(input.attachments[0]!.filename).toBe('screenshot.webp');
+  });
+
+  it('surfaces a recovery message when submit() rejects (chunk load failure)', async () => {
+    submit.mockRejectedValueOnce(new Error('chunk load failed'));
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    const titleInput = screen.getAllByRole('textbox')[0]!;
+    fireEvent.change(titleInput, { target: { value: 'oops' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    expect(
+      screen.getByText(/chunk load failed/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+    // Dialog stays open so the user can retry
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
 });

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -14,9 +14,8 @@ const install = vi.fn();
 const uninstall = vi.fn();
 
 vi.mock('brevwick-sdk', async () => {
-  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
-    'brevwick-sdk',
-  );
+  const actual =
+    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
   return {
     ...actual,
     createBrevwick: (_config: BrevwickConfig) =>
@@ -30,16 +29,18 @@ vi.mock('brevwick-sdk', async () => {
 });
 
 import { BrevwickProvider } from '../provider';
-import { FeedbackButton } from '../feedback-button';
+import { FeedbackButton, type FeedbackButtonProps } from '../feedback-button';
 
 beforeEach(() => {
   if (typeof URL.createObjectURL !== 'function') {
-    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL =
-      () => 'blob:mock';
+    (
+      URL as unknown as { createObjectURL: (b: Blob) => string }
+    ).createObjectURL = () => 'blob:mock';
   }
   if (typeof URL.revokeObjectURL !== 'function') {
-    (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL =
-      () => undefined;
+    (
+      URL as unknown as { revokeObjectURL: (u: string) => void }
+    ).revokeObjectURL = () => undefined;
   }
 });
 
@@ -48,10 +49,10 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const mount = () =>
+const mount = (props: FeedbackButtonProps = {}) =>
   render(
     <BrevwickProvider config={{ projectKey: 'pk_test_fab' }}>
-      <FeedbackButton onSubmit={onSubmitSpy} />
+      <FeedbackButton onSubmit={onSubmitSpy} {...props} />
     </BrevwickProvider>,
   );
 
@@ -75,7 +76,9 @@ describe('<FeedbackButton>', () => {
 
   it('surfaces a form-level error when title is missing', () => {
     mount();
-    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
     fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     expect(screen.getByRole('alert')).toHaveTextContent(/title is required/i);
     expect(submit).not.toHaveBeenCalled();
@@ -85,7 +88,9 @@ describe('<FeedbackButton>', () => {
     const blob = new Blob(['x'], { type: 'image/png' });
     captureScreenshot.mockResolvedValueOnce(blob);
     mount();
-    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
 
     await act(async () => {
       fireEvent.click(
@@ -100,7 +105,9 @@ describe('<FeedbackButton>', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ok' });
     mount();
-    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
 
     const titleInput = screen.getAllByRole('textbox')[0]!;
     fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
@@ -130,7 +137,9 @@ describe('<FeedbackButton>', () => {
       error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
     });
     mount();
-    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
 
     const titleInput = screen.getAllByRole('textbox')[0]!;
     fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
@@ -145,6 +154,24 @@ describe('<FeedbackButton>', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
+  it('invokes onSubmit with the { ok: false, error } shape on failure', async () => {
+    const failure: SubmitResult = {
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'nope' },
+    };
+    submit.mockResolvedValueOnce(failure);
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    const titleInput = screen.getAllByRole('textbox')[0]!;
+    fireEvent.change(titleInput, { target: { value: 'x' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(onSubmitSpy).toHaveBeenCalledWith(failure);
+  });
+
   it('renders nothing when hidden', () => {
     render(
       <BrevwickProvider config={{ projectKey: 'pk_test_hidden' }}>
@@ -154,5 +181,124 @@ describe('<FeedbackButton>', () => {
     expect(
       screen.queryByRole('button', { name: /open feedback form/i }),
     ).toBeNull();
+  });
+
+  it('renders a disabled FAB when disabled prop is true and does not open the dialog', () => {
+    mount({ disabled: true });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab).toBeDisabled();
+    fireEvent.click(fab);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('applies the brw-fab-bl class when position is bottom-left', () => {
+    mount({ position: 'bottom-left' });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab-bl/);
+    expect(fab.className).not.toMatch(/brw-fab-br/);
+  });
+
+  it('revokes the screenshot object URL on unmount', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:mock-unmount');
+    const revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined);
+
+    const { unmount } = mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+    expect(createObjectURL).toHaveBeenCalled();
+
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-unmount');
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+  });
+
+  it('clears form fields after a success + auto-close when reopened', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_reset' });
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0]!, { target: { value: 'title-a' } });
+    fireEvent.change(textboxes[1]!, { target: { value: 'desc-a' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    // Reopen
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    const reopenedBoxes = screen.getAllByRole('textbox');
+    expect((reopenedBoxes[0] as HTMLInputElement).value).toBe('');
+    expect((reopenedBoxes[1] as HTMLTextAreaElement).value).toBe('');
+    // Success banner should be cleared too
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('clears prior form state when the dialog is closed manually and reopened', () => {
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    const textboxes = screen.getAllByRole('textbox');
+    fireEvent.change(textboxes[0]!, { target: { value: 'stale-title' } });
+    fireEvent.change(textboxes[1]!, { target: { value: 'stale-desc' } });
+
+    // Close via Cancel
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    // Reopen
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+    const reopenedBoxes = screen.getAllByRole('textbox');
+    expect((reopenedBoxes[0] as HTMLInputElement).value).toBe('');
+    expect((reopenedBoxes[1] as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('surfaces an error in the dialog when captureScreenshot rejects', async () => {
+    captureScreenshot.mockRejectedValueOnce(new Error('canvas tainted'));
+    mount();
+    fireEvent.click(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    );
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+
+    expect(
+      screen.getByText(/canvas tainted/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+    // No thumbnail was rendered
+    expect(screen.queryByAltText(/screenshot preview/i)).toBeNull();
   });
 });

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1,0 +1,158 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Brevwick, BrevwickConfig, SubmitResult } from 'brevwick-sdk';
+
+const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
+const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const install = vi.fn();
+const uninstall = vi.fn();
+
+vi.mock('brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
+    'brevwick-sdk',
+  );
+  return {
+    ...actual,
+    createBrevwick: (_config: BrevwickConfig) =>
+      ({
+        install,
+        uninstall,
+        submit,
+        captureScreenshot,
+      }) as unknown as Brevwick,
+  };
+});
+
+import { BrevwickProvider } from '../provider';
+import { FeedbackButton } from '../feedback-button';
+
+beforeEach(() => {
+  if (typeof URL.createObjectURL !== 'function') {
+    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL =
+      () => 'blob:mock';
+  }
+  if (typeof URL.revokeObjectURL !== 'function') {
+    (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL =
+      () => undefined;
+  }
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+const mount = () =>
+  render(
+    <BrevwickProvider config={{ projectKey: 'pk_test_fab' }}>
+      <FeedbackButton onSubmit={onSubmitSpy} />
+    </BrevwickProvider>,
+  );
+
+const onSubmitSpy = vi.fn();
+
+afterEach(() => {
+  onSubmitSpy.mockReset();
+});
+
+describe('<FeedbackButton>', () => {
+  it('opens the dialog and marks FAB + dialog with data-brevwick-skip', () => {
+    mount();
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab).toHaveAttribute('data-brevwick-skip');
+    fireEvent.click(fab);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('data-brevwick-skip');
+    expect(screen.getByText('Send feedback')).toBeInTheDocument();
+  });
+
+  it('surfaces a form-level error when title is missing', () => {
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/title is required/i);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('attaches a screenshot by calling sdk.captureScreenshot and shows a thumbnail', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+    expect(captureScreenshot).toHaveBeenCalledTimes(1);
+    expect(screen.getByAltText(/screenshot preview/i)).toBeInTheDocument();
+  });
+
+  it('calls onSubmit with result and closes after 1.5s on success', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ok' });
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+
+    const titleInput = screen.getAllByRole('textbox')[0]!;
+    fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    expect(onSubmitSpy).toHaveBeenCalledWith({
+      ok: true,
+      report_id: 'rep_ok',
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/report sent/i);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('shows an inline error and keeps the dialog open on failure', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
+    });
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+
+    const titleInput = screen.getAllByRole('textbox')[0]!;
+    fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    expect(
+      screen.getByText(/quota exceeded/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('renders nothing when hidden', () => {
+    render(
+      <BrevwickProvider config={{ projectKey: 'pk_test_hidden' }}>
+        <FeedbackButton hidden />
+      </BrevwickProvider>,
+    );
+    expect(
+      screen.queryByRole('button', { name: /open feedback form/i }),
+    ).toBeNull();
+  });
+});

--- a/packages/react/src/__tests__/provider.test.tsx
+++ b/packages/react/src/__tests__/provider.test.tsx
@@ -9,9 +9,8 @@ const captureScreenshot = vi.fn();
 const createBrevwick = vi.fn<(config: BrevwickConfig) => Brevwick>();
 
 vi.mock('brevwick-sdk', async () => {
-  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
-    'brevwick-sdk',
-  );
+  const actual =
+    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
   return {
     ...actual,
     createBrevwick: (config: BrevwickConfig) => createBrevwick(config),
@@ -63,5 +62,34 @@ describe('BrevwickProvider', () => {
     );
     expect(createBrevwick).toHaveBeenCalledTimes(1);
     expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-creates the instance when a new config object is passed each render', () => {
+    // Documents the memoisation contract: consumers MUST hoist `config` or
+    // wrap it in `useMemo`. Passing a fresh object literal each render cycles
+    // install/uninstall on every render.
+    createBrevwick.mockImplementation(() => makeInstance());
+    const { rerender } = render(
+      <BrevwickProvider config={{ projectKey: 'pk_test_identity_a' }}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    rerender(
+      <BrevwickProvider config={{ projectKey: 'pk_test_identity_a' }}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    rerender(
+      <BrevwickProvider config={{ projectKey: 'pk_test_identity_a' }}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    // Every render yielded a fresh instance, so createBrevwick and install
+    // fire per render. The exact count may vary if React's dev-mode effect
+    // double-invocation is enabled; assert the cycling behaviour rather than
+    // a hard number.
+    expect(createBrevwick).toHaveBeenCalledTimes(3);
+    expect(install.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(uninstall.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/react/src/__tests__/provider.test.tsx
+++ b/packages/react/src/__tests__/provider.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Brevwick, BrevwickConfig } from 'brevwick-sdk';
+
+const install = vi.fn();
+const uninstall = vi.fn();
+const submit = vi.fn();
+const captureScreenshot = vi.fn();
+const createBrevwick = vi.fn<(config: BrevwickConfig) => Brevwick>();
+
+vi.mock('brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
+    'brevwick-sdk',
+  );
+  return {
+    ...actual,
+    createBrevwick: (config: BrevwickConfig) => createBrevwick(config),
+  };
+});
+
+import { BrevwickProvider } from '../provider';
+
+const makeInstance = (): Brevwick =>
+  ({
+    install,
+    uninstall,
+    submit,
+    captureScreenshot,
+  }) as unknown as Brevwick;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('BrevwickProvider', () => {
+  it('calls createBrevwick + install on mount, uninstall on unmount', () => {
+    createBrevwick.mockReturnValueOnce(makeInstance());
+    const { unmount } = render(
+      <BrevwickProvider config={{ projectKey: 'pk_test_provider' }}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    expect(createBrevwick).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(uninstall).not.toHaveBeenCalled();
+
+    unmount();
+    expect(uninstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the same instance while config identity is stable', () => {
+    createBrevwick.mockReturnValue(makeInstance());
+    const config: BrevwickConfig = { projectKey: 'pk_test_stable' };
+    const { rerender } = render(
+      <BrevwickProvider config={config}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    rerender(
+      <BrevwickProvider config={config}>
+        <div>child</div>
+      </BrevwickProvider>,
+    );
+    expect(createBrevwick).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/__tests__/use-feedback.test.tsx
+++ b/packages/react/src/__tests__/use-feedback.test.tsx
@@ -9,9 +9,8 @@ const install = vi.fn();
 const uninstall = vi.fn();
 
 vi.mock('brevwick-sdk', async () => {
-  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
-    'brevwick-sdk',
-  );
+  const actual =
+    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
   return {
     ...actual,
     createBrevwick: (_config: BrevwickConfig) =>
@@ -79,8 +78,6 @@ describe('useFeedback', () => {
   });
 
   it('throws when used outside a provider', () => {
-    expect(() => renderHook(() => useFeedback())).toThrow(
-      /BrevwickProvider/,
-    );
+    expect(() => renderHook(() => useFeedback())).toThrow(/BrevwickProvider/);
   });
 });

--- a/packages/react/src/__tests__/use-feedback.test.tsx
+++ b/packages/react/src/__tests__/use-feedback.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Brevwick, BrevwickConfig, SubmitResult } from 'brevwick-sdk';
+import type { ReactNode } from 'react';
+
+const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
+const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const install = vi.fn();
+const uninstall = vi.fn();
+
+vi.mock('brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('brevwick-sdk')>(
+    'brevwick-sdk',
+  );
+  return {
+    ...actual,
+    createBrevwick: (_config: BrevwickConfig) =>
+      ({
+        install,
+        uninstall,
+        submit,
+        captureScreenshot,
+      }) as unknown as Brevwick,
+  };
+});
+
+import { BrevwickProvider } from '../provider';
+import { useFeedback } from '../use-feedback';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <BrevwickProvider config={{ projectKey: 'pk_test_hook' }}>
+    {children}
+  </BrevwickProvider>
+);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useFeedback', () => {
+  it('transitions idle → submitting → success and returns the SubmitResult', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_123' });
+
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+    expect(result.current.status).toBe('idle');
+
+    let returned: SubmitResult | undefined;
+    await act(async () => {
+      returned = await result.current.submit({ description: 'broken' });
+    });
+
+    expect(returned).toEqual({ ok: true, report_id: 'rep_123' });
+    expect(result.current.status).toBe('success');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('transitions to error on failure', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'nope' },
+    });
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+    await act(async () => {
+      await result.current.submit({ description: 'x' });
+    });
+    expect(result.current.status).toBe('error');
+  });
+
+  it('captureScreenshot passes through to the SDK', async () => {
+    const blob = new Blob(['png'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+    await expect(result.current.captureScreenshot()).resolves.toBe(blob);
+    expect(captureScreenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when used outside a provider', () => {
+    expect(() => renderHook(() => useFeedback())).toThrow(
+      /BrevwickProvider/,
+    );
+  });
+});

--- a/packages/react/src/__tests__/use-feedback.test.tsx
+++ b/packages/react/src/__tests__/use-feedback.test.tsx
@@ -80,4 +80,16 @@ describe('useFeedback', () => {
   it('throws when used outside a provider', () => {
     expect(() => renderHook(() => useFeedback())).toThrow(/BrevwickProvider/);
   });
+
+  it('flips status to error and rethrows when submit() rejects', async () => {
+    const chunkLoadError = new Error('chunk load failed');
+    submit.mockRejectedValueOnce(chunkLoadError);
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+    await act(async () => {
+      await expect(result.current.submit({ description: 'x' })).rejects.toBe(
+        chunkLoadError,
+      );
+    });
+    expect(result.current.status).toBe('error');
+  });
 });

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { Brevwick } from 'brevwick-sdk';
+
+export interface BrevwickContextValue {
+  brevwick: Brevwick | null;
+}
+
+export const BrevwickContext = createContext<BrevwickContextValue | null>(null);
+
+export function useBrevwickInternal(): BrevwickContextValue {
+  const ctx = useContext(BrevwickContext);
+  if (!ctx) {
+    throw new Error(
+      'useFeedback() must be used inside <BrevwickProvider>. Wrap your app or test with <BrevwickProvider config={...}>.',
+    );
+  }
+  return ctx;
+}

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,8 +1,13 @@
 import { createContext, useContext } from 'react';
 import type { Brevwick } from 'brevwick-sdk';
 
+/**
+ * Internal context value carried by {@link BrevwickProvider}. The provider
+ * always supplies a non-null `Brevwick` instance; consumers rely on
+ * {@link useBrevwickInternal} to narrow and throw if the provider is missing.
+ */
 export interface BrevwickContextValue {
-  brevwick: Brevwick | null;
+  brevwick: Brevwick;
 }
 
 export const BrevwickContext = createContext<BrevwickContextValue | null>(null);

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -187,8 +187,12 @@ export function FeedbackButton({
       setTitleError(null);
 
       const attachments: Array<Blob | FeedbackAttachment> = [];
-      if (screenshot)
-        attachments.push({ blob: screenshot, filename: 'screenshot.png' });
+      if (screenshot) {
+        // Derive the extension from the blob's MIME (the SDK produces
+        // `image/webp`) so the attachment's filename matches its content.
+        const ext = screenshot.type.split('/')[1]?.split('+')[0] || 'webp';
+        attachments.push({ blob: screenshot, filename: `screenshot.${ext}` });
+      }
       for (const f of files) attachments.push({ blob: f, filename: f.name });
 
       const input: FeedbackInput = {
@@ -199,18 +203,30 @@ export function FeedbackButton({
         attachments: attachments.length ? attachments : undefined,
       };
 
-      const result = await submit(input);
-      if (!mountedRef.current) return;
-      onSubmit?.(result);
-      if (result.ok) {
-        closeTimerRef.current = setTimeout(() => {
-          closeTimerRef.current = null;
-          if (!mountedRef.current) return;
-          setOpen(false);
-          resetForm();
-        }, AUTO_CLOSE_MS);
-      } else {
-        setSubmitError(result.error.message);
+      try {
+        const result = await submit(input);
+        if (!mountedRef.current) return;
+        onSubmit?.(result);
+        if (result.ok) {
+          closeTimerRef.current = setTimeout(() => {
+            closeTimerRef.current = null;
+            if (!mountedRef.current) return;
+            setOpen(false);
+            resetForm();
+          }, AUTO_CLOSE_MS);
+        } else {
+          setSubmitError(result.error.message);
+        }
+      } catch (err) {
+        // `submit` only rejects when the lazy submit chunk fails to load
+        // (deploy mismatch / offline). Surface a generic message so the
+        // dialog can recover and the user can retry.
+        if (!mountedRef.current) return;
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : 'We could not submit your feedback. Please try again.';
+        setSubmitError(message);
       }
     },
     [

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -4,6 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type FormEvent,
@@ -18,26 +19,58 @@ import type {
 import { useFeedback } from './use-feedback';
 import { BREVWICK_CSS, BREVWICK_STYLE_ID } from './styles';
 
+/**
+ * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.
+ */
 export interface FeedbackButtonProps {
+  /** Corner the FAB pins to. Default `'bottom-right'`. */
   position?: 'bottom-right' | 'bottom-left';
+  /** When true, the FAB renders as disabled and cannot open the dialog. */
   disabled?: boolean;
+  /** When true, the component renders nothing. Useful for feature-flagging. */
   hidden?: boolean;
+  /** Additional class appended to the FAB and dialog root for styling overrides. */
   className?: string;
+  /** FAB label. Default `'Feedback'`. */
   label?: ReactNode;
+  /** Fired with the SDK's `SubmitResult` after every submit (success or failure). */
   onSubmit?: (result: SubmitResult) => void;
 }
 
 const AUTO_CLOSE_MS = 1500;
 
-function BrevwickStyles(): ReactElement {
-  return (
-    <style
-      id={BREVWICK_STYLE_ID}
-      // CSS is a constant string we authored; no interpolation. Inlined once
-      // per tree — React de-dupes by id via dangerouslySetInnerHTML identity.
-      dangerouslySetInnerHTML={{ __html: BREVWICK_CSS }}
-    />
-  );
+/**
+ * `useLayoutEffect` is a no-op on the server (React warns but does not run
+ * it). Alias to `useEffect` on the server so we can safely call it in code
+ * that might hydrate without triggering a warning. The module-only SSR-safe
+ * pattern.
+ */
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * Module-level guard so the `<style>` tag is inserted into the document at
+ * most once per session, regardless of how many `<FeedbackButton>` instances
+ * mount. React does not dedupe `<style>` tags by `id`, so the previous
+ * render-time approach could produce duplicate style nodes in consumers who
+ * render multiple buttons.
+ */
+let hasInjectedStyles = false;
+
+function useBrevwickStyles(): void {
+  useIsomorphicLayoutEffect(() => {
+    if (hasInjectedStyles) return;
+    if (typeof document === 'undefined') return;
+    if (document.getElementById(BREVWICK_STYLE_ID)) {
+      hasInjectedStyles = true;
+      return;
+    }
+    const el = document.createElement('style');
+    el.id = BREVWICK_STYLE_ID;
+    el.textContent = BREVWICK_CSS;
+    document.head.appendChild(el);
+    hasInjectedStyles = true;
+  }, []);
 }
 
 export function FeedbackButton({
@@ -60,6 +93,32 @@ export function FeedbackButton({
   const [titleError, setTitleError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  const screenshotUrlRef = useRef<string | null>(null);
+
+  useBrevwickStyles();
+
+  // Track mounted state so async handlers can bail out after unmount.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+      if (screenshotUrlRef.current) {
+        URL.revokeObjectURL(screenshotUrlRef.current);
+        screenshotUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  // Keep ref in sync so unmount cleanup revokes the current URL without
+  // needing a `screenshotUrl` dependency (which would retrigger the effect).
+  useEffect(() => {
+    screenshotUrlRef.current = screenshotUrl;
+  }, [screenshotUrl]);
 
   const resetForm = useCallback(() => {
     setTitle('');
@@ -77,14 +136,6 @@ export function FeedbackButton({
     reset();
   }, [reset]);
 
-  useEffect(
-    () => () => {
-      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
-      if (screenshotUrl) URL.revokeObjectURL(screenshotUrl);
-    },
-    [screenshotUrl],
-  );
-
   const handleOpenChange = useCallback(
     (next: boolean) => {
       setOpen(next);
@@ -100,12 +151,21 @@ export function FeedbackButton({
   );
 
   const handleCaptureScreenshot = useCallback(async () => {
-    const blob = await captureScreenshot();
-    setScreenshot(blob);
-    setScreenshotUrl((prev) => {
-      if (prev) URL.revokeObjectURL(prev);
-      return URL.createObjectURL(blob);
-    });
+    setSubmitError(null);
+    try {
+      const blob = await captureScreenshot();
+      if (!mountedRef.current) return;
+      setScreenshot(blob);
+      setScreenshotUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return URL.createObjectURL(blob);
+      });
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message =
+        err instanceof Error ? err.message : 'Screenshot capture failed';
+      setSubmitError(message);
+    }
   }, [captureScreenshot]);
 
   const handleFiles = useCallback((list: FileList | null) => {
@@ -116,6 +176,9 @@ export function FeedbackButton({
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      // Guard against double-submit via Enter-in-textarea while the submit
+      // button is disabled.
+      if (status === 'submitting') return;
       setSubmitError(null);
       if (!title.trim()) {
         setTitleError('Title is required');
@@ -137,9 +200,12 @@ export function FeedbackButton({
       };
 
       const result = await submit(input);
+      if (!mountedRef.current) return;
       onSubmit?.(result);
       if (result.ok) {
         closeTimerRef.current = setTimeout(() => {
+          closeTimerRef.current = null;
+          if (!mountedRef.current) return;
           setOpen(false);
           resetForm();
         }, AUTO_CLOSE_MS);
@@ -155,6 +221,7 @@ export function FeedbackButton({
       onSubmit,
       resetForm,
       screenshot,
+      status,
       submit,
       title,
     ],
@@ -162,140 +229,138 @@ export function FeedbackButton({
 
   if (hidden) return null;
 
-  const posClass =
-    position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  const posClass = position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
   const rootClassName = ['brw-root', className].filter(Boolean).join(' ');
 
   return (
-    <>
-      <BrevwickStyles />
-      <Dialog.Root open={open} onOpenChange={handleOpenChange}>
-        <Dialog.Trigger asChild>
-          <button
-            type="button"
-            data-brevwick-skip=""
-            className={`${rootClassName} brw-fab ${posClass}`}
-            disabled={disabled}
-            aria-label="Open feedback form"
-          >
-            {label}
-          </button>
-        </Dialog.Trigger>
-        <Dialog.Portal>
-          <Dialog.Overlay
-            data-brevwick-skip=""
-            className={`${rootClassName} brw-overlay`}
-          />
-          <Dialog.Content
-            data-brevwick-skip=""
-            className={`${rootClassName} brw-dialog`}
-            aria-describedby={undefined}
-          >
-            <Dialog.Title className="brw-title">Send feedback</Dialog.Title>
-            <form onSubmit={handleSubmit} noValidate>
-              <label className="brw-field">
-                <span className="brw-label">Title *</span>
-                <input
-                  className="brw-input"
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  aria-invalid={titleError ? 'true' : undefined}
-                  aria-describedby={titleError ? 'brw-title-err' : undefined}
-                />
-                {titleError && (
-                  <span id="brw-title-err" className="brw-error" role="alert">
-                    {titleError}
-                  </span>
-                )}
-              </label>
-              <label className="brw-field">
-                <span className="brw-label">Description</span>
-                <textarea
-                  className="brw-textarea"
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                />
-              </label>
-              <label className="brw-field">
-                <span className="brw-label">Expected</span>
-                <textarea
-                  className="brw-textarea"
-                  value={expected}
-                  onChange={(e) => setExpected(e.target.value)}
-                />
-              </label>
-              <label className="brw-field">
-                <span className="brw-label">Actual</span>
-                <textarea
-                  className="brw-textarea"
-                  value={actual}
-                  onChange={(e) => setActual(e.target.value)}
-                />
-              </label>
-              <div className="brw-field">
-                <div className="brw-row">
-                  <button
-                    type="button"
-                    className="brw-btn"
-                    onClick={handleCaptureScreenshot}
-                  >
-                    Attach screenshot
-                  </button>
-                  <label className="brw-btn" style={{ display: 'inline-block' }}>
-                    Attach file
-                    <input
-                      type="file"
-                      multiple
-                      style={{ display: 'none' }}
-                      onChange={(e) => handleFiles(e.target.files)}
-                    />
-                  </label>
-                </div>
-                {screenshotUrl && screenshot && (
-                  <div className="brw-thumb">
-                    <img src={screenshotUrl} alt="Screenshot preview" />
-                    <span>{formatSize(screenshot.size)}</span>
-                  </div>
-                )}
-                {files.length > 0 && (
-                  <div className="brw-files">
-                    {files.map((f) => `${f.name} (${formatSize(f.size)})`).join(', ')}
-                  </div>
-                )}
-              </div>
-              {submitError && (
-                <div className="brw-error" role="alert">
-                  {submitError}
-                </div>
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          data-brevwick-skip=""
+          className={`${rootClassName} brw-fab ${posClass}`}
+          disabled={disabled}
+          aria-label="Open feedback form"
+        >
+          {label}
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          data-brevwick-skip=""
+          className={`${rootClassName} brw-overlay`}
+        />
+        <Dialog.Content
+          data-brevwick-skip=""
+          className={`${rootClassName} brw-dialog`}
+          aria-describedby={undefined}
+        >
+          <Dialog.Title className="brw-title">Send feedback</Dialog.Title>
+          <form onSubmit={handleSubmit} noValidate>
+            <label className="brw-field">
+              <span className="brw-label">Title *</span>
+              <input
+                className="brw-input"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                aria-invalid={titleError ? 'true' : undefined}
+                aria-describedby={titleError ? 'brw-title-err' : undefined}
+              />
+              {titleError && (
+                <span id="brw-title-err" className="brw-error" role="alert">
+                  {titleError}
+                </span>
               )}
-              {status === 'success' && (
-                <div className="brw-success" role="status">
-                  Thanks — report sent
-                </div>
-              )}
-              <div className="brw-footer">
-                <Dialog.Close asChild>
-                  <button type="button" className="brw-btn">
-                    Cancel
-                  </button>
-                </Dialog.Close>
+            </label>
+            <label className="brw-field">
+              <span className="brw-label">Description</span>
+              <textarea
+                className="brw-textarea"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </label>
+            <label className="brw-field">
+              <span className="brw-label">Expected</span>
+              <textarea
+                className="brw-textarea"
+                value={expected}
+                onChange={(e) => setExpected(e.target.value)}
+              />
+            </label>
+            <label className="brw-field">
+              <span className="brw-label">Actual</span>
+              <textarea
+                className="brw-textarea"
+                value={actual}
+                onChange={(e) => setActual(e.target.value)}
+              />
+            </label>
+            <div className="brw-field">
+              <div className="brw-row">
                 <button
-                  type="submit"
-                  className="brw-btn brw-btn-primary"
-                  disabled={status === 'submitting'}
+                  type="button"
+                  className="brw-btn"
+                  onClick={handleCaptureScreenshot}
                 >
-                  {status === 'submitting' && (
-                    <span className="brw-spinner" aria-hidden="true" />
-                  )}
-                  {status === 'submitting' ? 'Sending…' : 'Send'}
+                  Attach screenshot
                 </button>
+                <label className="brw-btn brw-file-label">
+                  Attach file
+                  <input
+                    type="file"
+                    multiple
+                    className="brw-file-input"
+                    onChange={(e) => handleFiles(e.target.files)}
+                  />
+                </label>
               </div>
-            </form>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
-    </>
+              {screenshotUrl && screenshot && (
+                <div className="brw-thumb">
+                  <img src={screenshotUrl} alt="Screenshot preview" />
+                  <span>{formatSize(screenshot.size)}</span>
+                </div>
+              )}
+              {files.length > 0 && (
+                <div className="brw-files">
+                  {files
+                    .map((f) => `${f.name} (${formatSize(f.size)})`)
+                    .join(', ')}
+                </div>
+              )}
+            </div>
+            {submitError && (
+              <div className="brw-error" role="alert">
+                {submitError}
+              </div>
+            )}
+            {status === 'success' && (
+              <div className="brw-success" role="status">
+                Thanks — report sent
+              </div>
+            )}
+            <div className="brw-footer">
+              <Dialog.Close asChild>
+                <button type="button" className="brw-btn">
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                className="brw-btn brw-btn-primary"
+                disabled={status === 'submitting'}
+              >
+                {status === 'submitting' && (
+                  <span className="brw-spinner" aria-hidden="true" />
+                )}
+                {status === 'submitting' ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import type {
+  FeedbackAttachment,
+  FeedbackInput,
+  SubmitResult,
+} from 'brevwick-sdk';
+import { useFeedback } from './use-feedback';
+import { BREVWICK_CSS, BREVWICK_STYLE_ID } from './styles';
+
+export interface FeedbackButtonProps {
+  position?: 'bottom-right' | 'bottom-left';
+  disabled?: boolean;
+  hidden?: boolean;
+  className?: string;
+  label?: ReactNode;
+  onSubmit?: (result: SubmitResult) => void;
+}
+
+const AUTO_CLOSE_MS = 1500;
+
+function BrevwickStyles(): ReactElement {
+  return (
+    <style
+      id={BREVWICK_STYLE_ID}
+      // CSS is a constant string we authored; no interpolation. Inlined once
+      // per tree — React de-dupes by id via dangerouslySetInnerHTML identity.
+      dangerouslySetInnerHTML={{ __html: BREVWICK_CSS }}
+    />
+  );
+}
+
+export function FeedbackButton({
+  position = 'bottom-right',
+  disabled = false,
+  hidden = false,
+  className,
+  label = 'Feedback',
+  onSubmit,
+}: FeedbackButtonProps): ReactElement | null {
+  const { submit, captureScreenshot, status, reset } = useFeedback();
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [screenshot, setScreenshot] = useState<Blob | null>(null);
+  const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setDescription('');
+    setExpected('');
+    setActual('');
+    setScreenshot(null);
+    setScreenshotUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+    setFiles([]);
+    setTitleError(null);
+    setSubmitError(null);
+    reset();
+  }, [reset]);
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      if (screenshotUrl) URL.revokeObjectURL(screenshotUrl);
+    },
+    [screenshotUrl],
+  );
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) {
+        if (closeTimerRef.current) {
+          clearTimeout(closeTimerRef.current);
+          closeTimerRef.current = null;
+        }
+        resetForm();
+      }
+    },
+    [resetForm],
+  );
+
+  const handleCaptureScreenshot = useCallback(async () => {
+    const blob = await captureScreenshot();
+    setScreenshot(blob);
+    setScreenshotUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(blob);
+    });
+  }, [captureScreenshot]);
+
+  const handleFiles = useCallback((list: FileList | null) => {
+    if (!list) return;
+    setFiles(Array.from(list));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setSubmitError(null);
+      if (!title.trim()) {
+        setTitleError('Title is required');
+        return;
+      }
+      setTitleError(null);
+
+      const attachments: Array<Blob | FeedbackAttachment> = [];
+      if (screenshot)
+        attachments.push({ blob: screenshot, filename: 'screenshot.png' });
+      for (const f of files) attachments.push({ blob: f, filename: f.name });
+
+      const input: FeedbackInput = {
+        title: title.trim(),
+        description,
+        expected: expected || undefined,
+        actual: actual || undefined,
+        attachments: attachments.length ? attachments : undefined,
+      };
+
+      const result = await submit(input);
+      onSubmit?.(result);
+      if (result.ok) {
+        closeTimerRef.current = setTimeout(() => {
+          setOpen(false);
+          resetForm();
+        }, AUTO_CLOSE_MS);
+      } else {
+        setSubmitError(result.error.message);
+      }
+    },
+    [
+      actual,
+      description,
+      expected,
+      files,
+      onSubmit,
+      resetForm,
+      screenshot,
+      submit,
+      title,
+    ],
+  );
+
+  if (hidden) return null;
+
+  const posClass =
+    position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  const rootClassName = ['brw-root', className].filter(Boolean).join(' ');
+
+  return (
+    <>
+      <BrevwickStyles />
+      <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+        <Dialog.Trigger asChild>
+          <button
+            type="button"
+            data-brevwick-skip=""
+            className={`${rootClassName} brw-fab ${posClass}`}
+            disabled={disabled}
+            aria-label="Open feedback form"
+          >
+            {label}
+          </button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Overlay
+            data-brevwick-skip=""
+            className={`${rootClassName} brw-overlay`}
+          />
+          <Dialog.Content
+            data-brevwick-skip=""
+            className={`${rootClassName} brw-dialog`}
+            aria-describedby={undefined}
+          >
+            <Dialog.Title className="brw-title">Send feedback</Dialog.Title>
+            <form onSubmit={handleSubmit} noValidate>
+              <label className="brw-field">
+                <span className="brw-label">Title *</span>
+                <input
+                  className="brw-input"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  aria-invalid={titleError ? 'true' : undefined}
+                  aria-describedby={titleError ? 'brw-title-err' : undefined}
+                />
+                {titleError && (
+                  <span id="brw-title-err" className="brw-error" role="alert">
+                    {titleError}
+                  </span>
+                )}
+              </label>
+              <label className="brw-field">
+                <span className="brw-label">Description</span>
+                <textarea
+                  className="brw-textarea"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </label>
+              <label className="brw-field">
+                <span className="brw-label">Expected</span>
+                <textarea
+                  className="brw-textarea"
+                  value={expected}
+                  onChange={(e) => setExpected(e.target.value)}
+                />
+              </label>
+              <label className="brw-field">
+                <span className="brw-label">Actual</span>
+                <textarea
+                  className="brw-textarea"
+                  value={actual}
+                  onChange={(e) => setActual(e.target.value)}
+                />
+              </label>
+              <div className="brw-field">
+                <div className="brw-row">
+                  <button
+                    type="button"
+                    className="brw-btn"
+                    onClick={handleCaptureScreenshot}
+                  >
+                    Attach screenshot
+                  </button>
+                  <label className="brw-btn" style={{ display: 'inline-block' }}>
+                    Attach file
+                    <input
+                      type="file"
+                      multiple
+                      style={{ display: 'none' }}
+                      onChange={(e) => handleFiles(e.target.files)}
+                    />
+                  </label>
+                </div>
+                {screenshotUrl && screenshot && (
+                  <div className="brw-thumb">
+                    <img src={screenshotUrl} alt="Screenshot preview" />
+                    <span>{formatSize(screenshot.size)}</span>
+                  </div>
+                )}
+                {files.length > 0 && (
+                  <div className="brw-files">
+                    {files.map((f) => `${f.name} (${formatSize(f.size)})`).join(', ')}
+                  </div>
+                )}
+              </div>
+              {submitError && (
+                <div className="brw-error" role="alert">
+                  {submitError}
+                </div>
+              )}
+              {status === 'success' && (
+                <div className="brw-success" role="status">
+                  Thanks — report sent
+                </div>
+              )}
+              <div className="brw-footer">
+                <Dialog.Close asChild>
+                  <button type="button" className="brw-btn">
+                    Cancel
+                  </button>
+                </Dialog.Close>
+                <button
+                  type="submit"
+                  className="brw-btn brw-btn-primary"
+                  disabled={status === 'submitting'}
+                >
+                  {status === 'submitting' && (
+                    <span className="brw-spinner" aria-hidden="true" />
+                  )}
+                  {status === 'submitting' ? 'Sending…' : 'Send'}
+                </button>
+              </div>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,6 +6,10 @@
 
 declare const __BREVWICK_REACT_VERSION__: string;
 
+/**
+ * Semantic version of the installed `brevwick-react` package. Surfaced at
+ * runtime so consumers can include it in bug reports or diagnostics.
+ */
 export const BREVWICK_REACT_VERSION: string = __BREVWICK_REACT_VERSION__;
 
 export { BrevwickProvider } from './provider';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,12 +1,25 @@
 /**
  * Brevwick React bindings.
  *
- * Phase 0: ships only a placeholder export so the package publishes cleanly.
- * The provider, FAB, and useFeedback hook land in Phase 4 — see
- * brevwick-ops/docs/brevwick-sdd.md § 12 for the React contract.
+ * See brevwick-ops/docs/brevwick-sdd.md § 12 for the React contract.
  */
 
 declare const __BREVWICK_REACT_VERSION__: string;
 
-// Injected at build/test time from packages/react/package.json via tsup/vitest `define`.
 export const BREVWICK_REACT_VERSION: string = __BREVWICK_REACT_VERSION__;
+
+export { BrevwickProvider } from './provider';
+export type { BrevwickProviderProps } from './provider';
+
+export { useFeedback } from './use-feedback';
+export type { FeedbackStatus, UseFeedbackResult } from './use-feedback';
+
+export { FeedbackButton } from './feedback-button';
+export type { FeedbackButtonProps } from './feedback-button';
+
+export type {
+  BrevwickConfig,
+  FeedbackAttachment,
+  FeedbackInput,
+  SubmitResult,
+} from 'brevwick-sdk';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
+import { createBrevwick, type Brevwick, type BrevwickConfig } from 'brevwick-sdk';
+import { BrevwickContext, type BrevwickContextValue } from './context';
+
+export interface BrevwickProviderProps {
+  config: BrevwickConfig;
+  children?: ReactNode;
+}
+
+export function BrevwickProvider({
+  config,
+  children,
+}: BrevwickProviderProps): ReactElement {
+  const brevwick: Brevwick = useMemo(() => createBrevwick(config), [config]);
+
+  useEffect(() => {
+    brevwick.install();
+    return () => {
+      brevwick.uninstall();
+    };
+  }, [brevwick]);
+
+  const value = useMemo<BrevwickContextValue>(() => ({ brevwick }), [brevwick]);
+
+  return (
+    <BrevwickContext.Provider value={value}>{children}</BrevwickContext.Provider>
+  );
+}

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,14 +1,36 @@
 'use client';
 
 import { useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
-import { createBrevwick, type Brevwick, type BrevwickConfig } from 'brevwick-sdk';
+import {
+  createBrevwick,
+  type Brevwick,
+  type BrevwickConfig,
+} from 'brevwick-sdk';
 import { BrevwickContext, type BrevwickContextValue } from './context';
 
+/**
+ * Props for {@link BrevwickProvider}.
+ */
 export interface BrevwickProviderProps {
+  /**
+   * Brevwick SDK configuration. **The object identity matters**: the provider
+   * memoises the underlying `Brevwick` instance keyed on this reference, so
+   * passing a new object literal each render would cause `install` /
+   * `uninstall` to cycle on every render. Hoist the config to module scope or
+   * memoise it with `useMemo` in the parent component.
+   */
   config: BrevwickConfig;
   children?: ReactNode;
 }
 
+/**
+ * Provides a `Brevwick` SDK instance to descendant components.
+ *
+ * - Memoises `createBrevwick(config)` on `config` identity.
+ * - Calls `install()` on mount and `uninstall()` on unmount, so global
+ *   listeners (network, console, visibility) are attached only while the
+ *   provider is mounted.
+ */
 export function BrevwickProvider({
   config,
   children,
@@ -25,6 +47,8 @@ export function BrevwickProvider({
   const value = useMemo<BrevwickContextValue>(() => ({ brevwick }), [brevwick]);
 
   return (
-    <BrevwickContext.Provider value={value}>{children}</BrevwickContext.Provider>
+    <BrevwickContext.Provider value={value}>
+      {children}
+    </BrevwickContext.Provider>
   );
 }

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -102,4 +102,6 @@ export const BREVWICK_CSS = `
 @keyframes brw-spin { to { transform: rotate(360deg); } }
 .brw-footer { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
 .brw-files { margin-top: 6px; font-size: 12px; color: var(--brw-muted); }
+.brw-file-label { display: inline-block; }
+.brw-file-input { display: none; }
 `;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -1,0 +1,105 @@
+/**
+ * Styles are injected via a single <style> tag rendered into the tree so the
+ * package has zero CSS-loader requirements — consumers can drop the package
+ * into any bundler (Next.js, Vite, Webpack) without config. Theming is done
+ * through CSS variables and `prefers-color-scheme`.
+ */
+export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
+
+export const BREVWICK_CSS = `
+.brw-root {
+  --brw-bg: #ffffff;
+  --brw-fg: #0f172a;
+  --brw-muted: #64748b;
+  --brw-border: #e2e8f0;
+  --brw-accent: #0f172a;
+  --brw-accent-fg: #ffffff;
+  --brw-error: #b91c1c;
+  --brw-success: #047857;
+  --brw-overlay: rgba(15, 23, 42, 0.45);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  color: var(--brw-fg);
+}
+@media (prefers-color-scheme: dark) {
+  .brw-root {
+    --brw-bg: #0f172a;
+    --brw-fg: #f8fafc;
+    --brw-muted: #94a3b8;
+    --brw-border: #1e293b;
+    --brw-accent: #f8fafc;
+    --brw-accent-fg: #0f172a;
+    --brw-overlay: rgba(0, 0, 0, 0.6);
+  }
+}
+.brw-fab {
+  position: fixed;
+  z-index: 2147483000;
+  bottom: 20px;
+  height: 44px;
+  min-width: 44px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid var(--brw-border);
+  background: var(--brw-accent);
+  color: var(--brw-accent-fg);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
+.brw-fab-br { right: 20px; }
+.brw-fab-bl { left: 20px; }
+.brw-overlay {
+  position: fixed; inset: 0; z-index: 2147483001;
+  background: var(--brw-overlay);
+}
+.brw-dialog {
+  position: fixed; z-index: 2147483002;
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: min(92vw, 480px);
+  max-height: 90vh; overflow: auto;
+  background: var(--brw-bg);
+  color: var(--brw-fg);
+  border-radius: 12px;
+  border: 1px solid var(--brw-border);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+  padding: 20px;
+}
+.brw-title { margin: 0 0 12px; font-size: 16px; font-weight: 600; }
+.brw-field { display: block; margin-bottom: 12px; font-size: 13px; }
+.brw-label { display: block; margin-bottom: 4px; color: var(--brw-muted); }
+.brw-input, .brw-textarea {
+  width: 100%; box-sizing: border-box;
+  padding: 8px 10px; font: inherit; color: var(--brw-fg);
+  background: var(--brw-bg); border: 1px solid var(--brw-border);
+  border-radius: 6px;
+}
+.brw-textarea { min-height: 72px; resize: vertical; }
+.brw-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.brw-btn {
+  height: 34px; padding: 0 12px; border-radius: 6px;
+  border: 1px solid var(--brw-border); background: var(--brw-bg); color: var(--brw-fg);
+  font: inherit; cursor: pointer;
+}
+.brw-btn-primary {
+  background: var(--brw-accent); color: var(--brw-accent-fg); border-color: var(--brw-accent);
+}
+.brw-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.brw-thumb {
+  margin-top: 6px;
+  display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: var(--brw-muted);
+}
+.brw-thumb img { max-width: 96px; max-height: 64px; border-radius: 4px; border: 1px solid var(--brw-border); }
+.brw-error { color: var(--brw-error); font-size: 13px; margin-top: 8px; }
+.brw-success { color: var(--brw-success); font-size: 13px; margin-top: 8px; }
+.brw-spinner {
+  display: inline-block; width: 14px; height: 14px;
+  border: 2px solid currentColor; border-right-color: transparent;
+  border-radius: 999px; vertical-align: -2px; margin-right: 6px;
+  animation: brw-spin 0.7s linear infinite;
+}
+@keyframes brw-spin { to { transform: rotate(360deg); } }
+.brw-footer { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
+.brw-files { margin-top: 6px; font-size: 12px; color: var(--brw-muted); }
+`;

--- a/packages/react/src/use-feedback.ts
+++ b/packages/react/src/use-feedback.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { FeedbackInput, SubmitResult } from 'brevwick-sdk';
+import { useBrevwickInternal } from './context';
+
+export type FeedbackStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+export interface UseFeedbackResult {
+  submit: (input: FeedbackInput) => Promise<SubmitResult>;
+  captureScreenshot: () => Promise<Blob>;
+  status: FeedbackStatus;
+  reset: () => void;
+}
+
+export function useFeedback(): UseFeedbackResult {
+  const { brevwick } = useBrevwickInternal();
+  const [status, setStatus] = useState<FeedbackStatus>('idle');
+
+  const submit = useCallback(
+    async (input: FeedbackInput): Promise<SubmitResult> => {
+      if (!brevwick) {
+        const error: SubmitResult = {
+          ok: false,
+          error: {
+            code: 'INGEST_REJECTED',
+            message: 'Brevwick instance is not available.',
+          },
+        };
+        setStatus('error');
+        return error;
+      }
+      setStatus('submitting');
+      const result = await brevwick.submit(input);
+      setStatus(result.ok ? 'success' : 'error');
+      return result;
+    },
+    [brevwick],
+  );
+
+  const captureScreenshot = useCallback(async (): Promise<Blob> => {
+    if (!brevwick) {
+      throw new Error('Brevwick instance is not available.');
+    }
+    return brevwick.captureScreenshot();
+  }, [brevwick]);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+  }, []);
+
+  return { submit, captureScreenshot, status, reset };
+}

--- a/packages/react/src/use-feedback.ts
+++ b/packages/react/src/use-feedback.ts
@@ -4,32 +4,42 @@ import { useCallback, useState } from 'react';
 import type { FeedbackInput, SubmitResult } from 'brevwick-sdk';
 import { useBrevwickInternal } from './context';
 
+/**
+ * Submission lifecycle surfaced by {@link useFeedback}.
+ *
+ * - `idle` — nothing in-flight.
+ * - `submitting` — a `submit()` call is pending.
+ * - `success` — the last `submit()` resolved with `{ ok: true }`.
+ * - `error` — the last `submit()` resolved with `{ ok: false }`.
+ */
 export type FeedbackStatus = 'idle' | 'submitting' | 'success' | 'error';
 
+/**
+ * Return value of {@link useFeedback}. See the SDK SDD § 12 for the contract.
+ */
 export interface UseFeedbackResult {
+  /** Submit feedback. Returns the same tagged union the core SDK returns. */
   submit: (input: FeedbackInput) => Promise<SubmitResult>;
+  /** Capture a DOM screenshot via the core SDK (dynamic import). */
   captureScreenshot: () => Promise<Blob>;
+  /** Current submission status. */
   status: FeedbackStatus;
+  /** Reset `status` back to `'idle'`. Does not cancel an in-flight submit. */
   reset: () => void;
 }
 
+/**
+ * React hook that exposes the Brevwick submission primitives against the
+ * instance supplied by the nearest {@link BrevwickProvider}.
+ *
+ * Throws synchronously on mount when rendered outside a provider.
+ */
 export function useFeedback(): UseFeedbackResult {
   const { brevwick } = useBrevwickInternal();
   const [status, setStatus] = useState<FeedbackStatus>('idle');
 
   const submit = useCallback(
     async (input: FeedbackInput): Promise<SubmitResult> => {
-      if (!brevwick) {
-        const error: SubmitResult = {
-          ok: false,
-          error: {
-            code: 'INGEST_REJECTED',
-            message: 'Brevwick instance is not available.',
-          },
-        };
-        setStatus('error');
-        return error;
-      }
       setStatus('submitting');
       const result = await brevwick.submit(input);
       setStatus(result.ok ? 'success' : 'error');
@@ -38,12 +48,10 @@ export function useFeedback(): UseFeedbackResult {
     [brevwick],
   );
 
-  const captureScreenshot = useCallback(async (): Promise<Blob> => {
-    if (!brevwick) {
-      throw new Error('Brevwick instance is not available.');
-    }
-    return brevwick.captureScreenshot();
-  }, [brevwick]);
+  const captureScreenshot = useCallback(
+    (): Promise<Blob> => brevwick.captureScreenshot(),
+    [brevwick],
+  );
 
   const reset = useCallback(() => {
     setStatus('idle');

--- a/packages/react/src/use-feedback.ts
+++ b/packages/react/src/use-feedback.ts
@@ -41,9 +41,18 @@ export function useFeedback(): UseFeedbackResult {
   const submit = useCallback(
     async (input: FeedbackInput): Promise<SubmitResult> => {
       setStatus('submitting');
-      const result = await brevwick.submit(input);
-      setStatus(result.ok ? 'success' : 'error');
-      return result;
+      try {
+        const result = await brevwick.submit(input);
+        setStatus(result.ok ? 'success' : 'error');
+        return result;
+      } catch (error) {
+        // `brevwick.submit` only rejects when the lazy submit chunk itself
+        // fails to load (deploy mismatch / offline). Flip to 'error' so the
+        // UI isn't stuck on 'submitting', then rethrow so callers can
+        // distinguish an environmental failure from an ingest-level one.
+        setStatus('error');
+        throw error;
+      }
     },
     [brevwick],
   );

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["@testing-library/jest-dom"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -11,11 +11,18 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
-  treeshake: true,
+  // Rollup-driven treeshaking strips the `"use client"` directive that
+  // Next.js App Router needs. esbuild handles the bundle size fine without
+  // it — we rely on @radix-ui's tree-shakable exports for dead-code removal.
+  treeshake: false,
   splitting: false,
   external: ['react', 'react-dom', 'brevwick-sdk'],
   target: 'es2020',
   define: {
     __BREVWICK_REACT_VERSION__: JSON.stringify(pkg.version),
   },
+  // Every public export uses hooks/context/effects; marking the bundle
+  // `"use client"` lets Next.js App Router servers import it from Server
+  // Components without hitting the createContext-is-not-a-function wall.
+  banner: { js: '"use client";' },
 });

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,10 @@ importers:
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@18.0.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
 
   packages/react:
+    dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -501,6 +505,177 @@ packages:
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -920,6 +1095,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1061,6 +1240,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1233,6 +1415,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1703,6 +1889,36 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1961,6 +2177,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -2542,6 +2778,149 @@ snapshots:
 
   '@oxc-project/types@0.124.0': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
@@ -2918,6 +3297,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -3026,6 +3409,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -3230,6 +3615,8 @@ snapshots:
     optional: true
 
   get-caller-file@2.0.5: {}
+
+  get-nonce@1.0.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3618,6 +4005,33 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.5: {}
 
   read-yaml-file@1.1.0:
@@ -3818,8 +4232,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsup@8.5.1(postcss@8.5.9)(typescript@5.9.3):
     dependencies:
@@ -3883,6 +4296,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7):
     dependencies:


### PR DESCRIPTION
Closes #6

Implements [SDD § 12 React bindings](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts) and [§ 13 widget UX](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#13-widget-ux).

**SDD alignment PR (cross-repo):** tatlacas-com/brevwick-ops#8 — expands § 12 `@brevwick/react` to enumerate the full shipped API (`BrevwickProvider`, `useFeedback`, `FeedbackButton` props, `"use client"` banner, `data-brevwick-skip`, memoisation / unmount-safety contracts). Must land before this PR so the SDD matches what's shipped.

## Summary
- `<BrevwickProvider>` — SSR-safe, installs on mount, uninstalls on unmount, memoises the instance from `createBrevwick()` keyed on config identity.
- `useFeedback()` — `{ submit, captureScreenshot, status, reset }` with an `idle → submitting → success|error` state machine; throws outside a provider.
- `<FeedbackButton>` — drop-in FAB with Radix Dialog form (title / description / expected / actual + screenshot + file attachments), inline error + success states, auto-close 1.5 s after success. Double-submit-guarded, unmount-safe, revokes object URLs.
- `data-brevwick-skip` on the FAB, overlay, and dialog content so the widget never appears in its own screenshots.
- Theming via `.brw-root` CSS vars with a `prefers-color-scheme: dark` override; consumers override through `className` or by setting the vars on an ancestor.
- Bundle `"use client"` banner so Next.js App Router servers can import from Server Components. Verified with smoke builds against Next.js 14.2.35 / React 18 and Next.js 16.2.3 / React 19.

## Bundle
- `packages/react/dist/index.js` gzip: **4277 bytes** — well under the 25 kB budget.

## Test plan
- [x] `pnpm format:check` green
- [x] `pnpm type-check` green
- [x] `pnpm lint` green
- [x] `pnpm test` — 164 sdk + 21 react tests pass
- [x] `pnpm --filter brevwick-react build` green
- [x] gzip bundle < 25 kB (4.3 kB)
- [x] Next.js 14 + 16 smoke builds succeed
- [x] `@testing-library` covers: open → fill → submit → success → close, failure keeps dialog open, screenshot attach + thumbnail, `data-brevwick-skip` present, disabled prop, bottom-left position, URL.revokeObjectURL on unmount, reopen clears state, captureScreenshot rejection path, `onSubmit` fires on failure, config-identity memoisation negative case.
- [x] Changeset added (lockstep minor bump)