### PR TITLE
feat(react): chat-thread panel redesign for FeedbackButton

### DIFF
--- a/.changeset/chat-panel-redesign.md
+++ b/.changeset/chat-panel-redesign.md
@@ -1,0 +1,41 @@
+---
+'brevwick-react': minor
+'brevwick-sdk': minor
+---
+
+feat(react): chat-thread panel redesign for FeedbackButton
+
+Reshapes the `<FeedbackButton>` widget from a centered modal into an
+anchored, chat-style panel that slides up next to the FAB (bottom-right /
+bottom-left).
+
+- Layout: header (title, minimize, close) → scrollable bubble thread →
+  sticky composer (icons + autogrowing textarea + Send).
+- Composer: Enter sends; Shift/Ctrl/Meta/Alt + Enter inserts a newline;
+  IME composition is respected. Autogrow ceiling is shared between CSS
+  and JS via a single exported constant.
+- Attachments: screenshot chip + file chips with stable monotonic ids so
+  removing a middle file never flashes surviving chips into the wrong
+  slot.
+- Esc / overlay-click are mapped to "minimize with preserved state" (not
+  destructive close); the × button explicitly runs the dirty-confirm
+  flow, and is disabled while a submit is in-flight.
+- Progressive disclosure for expected / actual; hidden behind a single
+  "Add expected vs actual" button by default.
+- Title field is derived from the first line of the description (max 120
+  chars) — `FeedbackInput.title` wire shape is unchanged.
+- Success state replaces the thread with a persistent confirmation
+  bubble + "Send another"; no auto-close timer. "Send another" returns
+  focus to the composer textarea for keyboard users. If a submit
+  resolves while the panel is minimized, the success state is still
+  rendered on reopen so the user sees their report was received.
+- Dark-mode chip background is one step brighter than the border so the
+  chip outline stays visible.
+- `prefers-reduced-motion` disables both the panel slide animation and
+  the FAB hover transition; softens the spinner.
+- `data-brevwick-skip=""` remains on the FAB and dialog content.
+- No new dependencies. Widget ESM bundle ≈ 6.9 kB gzip (well under the
+  25 kB budget); core SDK untouched at 2.0 kB gzip.
+
+The `brevwick-sdk` bump is the lockstep pre-1.0 version (no code
+changes in the SDK for this PR).

--- a/ai-worktree.md
+++ b/ai-worktree.md
@@ -221,6 +221,7 @@ Adds a small AI on/off toggle inside the composer footer from WT-A. Widget calls
 **Scope:** `packages/sdk/src/types.ts` adds `use_ai` + `ProjectConfig`; new `packages/sdk/src/config.ts` (dynamic-imported) with `getConfig()`; `packages/sdk/src/submit.ts` `composePayload()` threads `use_ai`; `packages/react/src/feedback-button.tsx` lazy-fetches config on first open and conditionally renders the toggle; tests for the three config states (disabled / forced-on / submitter-choice).
 
 **Depends on:**
+
 - **WT-A (#25)** merged — this worktree mounts its toggle inside the composer footer WT-A created.
 - **brevwick-api#54** merged — adds `use_ai` to the ingest payload contract.
 - **brevwick-api#56** merged — adds the `GET /v1/ingest/config` endpoint.

--- a/notes/reviews/pr-27-claude-review.md
+++ b/notes/reviews/pr-27-claude-review.md
@@ -1,0 +1,111 @@
+# PR #27 Review — feat(react): chat-thread panel redesign for FeedbackButton
+
+**Issue**: #25 — Chat-thread UI redesign for FeedbackButton
+**Branch**: feat/issue-25-chat-ui
+**Reviewed**: 2026-04-19
+**Verdict**: CHANGES REQUIRED
+
+The UX rewrite itself is clean — readable subcomponent split, sensible state shape, 32/32 tests green locally, 6.93 kB gzip ESM (well under the 25 kB widget budget), no new deps, `data-brevwick-skip` still on FAB + `Dialog.Content`, no Claude attribution. However CI is **red on two required checks** and the SDD widget contract (§ 12) has diverged from the shipped behaviour without the required cross-repo update. Both are HARD blockers per `CLAUDE.md`.
+
+## Completeness (NON-NEGOTIABLE)
+
+- [x] **Missing changeset** — added `.changeset/chat-panel-redesign.md` with a minor bump for `brevwick-react` + lockstep `brevwick-sdk` bump.
+- [x] **SDD § 12 updated** — sibling PR opened on `tatlacas-com/brevwick-ops`: https://github.com/tatlacas-com/brevwick-ops/pull/17. Decisions pinned:
+  1. Widget form fields now documented as a single `description` composer textarea + progressive-disclosure for expected/actual. `title` is derived from the first line of `description`.
+  2. Auto-close timer removed; success path documented as persistent confirmation + "Send another".
+  3. `Dialog.Overlay` line dropped from the § 12 contract.
+  4. Esc + overlay-click documented as **minimize-with-preserve** (the "stray Esc never destroys a long draft" decision is now the canonical behaviour).
+- [x] **`pnpm format` — `ai-worktree.md` is prettier-clean** (one trailing-newline fix).
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] `packages/sdk/` untouched — framework-agnostic core stays clean.
+- [x] No React / DOM leaks into core; redaction + submit pipeline still owned by `packages/sdk/src/submit.ts`.
+- [x] Public API (`FeedbackButtonProps`, `useFeedback`, `BrevwickProvider`, `FeedbackInput`) unchanged — backward-compatible at the TS level.
+- [x] `"use client"` banner preserved at the top of `feedback-button.tsx`, provider, and `use-feedback.ts` — Next.js App Router stays drop-in.
+- [x] Subcomponents (`PanelHeader`, `Thread`, `Composer`, `AssistantBubble`, `UserBubble`, `AttachmentChip`, `DisclosureExpectedActual`, `SuccessState`) are local (not exported) — public surface is still the same four names.
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] `onInteractOutside` double-fire fixed — removed the explicit handler entirely. Radix's default outside-press routes through `onOpenChange(false)` → `handleMinimize`, so the minimize-preserve semantics fire exactly once.
+- [x] `AttachmentChip` stable keys — files are now stored as `{ id, file }` where `id` comes from a monotonically-increasing `fileIdRef`. `onRemoveFile` takes the id, not the index; survivors reconcile correctly when a middle chip is removed, even with duplicate filenames. New test covers this.
+- [x] Enter modifier guard tightened — Ctrl / Meta / Alt are now excluded alongside Shift and IME composition. New test asserts the modifier-plus-Enter combos do **not** submit.
+- [x] Autogrow ceiling now exported from `styles.ts` as `COMPOSER_MAX_HEIGHT_PX = 120` and interpolated into both the bundled CSS `max-height` and the JS autogrow clamp — single source of truth.
+- [x] Module-level `hasInjectedStyles` flag dropped — the effect now relies solely on the `document.getElementById(BREVWICK_STYLE_ID)` probe, which is HMR-safe (Fast Refresh tearing the style node down and rebuilding it won't poison a stale module-scope flag).
+- [x] No `any`, no dead code, no commented-out blocks, no stale TODOs.
+- [x] Function bodies small; nesting stays ≤ 2 levels. Names reveal intent.
+- [x] Comments explain WHY (e.g. `:156-158` on the Esc semantics, `:586-587` on the autogrow cost).
+
+## Public API & Types
+
+- [x] No exported-type changes; `FeedbackButtonProps` identical to main.
+- [x] JSDoc on every public export (`FeedbackButtonProps`, `FeedbackButton`).
+- [x] `Thread`'s `status` prop now imports `FeedbackStatus` from `./use-feedback` — no more duplicated string-union.
+
+## Cross-Runtime Safety
+
+- [x] `useIsomorphicLayoutEffect` guards SSR — `typeof window !== 'undefined'` fallback to `useEffect`.
+- [x] Style injection probes `typeof document === 'undefined'` before touching the DOM.
+- [x] `URL.createObjectURL` / `revokeObjectURL` only called in the attach / cleanup effect paths, never at module load.
+- [x] Composer autogrow flagged for the future "persist draft to localStorage" feature — no change required today because `draft` always starts empty, so the post-hydration reflow is a no-op. Keeping the reviewer's note so the invariant is visible when drafts gain persistence.
+
+## Bugs & Gaps
+
+- [x] **Submit-in-flight during minimize** — decision (a) implemented: on submit resolution while minimized, the component sets `open = true` so the success bubble (or error alert) is immediately visible. Tests cover both success and failure resolving after a mid-submit minimize.
+- [x] **Close-when-submitting** — the × button is now `disabled` while `status === 'submitting'`. Test asserts the disabled attribute during an in-flight submit.
+- [x] **Attachment chip confirm-close re-triggers** — new test: submit rejects → click × → discard confirm renders → Keep preserves the populated draft (`will fail`).
+- [x] **Focus management on Send another** — added a `composerRef` forwarded through `Composer`; `handleSendAnother` sets a pending-focus flag consumed by a layout effect after the `SuccessState` unmounts and the composer remounts. Test asserts `document.activeElement === textarea` after clicking "Send another".
+- [x] **Reduced-motion coverage** — `bundles a slide-up animation with a prefers-reduced-motion override` test extended to grep the bundled CSS for the `.brw-fab { transition: none; }` override as well.
+- [x] **Dark-mode chip background contrast** — `--brw-chip-bg` in dark mode bumped to `#253044` (one step brighter than `--brw-border: #1e293b`). New test grep-asserts the two CSS vars are distinct in the dark-mode block so a future regression is caught.
+
+## Security
+
+- [x] No new payload fields → redaction mandate untouched (confirmed by PR body; `submit.ts` path unchanged).
+- [x] No `eval`, no `Function()`, no `dangerouslySetInnerHTML`.
+- [x] No secrets in code.
+- [x] Inline SVG icons render through JSX, not `innerHTML` — CSP-safe.
+- [x] Style injection uses `textContent = BREVWICK_CSS` (static string, no interpolation of user input) — safe without a CSP nonce. `styles.ts:8` note already flags the CSP-nonce backlog.
+
+## Tests
+
+- [x] 32/32 passing locally. Coverage hits Enter/Shift+Enter, capture reject, submit reject, `result.ok=false`, screenshot attach + extension derivation, minimize preserves state, close clean vs dirty, disclosure, expected/actual in payload, success + Send another, unmount revokes objectURL, aria-live on thread + confirmation, double-send guard, bundled CSS contains slide-up keyframe + reduced-motion override.
+- [x] **submit-in-flight during minimize** — two new tests (`submit resolving while minimized pops the panel back open with success`, `submit failure resolving while minimized pops the panel back open with alert`).
+- [x] **focus moves to composer on "Send another"** — new test asserts `document.activeElement === textarea` after the reset click.
+- [x] **Esc minimizes, does not destroy** — new test (`Esc minimizes (preserves draft + attachments), does not destroy state`) dispatches `keyDown` with `key: 'Escape'` against the dialog content, asserts panel closes, reopen restores draft + screenshot chip.
+- [x] **× while clean but succeeded** — new test (`close on a success-state panel dismisses without a confirm`) asserts no `alertdialog` renders when × is clicked in the success state, and the next open is empty.
+- [x] **Focused aria assertions added** — composer `aria-label`, disclosure `aria-expanded` flipping across both states. (Axe still omitted per the PR body's NO-new-dependencies rule; the invariants it would have caught are now asserted by hand.)
+- [x] 80% patch coverage — the 32-test suite covers the new surface densely. Didn't measure exact percentage, but visual coverage is high.
+
+## Build & Bundle
+
+- [x] `pnpm --filter brevwick-react build` succeeds (ESM 29.08 kB raw, 6.93 kB gzip; CJS 33.15 kB raw, 7.62 kB gzip).
+- [x] `pnpm --filter brevwick-react type-check` clean.
+- [x] `pnpm lint` clean.
+- [x] `pnpm test` green (32/32).
+- [x] `.d.ts` emitted for both ESM and CJS (`dist/index.d.ts`, `dist/index.d.cts`).
+- [x] `sideEffects: false` honoured; style injection is gated on the component actually mounting (not module import).
+- [x] Under 25 kB widget budget by ~3.6x.
+- [x] `packages/sdk` untouched → 2.2 kB core budget untouched.
+
+## PR Hygiene
+
+- [x] Conventional commit: `feat(react): chat-thread panel redesign for FeedbackButton (#25)`, 64 chars.
+- [x] `Closes #25` in PR body.
+- [x] No Claude attribution in commit message, PR body, or code (grep clean).
+- [x] Branch name matches `feat/issue-<N>-short-desc`.
+- [x] **PR body test-plan manual-smoke box** — left unchecked as reviewer-owned (the box is explicitly "reviewer to verify"). Not flagged as a blocker per the review; the item says "flag explicitly" and this note does so.
+
+## Files Reviewed
+
+| file                                                         | status          | notes                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/feedback-button.tsx`                     | resolved        | Fixes: onInteractOutside simplified to rely on Radix's onOpenChange routing; attachment state shape → `{ id, file }` with monotonic ids; Enter modifier guard extended to Ctrl/Meta/Alt; autogrow uses shared `COMPOSER_MAX_HEIGHT_PX`; HMR-safe style probe; close button disabled while submitting; submit-resolve-while-minimized pops panel back open; focus returns to composer on Send another. |
+| `packages/react/src/styles.ts`                               | resolved        | Dark-mode `--brw-chip-bg` bumped to `#253044` (distinct from `--brw-border`); `COMPOSER_MAX_HEIGHT_PX` exported and interpolated into the CSS template.                                                                                                       |
+| `packages/react/src/__tests__/feedback-button.test.tsx`      | resolved        | Added: Esc-minimize-preserves, submit-resolve-while-minimized (success + failure), Send-another focus return, × on success state dismiss, close-disabled-while-submitting, submit-reject discard confirm, Enter+modifier guard, stable attachment keys, dark-mode chip contrast, composer aria-label, disclosure `aria-expanded` both states, FAB reduced-motion CSS grep. |
+| `packages/react/src/use-feedback.ts`                         | unchanged       | `FeedbackStatus` re-exported and consumed by `Thread`.                                                                                                                                                                                                         |
+| `packages/react/src/provider.tsx`                            | unchanged       | —                                                                                                                                                                                                                                                             |
+| `packages/react/src/index.ts`                                | unchanged       | —                                                                                                                                                                                                                                                             |
+| `packages/react/package.json`                                | unchanged       | No new deps — verified.                                                                                                                                                                                                                                       |
+| `.changeset/chat-panel-redesign.md`                          | added           | Minor bump for `brevwick-react` + lockstep `brevwick-sdk`.                                                                                                                                                                                                     |
+| `brevwick-ops/docs/brevwick-sdd.md` § 12                     | updated         | Sibling PR: https://github.com/tatlacas-com/brevwick-ops/pull/17.                                                                                                                                                                                             |
+| `ai-worktree.md`                                             | formatted       | `pnpm format` applied — prettier clean.                                                                                                                                                                                                                        |

--- a/notes/reviews/pr-27-claude-review.md
+++ b/notes/reviews/pr-27-claude-review.md
@@ -109,3 +109,40 @@ The UX rewrite itself is clean — readable subcomponent split, sensible state s
 | `.changeset/chat-panel-redesign.md`                          | added           | Minor bump for `brevwick-react` + lockstep `brevwick-sdk`.                                                                                                                                                                                                     |
 | `brevwick-ops/docs/brevwick-sdd.md` § 12                     | updated         | Sibling PR: https://github.com/tatlacas-com/brevwick-ops/pull/17.                                                                                                                                                                                             |
 | `ai-worktree.md`                                             | formatted       | `pnpm format` applied — prettier clean.                                                                                                                                                                                                                        |
+
+## Validation — 2026-04-19
+
+**Verdict**: APPROVED
+
+### Items Confirmed Fixed
+
+- [x] Missing changeset — `.changeset/chat-panel-redesign.md` present with `brevwick-react: minor` + `brevwick-sdk: minor` lockstep bump; confirmed at changeset file lines 1-4.
+- [x] SDD § 12 updated — cross-repo PR tatlacas-com/brevwick-ops#17 open (not draft); `gh pr diff` confirms all four documented changes (no title form field, derived from description's first line capped at 120 chars; no 1.5s auto-close / persistent success + Send another; no Dialog.Overlay line; Esc/outside-press → minimize-with-preserve). PR body cross-links `brevwick-sdk-js#27`.
+- [x] `pnpm format` — ai-worktree.md diff is one trailing blank line before a markdown list (prettier-clean).
+- [x] `onInteractOutside` double-fire removed — `feedback-button.tsx:333-337`: `Dialog.Content` has no `onInteractOutside` prop. Radix default routes outside-press through `onOpenChange(false)` → `handleMinimize` via `handleOpenChange` (lines 171-180). Minimize fires exactly once.
+- [x] Attachment stable keys — `feedback-button.tsx:86-89` introduces `FileAttachment { id, file }`; `fileIdRef` is a monotonic counter (line 114); `handleFiles` (lines 211-220) increments per file; `removeFile` takes the id (lines 229-231); `Thread` keys by `id` (line 483). Test at `__tests__/feedback-button.test.tsx:683-711` asserts middle-removal of duplicate-named files leaves survivors intact.
+- [x] Enter modifier guard — `feedback-button.tsx:658-670` excludes Shift, Ctrl, Meta, Alt, and `isComposing`. Test at `__tests__/feedback-button.test.tsx:664-681` asserts modifier-plus-Enter does not submit and plain Enter still submits.
+- [x] `COMPOSER_MAX_HEIGHT_PX = 120` exported from `styles.ts:17`, interpolated into CSS at `styles.ts:295`, used in autogrow JS clamp at `feedback-button.tsx:655`. Single source of truth confirmed.
+- [x] Module-level `hasInjectedStyles` dropped — `feedback-button.tsx:59-68` now only probes `document.getElementById(BREVWICK_STYLE_ID)`. HMR-safe.
+- [x] `Thread` imports `FeedbackStatus` from `./use-feedback` — `feedback-button.tsx:21` imports the type alias; `ThreadProps.status` uses it (line 434).
+- [x] × disabled while submitting — `feedback-button.tsx:416` sets `disabled={submitting}`. Success path bypasses dirty-confirm at lines 182-192 (`handleCloseClick` → `handleFullClose` when `succeeded`). Tests at `__tests__/feedback-button.test.tsx:598-617` and `619-639` confirm both behaviours.
+- [x] Submit-resolve-while-minimized pops panel — `feedback-button.tsx:271` (success), `276` (`result.ok === false`), `285` (thrown) all `setOpen(true)`. Tests at `__tests__/feedback-button.test.tsx:518-547` (success pop) and `549-579` (failure pop) prove the behaviour end-to-end.
+- [x] Focus-return on Send another — pending-focus flag at line 292, `handleSendAnother` at 299-302 sets the flag, layout effect at 304-309 consumes it after `SuccessState` unmounts. Test at `__tests__/feedback-button.test.tsx:581-596` asserts `document.activeElement === textarea`.
+- [x] Dark-mode `--brw-chip-bg` bumped to `#253044` — `styles.ts:53` confirmed distinct from `--brw-border: #1e293b` at line 44. Test at `__tests__/feedback-button.test.tsx:713-727` grep-asserts the two CSS vars are different.
+- [x] New tests — 44/44 react tests pass; 172/172 sdk tests pass (216 total). Coverage on `feedback-button.tsx`: 95.37% lines / 81.08% branches — exceeds 80% patch-coverage gate.
+
+### Independent Findings
+
+None. Architecture untouched (sdk/ unchanged, `packages/sdk` gzip still 2.02 kB / 2068 bytes under the 2.2 kB budget), public API unchanged, no new deps, `"use client"` preserved, no `any`, no DOM leaks into core, redaction path untouched (no new payload fields). PR body's "NO new dependencies" rationale for omitting `vitest-axe` is a legitimate constraint-driven trade-off (bundle + dep budget), not scope-dodging — invariants replicated by hand in the suite.
+
+### Tooling
+
+- `pnpm install --frozen-lockfile`: pass (lockfile up to date)
+- `pnpm lint`: pass (clean)
+- `pnpm type-check`: pass (sdk + react)
+- `pnpm test`: pass (172 + 44 = 216 green)
+- `pnpm test --coverage` on `brevwick-react`: pass (96.09% lines / 81.73% branches overall, 95.37% / 81.08% on `feedback-button.tsx`)
+- `pnpm build`: pass (react ESM 30.27 kB raw / 7.10 kB gzip; sdk core 2.02 kB gzip; Next.js example builds + type-checks)
+- `gh pr checks 27`: pass on all four required checks (`check` Changeset + `check` CI + `codecov/patch` + `codecov/project`)
+- `gh pr view 17 --repo tatlacas-com/brevwick-ops`: open (not draft); diff confirms the four § 12 changes
+- No Claude attribution in the fix commit, the feature commit, the PR body, the SDD PR body, or code comments (grep clean — only negative mentions in worktree scaffold docs)

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -323,7 +323,7 @@ describe('<FeedbackButton>', () => {
     fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
     // Panel remains open, confirm inline renders.
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    const confirm = screen.getByRole('alertdialog', {
+    const confirm = screen.getByRole('alert', {
       name: /discard draft/i,
     });
     expect(
@@ -332,7 +332,7 @@ describe('<FeedbackButton>', () => {
 
     // Keep → confirm disappears, draft remains.
     fireEvent.click(within(confirm).getByRole('button', { name: /keep/i }));
-    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(screen.queryByRole('alert', { name: /discard draft/i })).toBeNull();
     expect(getComposer().value).toBe('draft-content');
 
     // Close again → Discard → panel closes and reopens empty.
@@ -608,7 +608,7 @@ describe('<FeedbackButton>', () => {
     // × on the success-state panel: no confirm dialog, panel closes,
     // next open is empty.
     fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
-    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(screen.queryByRole('alert', { name: /discard draft/i })).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
 
     openPanel();
@@ -652,7 +652,7 @@ describe('<FeedbackButton>', () => {
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
-    const confirm = screen.getByRole('alertdialog', {
+    const confirm = screen.getByRole('alert', {
       name: /discard draft/i,
     });
     expect(confirm).toBeInTheDocument();
@@ -745,5 +745,63 @@ describe('<FeedbackButton>', () => {
       name: /hide expected vs actual/i,
     });
     expect(toggleOpen).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('disclosure uses a per-instance id so two buttons do not collide', () => {
+    render(
+      <BrevwickProvider config={{ projectKey: 'pk_test_dupe' }}>
+        <FeedbackButton />
+        <FeedbackButton position="bottom-left" />
+      </BrevwickProvider>,
+    );
+    const fabs = screen.getAllByRole('button', {
+      name: /open feedback form/i,
+    });
+    fireEvent.click(fabs[0]!);
+    fireEvent.click(fabs[1]!);
+    const toggles = screen.getAllByRole('button', {
+      name: /add expected vs actual/i,
+    });
+    const ids = toggles.map((t) => t.getAttribute('aria-controls'));
+    expect(ids[0]).toBeTruthy();
+    expect(ids[1]).toBeTruthy();
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('file input carries an accessible name directly (not only via <label>)', () => {
+    mount();
+    openPanel();
+    const fileInput = screen
+      .getByRole('dialog')
+      .querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    expect(fileInput).toHaveAttribute('aria-label', 'Attach file');
+  });
+
+  it('discard confirm moves focus to Keep so Enter preserves the draft', () => {
+    mount();
+    openPanel();
+    typeDraft('precious');
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    const keep = screen.getByRole('button', { name: /keep/i });
+    expect(keep).toHaveFocus();
+  });
+
+  it('submits the raw draft so the bubble and payload stay in sync', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ws' });
+    mount();
+    openPanel();
+    // Trailing newlines and whitespace — the user's intentional formatting.
+    typeDraft('  hello world\n\n');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as {
+      description: string;
+      title?: string;
+    };
+    expect(input.description).toBe('  hello world\n\n');
+    // Title still derived from the first non-empty line so it remains useful.
+    expect(input.title).toBe('hello world');
   });
 });

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -482,6 +482,268 @@ describe('<FeedbackButton>', () => {
     expect(BREVWICK_CSS).toMatch(
       /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.brw-panel[^{]*\{[^}]*animation:\s*none/,
     );
+    // FAB hover transition must also be disabled under reduced-motion so a
+    // CSS edit that drops the `.brw-fab { transition: none; }` rule is
+    // caught by the test suite.
+    expect(BREVWICK_CSS).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.brw-fab[^{]*\{[^}]*transition:\s*none/,
+    );
     expect(BREVWICK_STYLE_ID).toBe('brevwick-react-styles');
+  });
+
+  it('Esc minimizes (preserves draft + attachments), does not destroy state', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    openPanel();
+    typeDraft('draft survives esc');
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+
+    // Radix's dialog listens on the document; target the dialog content.
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('draft survives esc');
+    expect(
+      screen.getByRole('button', { name: /remove screenshot/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('submit resolving while minimized pops the panel back open with success', async () => {
+    let release: (r: SubmitResult) => void = () => undefined;
+    submit.mockReturnValueOnce(
+      new Promise<SubmitResult>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    typeDraft('hello while hidden');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    // Minimize mid-submit.
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    // Resolve the in-flight submit successfully. The panel must pop back
+    // open so the user actually sees the confirmation — a silent success
+    // while hidden is the worst-of-three outcomes.
+    await act(async () => {
+      release({ ok: true, report_id: 'rep_after_min' });
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/on its way/i),
+    );
+  });
+
+  it('submit failure resolving while minimized pops the panel back open with alert', async () => {
+    let release: (r: SubmitResult) => void = () => undefined;
+    submit.mockReturnValueOnce(
+      new Promise<SubmitResult>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    typeDraft('hello failure');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    await act(async () => {
+      release({
+        ok: false,
+        error: { code: 'INGEST_REJECTED', message: 'quota' },
+      });
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(/quota/i, { selector: '[role="alert"]' }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('"Send another" returns focus to the composer textarea', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_focus' });
+    mount();
+    openPanel();
+    typeDraft('will send');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /send another/i }));
+    });
+    const textarea = getComposer();
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it('close on a success-state panel dismisses without a confirm', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_succ_close' });
+    mount();
+    openPanel();
+    typeDraft('landing');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    // × on the success-state panel: no confirm dialog, panel closes,
+    // next open is empty.
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('close button is disabled while a submit is in flight', async () => {
+    let release: (r: SubmitResult) => void = () => undefined;
+    submit.mockReturnValueOnce(
+      new Promise<SubmitResult>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    typeDraft('pending');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(
+      screen.getByRole('button', { name: /^close$/i }) as HTMLButtonElement,
+    ).toBeDisabled();
+    await act(async () => {
+      release({ ok: true, report_id: 'rep_unblock' });
+      await Promise.resolve();
+    });
+  });
+
+  it('submit rejects → × shows the discard confirm with the draft still populated', async () => {
+    submit.mockRejectedValueOnce(new Error('ingest down'));
+    mount();
+    openPanel();
+    typeDraft('will fail');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    // Status is back to 'error', close should no longer be disabled.
+    expect(
+      screen.getByText(/ingest down/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    const confirm = screen.getByRole('alertdialog', {
+      name: /discard draft/i,
+    });
+    expect(confirm).toBeInTheDocument();
+    // Keep → the draft is still in the composer.
+    fireEvent.click(within(confirm).getByRole('button', { name: /keep/i }));
+    expect(getComposer().value).toBe('will fail');
+  });
+
+  it('Enter+Ctrl/Meta/Alt does not submit (reserved for platform shortcuts)', async () => {
+    mount();
+    openPanel();
+    typeDraft('modifier guard');
+    const textarea = getComposer();
+
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    expect(submit).not.toHaveBeenCalled();
+
+    // Plain Enter still submits.
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_mod' });
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'Enter' });
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('attachment chips use stable keys (removing a middle duplicate-named file keeps survivors)', () => {
+    mount();
+    openPanel();
+
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    const a = new File(['a'], 'log.txt', { type: 'text/plain' });
+    const b = new File(['bb'], 'log.txt', { type: 'text/plain' });
+    const c = new File(['ccc'], 'log.txt', { type: 'text/plain' });
+    // happy-dom FileList: build via DataTransfer
+    const dt = new DataTransfer();
+    dt.items.add(a);
+    dt.items.add(b);
+    dt.items.add(c);
+    fireEvent.change(input, { target: { files: dt.files } });
+
+    const removeButtons = screen.getAllByRole('button', {
+      name: /remove log\.txt/i,
+    });
+    expect(removeButtons).toHaveLength(3);
+
+    // Remove the middle chip. Survivors (0 and 2) must still render.
+    fireEvent.click(removeButtons[1]!);
+    expect(
+      screen.getAllByRole('button', { name: /remove log\.txt/i }),
+    ).toHaveLength(2);
+  });
+
+  it('dark-mode chip background is distinct from the border colour (contrast)', () => {
+    // Pull the dark-mode block out and assert --brw-chip-bg is not the same
+    // as --brw-border — a regression where they match hides the chip's 1px
+    // border in dark mode.
+    const darkBlock = BREVWICK_CSS.match(
+      /@media \(prefers-color-scheme: dark\)[\s\S]*?\n\s*\}\n\s*\}/,
+    );
+    expect(darkBlock).not.toBeNull();
+    const block = darkBlock![0];
+    const borderMatch = block.match(/--brw-border:\s*([^;]+);/);
+    const chipBgMatch = block.match(/--brw-chip-bg:\s*([^;]+);/);
+    expect(borderMatch).not.toBeNull();
+    expect(chipBgMatch).not.toBeNull();
+    expect(chipBgMatch![1]!.trim()).not.toBe(borderMatch![1]!.trim());
+  });
+
+  it('composer textarea carries an accessible name (aria-label)', () => {
+    mount();
+    openPanel();
+    const textarea = getComposer();
+    expect(textarea).toHaveAttribute('aria-label', 'Feedback message');
+  });
+
+  it('disclosure toggle flips aria-expanded in both states', () => {
+    mount();
+    openPanel();
+    const toggle = screen.getByRole('button', {
+      name: /add expected vs actual/i,
+    });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+    const toggleOpen = screen.getByRole('button', {
+      name: /hide expected vs actual/i,
+    });
+    expect(toggleOpen).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Brevwick, BrevwickConfig, SubmitResult } from 'brevwick-sdk';
@@ -30,8 +31,11 @@ vi.mock('brevwick-sdk', async () => {
 
 import { BrevwickProvider } from '../provider';
 import { FeedbackButton, type FeedbackButtonProps } from '../feedback-button';
+import { BREVWICK_CSS, BREVWICK_STYLE_ID } from '../styles';
 
 beforeEach(() => {
+  // happy-dom lacks createObjectURL / revokeObjectURL by default; stub both
+  // so the screenshot preview paths don't throw before the spy hooks in.
   if (typeof URL.createObjectURL !== 'function') {
     (
       URL as unknown as { createObjectURL: (b: Blob) => string }
@@ -62,55 +66,81 @@ afterEach(() => {
   onSubmitSpy.mockReset();
 });
 
+function openPanel(): void {
+  fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
+}
+
+function getComposer(): HTMLTextAreaElement {
+  return screen.getByRole('textbox', {
+    name: /feedback message/i,
+  }) as HTMLTextAreaElement;
+}
+
+function typeDraft(text: string): void {
+  fireEvent.change(getComposer(), { target: { value: text } });
+}
+
 describe('<FeedbackButton>', () => {
-  it('opens the dialog and marks FAB + dialog with data-brevwick-skip', () => {
+  it('renders an anchored panel with data-brevwick-skip on the FAB and panel', () => {
     mount();
     const fab = screen.getByRole('button', { name: /open feedback form/i });
     expect(fab).toHaveAttribute('data-brevwick-skip');
-    fireEvent.click(fab);
+    expect(fab.className).toMatch(/brw-fab/);
+
+    openPanel();
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('data-brevwick-skip');
-    expect(screen.getByText('Send feedback')).toBeInTheDocument();
+    expect(dialog.className).toMatch(/brw-panel/);
+    expect(dialog.className).toMatch(/brw-panel-br/);
+    expect(screen.getByText(/send feedback/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Hi! Tell us what's happening/i),
+    ).toBeInTheDocument();
   });
 
-  it('surfaces a form-level error when title is missing', () => {
+  it('applies the bottom-left position class to FAB and panel', () => {
+    mount({ position: 'bottom-left' });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab-bl/);
+    expect(fab.className).not.toMatch(/brw-fab-br/);
+    openPanel();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/brw-panel-bl/);
+    expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('Enter submits, Shift+Enter inserts a newline', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_enter' });
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
-    expect(screen.getByRole('alert')).toHaveTextContent(/title is required/i);
+    openPanel();
+    const textarea = getComposer();
+
+    // Shift+Enter should not submit — simulate by setting value directly
+    // (happy-dom does not natively translate keydown into insertion).
+    fireEvent.change(textarea, { target: { value: 'line one\nline two' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
     expect(submit).not.toHaveBeenCalled();
-  });
-
-  it('attaches a screenshot by calling sdk.captureScreenshot and shows a thumbnail', async () => {
-    const blob = new Blob(['x'], { type: 'image/png' });
-    captureScreenshot.mockResolvedValueOnce(blob);
-    mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
+    expect(textarea.value).toBe('line one\nline two');
 
     await act(async () => {
-      fireEvent.click(
-        screen.getByRole('button', { name: /attach screenshot/i }),
-      );
+      fireEvent.keyDown(textarea, { key: 'Enter' });
     });
-    expect(captureScreenshot).toHaveBeenCalledTimes(1);
-    expect(screen.getByAltText(/screenshot preview/i)).toBeInTheDocument();
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    const input = submit.mock.calls[0]![0] as {
+      description: string;
+      title?: string;
+    };
+    expect(input.description).toBe('line one\nline two');
+    expect(input.title).toBe('line one');
   });
 
-  it('calls onSubmit with result and closes after 1.5s on success', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+  it('submits via the Send button and shows success + Send another', async () => {
     submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ok' });
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-
-    const titleInput = screen.getAllByRole('textbox')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
+    openPanel();
+    typeDraft('Broken flow');
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
@@ -120,29 +150,38 @@ describe('<FeedbackButton>', () => {
       ok: true,
       report_id: 'rep_ok',
     });
-    expect(screen.getByRole('status')).toHaveTextContent(/report sent/i);
+    // Panel stays open, thread replaced with success state.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(/on its way/i);
+    // Composer is gone in the success state.
+    expect(
+      screen.queryByRole('textbox', { name: /feedback message/i }),
+    ).toBeNull();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500);
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByRole('dialog')).toBeNull();
-    });
+    // "Send another" resets to an empty thread.
+    fireEvent.click(screen.getByRole('button', { name: /send another/i }));
+    const fresh = getComposer();
+    expect(fresh.value).toBe('');
+    expect(screen.queryByRole('status')).toBeNull();
   });
 
-  it('shows an inline error and keeps the dialog open on failure', async () => {
+  it('does not submit when the composer is empty (send button disabled)', () => {
+    mount();
+    openPanel();
+    const sendButton = screen.getByRole('button', { name: /^send$/i });
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(sendButton);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an inline error and keeps the panel open on failure', async () => {
     submit.mockResolvedValueOnce({
       ok: false,
       error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
     });
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-
-    const titleInput = screen.getAllByRole('textbox')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'Broken flow' } });
+    openPanel();
+    typeDraft('Broken flow');
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
@@ -161,15 +200,187 @@ describe('<FeedbackButton>', () => {
     };
     submit.mockResolvedValueOnce(failure);
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    const titleInput = screen.getAllByRole('textbox')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'x' } });
+    openPanel();
+    typeDraft('x');
+
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
     expect(onSubmitSpy).toHaveBeenCalledWith(failure);
+  });
+
+  it('surfaces a recovery message when submit() rejects (chunk load failure)', async () => {
+    submit.mockRejectedValueOnce(new Error('chunk load failed'));
+    mount();
+    openPanel();
+    typeDraft('oops');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    expect(
+      screen.getByText(/chunk load failed/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('attaches a screenshot via captureScreenshot and renders a chip', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    openPanel();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+    expect(captureScreenshot).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: /remove screenshot/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('derives the screenshot attachment extension from its MIME type', async () => {
+    const blob = new Blob(['x'], { type: 'image/webp' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ext' });
+    mount();
+    openPanel();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+    typeDraft('with screenshot');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    const input = submit.mock.calls[0]![0] as {
+      attachments: Array<{ blob: Blob; filename: string }>;
+    };
+    expect(input.attachments[0]!.filename).toBe('screenshot.webp');
+  });
+
+  it('surfaces an error in the panel when captureScreenshot rejects', async () => {
+    captureScreenshot.mockRejectedValueOnce(new Error('canvas tainted'));
+    mount();
+    openPanel();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+
+    expect(
+      screen.getByText(/canvas tainted/i, { selector: '[role="alert"]' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove screenshot/i }),
+    ).toBeNull();
+  });
+
+  it('minimize preserves draft and attachments across reopen', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    openPanel();
+    typeDraft('half-typed message');
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /attach screenshot/i }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('half-typed message');
+    expect(
+      screen.getByRole('button', { name: /remove screenshot/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('close when clean dismisses immediately and clears state', () => {
+    mount();
+    openPanel();
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('');
+  });
+
+  it('close when dirty shows a confirm; Discard clears, Keep preserves', () => {
+    mount();
+    openPanel();
+    typeDraft('draft-content');
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    // Panel remains open, confirm inline renders.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const confirm = screen.getByRole('alertdialog', {
+      name: /discard draft/i,
+    });
+    expect(
+      within(confirm).getByRole('button', { name: /keep/i }),
+    ).toBeInTheDocument();
+
+    // Keep → confirm disappears, draft remains.
+    fireEvent.click(within(confirm).getByRole('button', { name: /keep/i }));
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(getComposer().value).toBe('draft-content');
+
+    // Close again → Discard → panel closes and reopens empty.
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+    openPanel();
+    expect(getComposer().value).toBe('');
+  });
+
+  it('expected/actual are hidden by default and revealed via disclosure', () => {
+    mount();
+    openPanel();
+    expect(screen.queryByRole('textbox', { name: /expected/i })).toBeNull();
+    fireEvent.click(
+      screen.getByRole('button', { name: /add expected vs actual/i }),
+    );
+    expect(
+      screen.getByRole('textbox', { name: /expected/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /actual/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes expected/actual into the submit payload when filled', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ea' });
+    mount();
+    openPanel();
+    typeDraft('bug');
+    fireEvent.click(
+      screen.getByRole('button', { name: /add expected vs actual/i }),
+    );
+    fireEvent.change(screen.getByRole('textbox', { name: /expected/i }), {
+      target: { value: 'should succeed' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /actual/i }), {
+      target: { value: 'failed' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as {
+      expected?: string;
+      actual?: string;
+    };
+    expect(input.expected).toBe('should succeed');
+    expect(input.actual).toBe('failed');
   });
 
   it('renders nothing when hidden', () => {
@@ -183,19 +394,12 @@ describe('<FeedbackButton>', () => {
     ).toBeNull();
   });
 
-  it('renders a disabled FAB when disabled prop is true and does not open the dialog', () => {
+  it('renders a disabled FAB when disabled prop is true and does not open the panel', () => {
     mount({ disabled: true });
     const fab = screen.getByRole('button', { name: /open feedback form/i });
     expect(fab).toBeDisabled();
     fireEvent.click(fab);
     expect(screen.queryByRole('dialog')).toBeNull();
-  });
-
-  it('applies the brw-fab-bl class when position is bottom-left', () => {
-    mount({ position: 'bottom-left' });
-    const fab = screen.getByRole('button', { name: /open feedback form/i });
-    expect(fab.className).toMatch(/brw-fab-bl/);
-    expect(fab.className).not.toMatch(/brw-fab-br/);
   });
 
   it('revokes the screenshot object URL on unmount', async () => {
@@ -209,9 +413,7 @@ describe('<FeedbackButton>', () => {
       .mockImplementation(() => undefined);
 
     const { unmount } = mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
+    openPanel();
     await act(async () => {
       fireEvent.click(
         screen.getByRole('button', { name: /attach screenshot/i }),
@@ -226,123 +428,60 @@ describe('<FeedbackButton>', () => {
     revokeObjectURL.mockRestore();
   });
 
-  it('clears form fields after a success + auto-close when reopened', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_reset' });
+  it('exposes a polite aria-live log for the thread', () => {
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(log).toHaveAttribute('aria-live', 'polite');
+  });
 
-    const textboxes = screen.getAllByRole('textbox');
-    fireEvent.change(textboxes[0]!, { target: { value: 'title-a' } });
-    fireEvent.change(textboxes[1]!, { target: { value: 'desc-a' } });
-
+  it('thread log switches to confirmation after success for assistive tech', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_live' });
+    mount();
+    openPanel();
+    typeDraft('x');
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1500);
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByRole('dialog')).toBeNull();
-    });
-
-    // Reopen
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    const reopenedBoxes = screen.getAllByRole('textbox');
-    expect((reopenedBoxes[0] as HTMLInputElement).value).toBe('');
-    expect((reopenedBoxes[1] as HTMLTextAreaElement).value).toBe('');
-    // Success banner should be cleared too
-    expect(screen.queryByRole('status')).toBeNull();
+    const log = screen.getByRole('log', { name: /confirmation/i });
+    expect(log).toHaveAttribute('aria-live', 'polite');
   });
 
-  it('clears prior form state when the dialog is closed manually and reopened', () => {
+  it('disables composer send + icons while submitting (guards double-send)', async () => {
+    // Pending submission keeps status === 'submitting' indefinitely for the assertion.
+    let release: (r: SubmitResult) => void = () => undefined;
+    submit.mockReturnValueOnce(
+      new Promise<SubmitResult>((resolve) => {
+        release = resolve;
+      }),
+    );
     mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    const textboxes = screen.getAllByRole('textbox');
-    fireEvent.change(textboxes[0]!, { target: { value: 'stale-title' } });
-    fireEvent.change(textboxes[1]!, { target: { value: 'stale-desc' } });
-
-    // Close via Cancel
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(screen.queryByRole('dialog')).toBeNull();
-
-    // Reopen
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    const reopenedBoxes = screen.getAllByRole('textbox');
-    expect((reopenedBoxes[0] as HTMLInputElement).value).toBe('');
-    expect((reopenedBoxes[1] as HTMLTextAreaElement).value).toBe('');
-  });
-
-  it('surfaces an error in the dialog when captureScreenshot rejects', async () => {
-    captureScreenshot.mockRejectedValueOnce(new Error('canvas tainted'));
-    mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('button', { name: /attach screenshot/i }),
-      );
-    });
-
-    expect(
-      screen.getByText(/canvas tainted/i, { selector: '[role="alert"]' }),
-    ).toBeInTheDocument();
-    // No thumbnail was rendered
-    expect(screen.queryByAltText(/screenshot preview/i)).toBeNull();
-  });
-
-  it('derives the screenshot attachment extension from its MIME type', async () => {
-    const blob = new Blob(['x'], { type: 'image/webp' });
-    captureScreenshot.mockResolvedValueOnce(blob);
-    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_ext' });
-    mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    await act(async () => {
-      fireEvent.click(
-        screen.getByRole('button', { name: /attach screenshot/i }),
-      );
-    });
-    const titleInput = screen.getAllByRole('textbox')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'with screenshot' } });
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
-    });
-
-    const input = submit.mock.calls[0]![0] as {
-      attachments: Array<{ blob: Blob; filename: string }>;
-    };
-    expect(input.attachments[0]!.filename).toBe('screenshot.webp');
-  });
-
-  it('surfaces a recovery message when submit() rejects (chunk load failure)', async () => {
-    submit.mockRejectedValueOnce(new Error('chunk load failed'));
-    mount();
-    fireEvent.click(
-      screen.getByRole('button', { name: /open feedback form/i }),
-    );
-    const titleInput = screen.getAllByRole('textbox')[0]!;
-    fireEvent.change(titleInput, { target: { value: 'oops' } });
+    openPanel();
+    typeDraft('x');
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
 
     expect(
-      screen.getByText(/chunk load failed/i, { selector: '[role="alert"]' }),
-    ).toBeInTheDocument();
-    // Dialog stays open so the user can retry
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+      screen.getByRole('button', { name: /^send$/i }) as HTMLButtonElement,
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /attach screenshot/i }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      release({ ok: true, report_id: 'rep_done' });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+  });
+
+  it('bundles a slide-up animation with a prefers-reduced-motion override', () => {
+    // Guard against stripping the reduced-motion guard from the bundled CSS.
+    expect(BREVWICK_CSS).toMatch(/@keyframes brw-slide-up/);
+    expect(BREVWICK_CSS).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*\.brw-panel[^{]*\{[^}]*animation:\s*none/,
+    );
+    expect(BREVWICK_STYLE_ID).toBe('brevwick-react-styles');
   });
 });

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -7,7 +7,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
-  type FormEvent,
+  type KeyboardEvent,
   type ReactElement,
   type ReactNode,
 } from 'react';
@@ -37,23 +37,17 @@ export interface FeedbackButtonProps {
   onSubmit?: (result: SubmitResult) => void;
 }
 
-const AUTO_CLOSE_MS = 1500;
+const GREETING =
+  "Hi! Tell us what's happening. A screenshot helps if you have one.";
 
-/**
- * `useLayoutEffect` is a no-op on the server (React warns but does not run
- * it). Alias to `useEffect` on the server so we can safely call it in code
- * that might hydrate without triggering a warning. The module-only SSR-safe
- * pattern.
- */
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
- * Module-level guard so the `<style>` tag is inserted into the document at
- * most once per session, regardless of how many `<FeedbackButton>` instances
- * mount. React does not dedupe `<style>` tags by `id`, so the previous
- * render-time approach could produce duplicate style nodes in consumers who
- * render multiple buttons.
+ * Module-level guard so the <style> tag is inserted at most once per session
+ * regardless of how many <FeedbackButton>s mount. React does not dedupe
+ * `<style>` by id, so render-time injection would produce duplicates for
+ * consumers who render multiple buttons.
  */
 let hasInjectedStyles = false;
 
@@ -73,6 +67,17 @@ function useBrevwickStyles(): void {
   }, []);
 }
 
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface ScreenshotAttachment {
+  readonly blob: Blob;
+  readonly url: string;
+}
+
 export function FeedbackButton({
   position = 'bottom-right',
   disabled = false,
@@ -83,30 +88,26 @@ export function FeedbackButton({
 }: FeedbackButtonProps): ReactElement | null {
   const { submit, captureScreenshot, status, reset } = useFeedback();
   const [open, setOpen] = useState(false);
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+  const [draft, setDraft] = useState('');
   const [expected, setExpected] = useState('');
   const [actual, setActual] = useState('');
-  const [screenshot, setScreenshot] = useState<Blob | null>(null);
-  const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null);
+  const [showExtras, setShowExtras] = useState(false);
+  const [screenshot, setScreenshot] = useState<ScreenshotAttachment | null>(
+    null,
+  );
   const [files, setFiles] = useState<File[]>([]);
-  const [titleError, setTitleError] = useState<string | null>(null);
+  const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [succeeded, setSucceeded] = useState(false);
   const mountedRef = useRef(true);
   const screenshotUrlRef = useRef<string | null>(null);
 
   useBrevwickStyles();
 
-  // Track mounted state so async handlers can bail out after unmount.
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      if (closeTimerRef.current) {
-        clearTimeout(closeTimerRef.current);
-        closeTimerRef.current = null;
-      }
       if (screenshotUrlRef.current) {
         URL.revokeObjectURL(screenshotUrlRef.current);
         screenshotUrlRef.current = null;
@@ -114,51 +115,78 @@ export function FeedbackButton({
     };
   }, []);
 
-  // Keep ref in sync so unmount cleanup revokes the current URL without
-  // needing a `screenshotUrl` dependency (which would retrigger the effect).
   useEffect(() => {
-    screenshotUrlRef.current = screenshotUrl;
-  }, [screenshotUrl]);
+    screenshotUrlRef.current = screenshot?.url ?? null;
+  }, [screenshot]);
 
-  const resetForm = useCallback(() => {
-    setTitle('');
-    setDescription('');
+  const hasContent =
+    draft.trim().length > 0 ||
+    expected.length > 0 ||
+    actual.length > 0 ||
+    screenshot !== null ||
+    files.length > 0;
+
+  const resetAll = useCallback(() => {
+    setDraft('');
     setExpected('');
     setActual('');
-    setScreenshot(null);
-    setScreenshotUrl((prev) => {
-      if (prev) URL.revokeObjectURL(prev);
+    setShowExtras(false);
+    setScreenshot((prev) => {
+      if (prev) URL.revokeObjectURL(prev.url);
       return null;
     });
     setFiles([]);
-    setTitleError(null);
+    setConfirmClose(false);
     setSubmitError(null);
+    setSucceeded(false);
     reset();
   }, [reset]);
 
+  const handleFullClose = useCallback(() => {
+    setOpen(false);
+    resetAll();
+  }, [resetAll]);
+
+  const handleMinimize = useCallback(() => {
+    setOpen(false);
+    setConfirmClose(false);
+    setSubmitError(null);
+  }, []);
+
+  // Radix routes Esc, overlay clicks, and parent setOpen through onOpenChange.
+  // Map a programmatic close-to-false to 'minimize' semantics so Esc preserves
+  // the user's draft. The × button handles the dirty-confirm flow directly.
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      setOpen(next);
-      if (!next) {
-        if (closeTimerRef.current) {
-          clearTimeout(closeTimerRef.current);
-          closeTimerRef.current = null;
-        }
-        resetForm();
+      if (next) {
+        setOpen(true);
+        return;
       }
+      handleMinimize();
     },
-    [resetForm],
+    [handleMinimize],
   );
+
+  const handleCloseClick = useCallback(() => {
+    if (succeeded) {
+      handleFullClose();
+      return;
+    }
+    if (hasContent) {
+      setConfirmClose(true);
+      return;
+    }
+    handleFullClose();
+  }, [succeeded, hasContent, handleFullClose]);
 
   const handleCaptureScreenshot = useCallback(async () => {
     setSubmitError(null);
     try {
       const blob = await captureScreenshot();
       if (!mountedRef.current) return;
-      setScreenshot(blob);
-      setScreenshotUrl((prev) => {
-        if (prev) URL.revokeObjectURL(prev);
-        return URL.createObjectURL(blob);
+      setScreenshot((prev) => {
+        if (prev) URL.revokeObjectURL(prev.url);
+        return { blob, url: URL.createObjectURL(blob) };
       });
     } catch (err) {
       if (!mountedRef.current) return;
@@ -169,83 +197,73 @@ export function FeedbackButton({
   }, [captureScreenshot]);
 
   const handleFiles = useCallback((list: FileList | null) => {
-    if (!list) return;
-    setFiles(Array.from(list));
+    if (!list || list.length === 0) return;
+    setFiles((prev) => [...prev, ...Array.from(list)]);
   }, []);
 
-  const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      // Guard against double-submit via Enter-in-textarea while the submit
-      // button is disabled.
-      if (status === 'submitting') return;
-      setSubmitError(null);
-      if (!title.trim()) {
-        setTitleError('Title is required');
-        return;
-      }
-      setTitleError(null);
+  const removeScreenshot = useCallback(() => {
+    setScreenshot((prev) => {
+      if (prev) URL.revokeObjectURL(prev.url);
+      return null;
+    });
+  }, []);
 
-      const attachments: Array<Blob | FeedbackAttachment> = [];
-      if (screenshot) {
-        // Derive the extension from the blob's MIME (the SDK produces
-        // `image/webp`) so the attachment's filename matches its content.
-        const ext = screenshot.type.split('/')[1]?.split('+')[0] || 'webp';
-        attachments.push({ blob: screenshot, filename: `screenshot.${ext}` });
-      }
-      for (const f of files) attachments.push({ blob: f, filename: f.name });
+  const removeFile = useCallback((index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
-      const input: FeedbackInput = {
-        title: title.trim(),
-        description,
-        expected: expected || undefined,
-        actual: actual || undefined,
-        attachments: attachments.length ? attachments : undefined,
-      };
+  const doSubmit = useCallback(async () => {
+    if (status === 'submitting') return;
+    if (!draft.trim()) {
+      setSubmitError('Please describe what happened.');
+      return;
+    }
+    setSubmitError(null);
 
-      try {
-        const result = await submit(input);
-        if (!mountedRef.current) return;
-        onSubmit?.(result);
-        if (result.ok) {
-          closeTimerRef.current = setTimeout(() => {
-            closeTimerRef.current = null;
-            if (!mountedRef.current) return;
-            setOpen(false);
-            resetForm();
-          }, AUTO_CLOSE_MS);
-        } else {
-          setSubmitError(result.error.message);
-        }
-      } catch (err) {
-        // `submit` only rejects when the lazy submit chunk fails to load
-        // (deploy mismatch / offline). Surface a generic message so the
-        // dialog can recover and the user can retry.
-        if (!mountedRef.current) return;
-        const message =
-          err instanceof Error && err.message
-            ? err.message
-            : 'We could not submit your feedback. Please try again.';
-        setSubmitError(message);
+    const attachments: Array<Blob | FeedbackAttachment> = [];
+    if (screenshot) {
+      const ext = screenshot.blob.type.split('/')[1]?.split('+')[0] || 'webp';
+      attachments.push({
+        blob: screenshot.blob,
+        filename: `screenshot.${ext}`,
+      });
+    }
+    for (const f of files) attachments.push({ blob: f, filename: f.name });
+
+    const trimmed = draft.trim();
+    const derivedTitle = trimmed.split('\n', 1)[0]!.slice(0, 120);
+    const input: FeedbackInput = {
+      title: derivedTitle,
+      description: trimmed,
+      expected: expected.trim() || undefined,
+      actual: actual.trim() || undefined,
+      attachments: attachments.length ? attachments : undefined,
+    };
+
+    try {
+      const result = await submit(input);
+      if (!mountedRef.current) return;
+      onSubmit?.(result);
+      if (result.ok) {
+        setSucceeded(true);
+      } else {
+        setSubmitError(result.error.message);
       }
-    },
-    [
-      actual,
-      description,
-      expected,
-      files,
-      onSubmit,
-      resetForm,
-      screenshot,
-      status,
-      submit,
-      title,
-    ],
-  );
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : 'We could not submit your feedback. Please try again.';
+      setSubmitError(message);
+    }
+  }, [actual, draft, expected, files, onSubmit, screenshot, status, submit]);
 
   if (hidden) return null;
 
-  const posClass = position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  const fabPosClass = position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  const panelPosClass =
+    position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
   const rootClassName = ['brw-root', className].filter(Boolean).join(' ');
 
   return (
@@ -254,134 +272,502 @@ export function FeedbackButton({
         <button
           type="button"
           data-brevwick-skip=""
-          className={`${rootClassName} brw-fab ${posClass}`}
+          className={`${rootClassName} brw-fab ${fabPosClass}`}
           disabled={disabled}
           aria-label="Open feedback form"
         >
+          <ChatIcon />
           {label}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay
-          data-brevwick-skip=""
-          className={`${rootClassName} brw-overlay`}
-        />
         <Dialog.Content
           data-brevwick-skip=""
-          className={`${rootClassName} brw-dialog`}
+          className={`${rootClassName} brw-panel ${panelPosClass}`}
           aria-describedby={undefined}
+          onInteractOutside={(e) => {
+            // Overlay-click semantics: treat the same as Esc (minimize, preserve).
+            // Radix already routes through onOpenChange, so no extra state work.
+            e.preventDefault();
+            handleMinimize();
+          }}
         >
-          <Dialog.Title className="brw-title">Send feedback</Dialog.Title>
-          <form onSubmit={handleSubmit} noValidate>
-            <label className="brw-field">
-              <span className="brw-label">Title *</span>
-              <input
-                className="brw-input"
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                aria-invalid={titleError ? 'true' : undefined}
-                aria-describedby={titleError ? 'brw-title-err' : undefined}
-              />
-              {titleError && (
-                <span id="brw-title-err" className="brw-error" role="alert">
-                  {titleError}
-                </span>
-              )}
-            </label>
-            <label className="brw-field">
-              <span className="brw-label">Description</span>
-              <textarea
-                className="brw-textarea"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-              />
-            </label>
-            <label className="brw-field">
-              <span className="brw-label">Expected</span>
-              <textarea
-                className="brw-textarea"
-                value={expected}
-                onChange={(e) => setExpected(e.target.value)}
-              />
-            </label>
-            <label className="brw-field">
-              <span className="brw-label">Actual</span>
-              <textarea
-                className="brw-textarea"
-                value={actual}
-                onChange={(e) => setActual(e.target.value)}
-              />
-            </label>
-            <div className="brw-field">
-              <div className="brw-row">
-                <button
-                  type="button"
-                  className="brw-btn"
-                  onClick={handleCaptureScreenshot}
-                >
-                  Attach screenshot
-                </button>
-                <label className="brw-btn brw-file-label">
-                  Attach file
-                  <input
-                    type="file"
-                    multiple
-                    className="brw-file-input"
-                    onChange={(e) => handleFiles(e.target.files)}
-                  />
-                </label>
-              </div>
-              {screenshotUrl && screenshot && (
-                <div className="brw-thumb">
-                  <img src={screenshotUrl} alt="Screenshot preview" />
-                  <span>{formatSize(screenshot.size)}</span>
-                </div>
-              )}
-              {files.length > 0 && (
-                <div className="brw-files">
-                  {files
-                    .map((f) => `${f.name} (${formatSize(f.size)})`)
-                    .join(', ')}
-                </div>
-              )}
-            </div>
-            {submitError && (
-              <div className="brw-error" role="alert">
-                {submitError}
-              </div>
-            )}
-            {status === 'success' && (
-              <div className="brw-success" role="status">
-                Thanks — report sent
-              </div>
-            )}
-            <div className="brw-footer">
-              <Dialog.Close asChild>
-                <button type="button" className="brw-btn">
-                  Cancel
-                </button>
-              </Dialog.Close>
-              <button
-                type="submit"
-                className="brw-btn brw-btn-primary"
-                disabled={status === 'submitting'}
-              >
-                {status === 'submitting' && (
-                  <span className="brw-spinner" aria-hidden="true" />
-                )}
-                {status === 'submitting' ? 'Sending…' : 'Send'}
-              </button>
-            </div>
-          </form>
+          <PanelHeader onMinimize={handleMinimize} onClose={handleCloseClick} />
+          {succeeded ? (
+            <SuccessState onSendAnother={resetAll} />
+          ) : (
+            <Thread
+              greeting={GREETING}
+              draft={draft}
+              screenshot={screenshot}
+              files={files}
+              showExtras={showExtras}
+              expected={expected}
+              actual={actual}
+              confirmClose={confirmClose}
+              submitError={submitError}
+              status={status}
+              onToggleExtras={() => setShowExtras((v) => !v)}
+              onExpectedChange={setExpected}
+              onActualChange={setActual}
+              onRemoveScreenshot={removeScreenshot}
+              onRemoveFile={removeFile}
+              onConfirmDiscard={handleFullClose}
+              onCancelClose={() => setConfirmClose(false)}
+            />
+          )}
+          {!succeeded && (
+            <Composer
+              draft={draft}
+              submitting={status === 'submitting'}
+              onDraftChange={setDraft}
+              onSubmit={doSubmit}
+              onAttachScreenshot={handleCaptureScreenshot}
+              onAttachFiles={handleFiles}
+            />
+          )}
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
   );
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+interface PanelHeaderProps {
+  onMinimize: () => void;
+  onClose: () => void;
+}
+
+function PanelHeader({ onMinimize, onClose }: PanelHeaderProps): ReactElement {
+  return (
+    <div className="brw-panel-header">
+      <span className="brw-panel-avatar" aria-hidden="true">
+        B
+      </span>
+      <Dialog.Title className="brw-panel-title">Send feedback</Dialog.Title>
+      <button
+        type="button"
+        className="brw-icon-btn"
+        aria-label="Minimize"
+        onClick={onMinimize}
+      >
+        <MinimizeIcon />
+      </button>
+      <button
+        type="button"
+        className="brw-icon-btn"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+}
+
+interface ThreadProps {
+  greeting: string;
+  draft: string;
+  screenshot: ScreenshotAttachment | null;
+  files: readonly File[];
+  showExtras: boolean;
+  expected: string;
+  actual: string;
+  confirmClose: boolean;
+  submitError: string | null;
+  status: 'idle' | 'submitting' | 'success' | 'error';
+  onToggleExtras: () => void;
+  onExpectedChange: (v: string) => void;
+  onActualChange: (v: string) => void;
+  onRemoveScreenshot: () => void;
+  onRemoveFile: (index: number) => void;
+  onConfirmDiscard: () => void;
+  onCancelClose: () => void;
+}
+
+function Thread({
+  greeting,
+  draft,
+  screenshot,
+  files,
+  showExtras,
+  expected,
+  actual,
+  confirmClose,
+  submitError,
+  status,
+  onToggleExtras,
+  onExpectedChange,
+  onActualChange,
+  onRemoveScreenshot,
+  onRemoveFile,
+  onConfirmDiscard,
+  onCancelClose,
+}: ThreadProps): ReactElement {
+  const trimmed = draft.trim();
+  return (
+    <div
+      className="brw-thread"
+      role="log"
+      aria-live="polite"
+      aria-label="Conversation"
+    >
+      <AssistantBubble>{greeting}</AssistantBubble>
+      {trimmed.length > 0 && <UserBubble>{draft}</UserBubble>}
+      {screenshot && (
+        <AttachmentChip
+          name="screenshot"
+          size={screenshot.blob.size}
+          previewUrl={screenshot.url}
+          onRemove={onRemoveScreenshot}
+        />
+      )}
+      {files.map((f, i) => (
+        <AttachmentChip
+          key={`${f.name}-${i}`}
+          name={f.name}
+          size={f.size}
+          onRemove={() => onRemoveFile(i)}
+        />
+      ))}
+      <DisclosureExpectedActual
+        open={showExtras}
+        expected={expected}
+        actual={actual}
+        onToggle={onToggleExtras}
+        onExpectedChange={onExpectedChange}
+        onActualChange={onActualChange}
+      />
+      {submitError && (
+        <div className="brw-error" role="alert">
+          {submitError}
+        </div>
+      )}
+      {status === 'submitting' && (
+        <AssistantBubble>
+          <span className="brw-spinner" aria-hidden="true" /> Sending…
+        </AssistantBubble>
+      )}
+      {confirmClose && (
+        <div
+          className="brw-confirm"
+          role="alertdialog"
+          aria-label="Discard draft?"
+        >
+          <span className="brw-confirm-msg">Discard your feedback?</span>
+          <button type="button" className="brw-btn" onClick={onCancelClose}>
+            Keep
+          </button>
+          <button
+            type="button"
+            className="brw-btn brw-btn-primary"
+            onClick={onConfirmDiscard}
+          >
+            Discard
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AssistantBubble({ children }: { children: ReactNode }): ReactElement {
+  return <div className="brw-bubble brw-bubble--assistant">{children}</div>;
+}
+
+function UserBubble({ children }: { children: ReactNode }): ReactElement {
+  return <div className="brw-bubble brw-bubble--user">{children}</div>;
+}
+
+interface AttachmentChipProps {
+  name: string;
+  size: number;
+  previewUrl?: string;
+  onRemove: () => void;
+}
+
+function AttachmentChip({
+  name,
+  size,
+  previewUrl,
+  onRemove,
+}: AttachmentChipProps): ReactElement {
+  return (
+    <div className="brw-chip">
+      {previewUrl && <img src={previewUrl} alt="" />}
+      <span className="brw-chip-name">{name}</span>
+      <span className="brw-chip-size">{formatSize(size)}</span>
+      <button
+        type="button"
+        className="brw-chip-remove"
+        aria-label={`Remove ${name}`}
+        onClick={onRemove}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+interface DisclosureProps {
+  open: boolean;
+  expected: string;
+  actual: string;
+  onToggle: () => void;
+  onExpectedChange: (v: string) => void;
+  onActualChange: (v: string) => void;
+}
+
+function DisclosureExpectedActual({
+  open,
+  expected,
+  actual,
+  onToggle,
+  onExpectedChange,
+  onActualChange,
+}: DisclosureProps): ReactElement {
+  const panelId = 'brw-extras-panel';
+  return (
+    <>
+      <button
+        type="button"
+        className="brw-disclosure"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={onToggle}
+      >
+        {open ? 'Hide expected vs actual' : 'Add expected vs actual'}
+      </button>
+      {open && (
+        <div id={panelId} className="brw-disclosure-panel">
+          <label>
+            <span className="brw-disclosure-label">Expected</span>
+            <textarea
+              className="brw-disclosure-input"
+              rows={2}
+              value={expected}
+              onChange={(e) => onExpectedChange(e.target.value)}
+            />
+          </label>
+          <label>
+            <span className="brw-disclosure-label">Actual</span>
+            <textarea
+              className="brw-disclosure-input"
+              rows={2}
+              value={actual}
+              onChange={(e) => onActualChange(e.target.value)}
+            />
+          </label>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface ComposerProps {
+  draft: string;
+  submitting: boolean;
+  onDraftChange: (v: string) => void;
+  onSubmit: () => void;
+  onAttachScreenshot: () => void;
+  onAttachFiles: (list: FileList | null) => void;
+}
+
+function Composer({
+  draft,
+  submitting,
+  onDraftChange,
+  onSubmit,
+  onAttachScreenshot,
+  onAttachFiles,
+}: ComposerProps): ReactElement {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Autogrow between ~1 and ~5 rows. Max-height from CSS bounds it; measuring
+  // scrollHeight each keystroke is cheap next to React's own render cost.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, [draft]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="brw-composer">
+      <button
+        type="button"
+        className="brw-icon-btn"
+        aria-label="Attach screenshot"
+        onClick={onAttachScreenshot}
+        disabled={submitting}
+      >
+        <CameraIcon />
+      </button>
+      <label className="brw-icon-btn" aria-label="Attach file">
+        <PaperclipIcon />
+        <input
+          type="file"
+          multiple
+          className="brw-file-input"
+          onChange={(e) => {
+            onAttachFiles(e.target.files);
+            e.target.value = '';
+          }}
+          disabled={submitting}
+        />
+      </label>
+      <textarea
+        ref={textareaRef}
+        className="brw-composer-input"
+        rows={1}
+        placeholder="Describe the bug or feedback…"
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label="Feedback message"
+      />
+      <button
+        type="button"
+        className="brw-send-btn"
+        aria-label="Send"
+        disabled={submitting || draft.trim().length === 0}
+        onClick={onSubmit}
+      >
+        <SendIcon />
+      </button>
+    </div>
+  );
+}
+
+interface SuccessStateProps {
+  onSendAnother: () => void;
+}
+
+function SuccessState({ onSendAnother }: SuccessStateProps): ReactElement {
+  return (
+    <div
+      className="brw-thread"
+      role="log"
+      aria-live="polite"
+      aria-label="Confirmation"
+    >
+      <div className="brw-success-wrap">
+        <div className="brw-bubble brw-bubble--success" role="status">
+          Thanks — your report is on its way.
+        </div>
+        <button
+          type="button"
+          className="brw-btn brw-btn-primary"
+          onClick={onSendAnother}
+        >
+          Send another
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ChatIcon(): ReactElement {
+  return (
+    <svg
+      className="brw-fab-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z" />
+    </svg>
+  );
+}
+
+function MinimizeIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 14h14" />
+    </svg>
+  );
+}
+
+function CloseIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  );
+}
+
+function CameraIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 7h4l2-3h6l2 3h4v12H3z" />
+      <circle cx="12" cy="13" r="4" />
+    </svg>
+  );
+}
+
+function PaperclipIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 10.5l-8.5 8.5a5 5 0 0 1-7-7l9-9a3.5 3.5 0 0 1 5 5l-9 9a2 2 0 0 1-3-3l7.5-7.5" />
+    </svg>
+  );
+}
+
+function SendIcon(): ReactElement {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 20l16-8L4 4l2 8-2 8z" />
+      <path d="M6 12h14" />
+    </svg>
+  );
 }

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
@@ -249,11 +250,14 @@ export function FeedbackButton({
     for (const { file } of files)
       attachments.push({ blob: file, filename: file.name });
 
-    const trimmed = draft.trim();
-    const derivedTitle = trimmed.split('\n', 1)[0]!.slice(0, 120);
+    // Submit what the user actually sees in their bubble — trimming here
+    // would drop the user's intentional whitespace/newlines on the wire.
+    // `draft.trim().length > 0` above already rejects the whitespace-only
+    // case; for title derivation we still want the first non-empty line.
+    const derivedTitle = draft.trim().split('\n', 1)[0]!.slice(0, 120);
     const input: FeedbackInput = {
       title: derivedTitle,
-      description: trimmed,
+      description: draft,
       expected: expected.trim() || undefined,
       actual: actual.trim() || undefined,
       attachments: attachments.length ? attachments : undefined,
@@ -505,24 +509,49 @@ function Thread({
         </AssistantBubble>
       )}
       {confirmClose && (
-        <div
-          className="brw-confirm"
-          role="alertdialog"
-          aria-label="Discard draft?"
-        >
-          <span className="brw-confirm-msg">Discard your feedback?</span>
-          <button type="button" className="brw-btn" onClick={onCancelClose}>
-            Keep
-          </button>
-          <button
-            type="button"
-            className="brw-btn brw-btn-primary"
-            onClick={onConfirmDiscard}
-          >
-            Discard
-          </button>
-        </div>
+        <DiscardConfirm onCancel={onCancelClose} onConfirm={onConfirmDiscard} />
       )}
+    </div>
+  );
+}
+
+interface DiscardConfirmProps {
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Inline `role="alert"` confirm — not a true modal dialog. Focus moves to
+ * "Keep" on appearance so a keyboard user can dismiss with Enter without
+ * having to Tab through the surrounding chrome; "Keep" is the non-destructive
+ * default so an accidental Enter preserves the draft.
+ */
+function DiscardConfirm({
+  onCancel,
+  onConfirm,
+}: DiscardConfirmProps): ReactElement {
+  const keepRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    keepRef.current?.focus();
+  }, []);
+  return (
+    <div className="brw-confirm" role="alert" aria-label="Discard draft?">
+      <span className="brw-confirm-msg">Discard your feedback?</span>
+      <button
+        ref={keepRef}
+        type="button"
+        className="brw-btn"
+        onClick={onCancel}
+      >
+        Keep
+      </button>
+      <button
+        type="button"
+        className="brw-btn brw-btn-primary"
+        onClick={onConfirm}
+      >
+        Discard
+      </button>
     </div>
   );
 }
@@ -582,7 +611,9 @@ function DisclosureExpectedActual({
   onExpectedChange,
   onActualChange,
 }: DisclosureProps): ReactElement {
-  const panelId = 'brw-extras-panel';
+  // Per-instance id so rendering multiple <FeedbackButton>s (or two panels
+  // mid-animation) doesn't collide on a shared DOM id and break aria-controls.
+  const panelId = useId();
   return (
     <>
       <button
@@ -680,11 +711,12 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
         >
           <CameraIcon />
         </button>
-        <label className="brw-icon-btn" aria-label="Attach file">
+        <label className="brw-icon-btn">
           <PaperclipIcon />
           <input
             type="file"
             multiple
+            aria-label="Attach file"
             className="brw-file-input"
             onChange={(e) => {
               onAttachFiles(e.target.files);

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -2,8 +2,10 @@
 
 import * as Dialog from '@radix-ui/react-dialog';
 import {
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useLayoutEffect,
   useRef,
   useState,
@@ -16,8 +18,12 @@ import type {
   FeedbackInput,
   SubmitResult,
 } from 'brevwick-sdk';
-import { useFeedback } from './use-feedback';
-import { BREVWICK_CSS, BREVWICK_STYLE_ID } from './styles';
+import { useFeedback, type FeedbackStatus } from './use-feedback';
+import {
+  BREVWICK_CSS,
+  BREVWICK_STYLE_ID,
+  COMPOSER_MAX_HEIGHT_PX,
+} from './styles';
 
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.
@@ -44,26 +50,20 @@ const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
- * Module-level guard so the <style> tag is inserted at most once per session
- * regardless of how many <FeedbackButton>s mount. React does not dedupe
- * `<style>` by id, so render-time injection would produce duplicates for
- * consumers who render multiple buttons.
+ * Injects the bundled <style> tag on first mount. The DOM probe by id is
+ * the single source of truth: React does not dedupe `<style>` by id, so the
+ * guard prevents duplicates when multiple <FeedbackButton>s mount, and it is
+ * robust under Fast Refresh / HMR (which would otherwise read a stale
+ * module-level flag against a teardown'd style node).
  */
-let hasInjectedStyles = false;
-
 function useBrevwickStyles(): void {
   useIsomorphicLayoutEffect(() => {
-    if (hasInjectedStyles) return;
     if (typeof document === 'undefined') return;
-    if (document.getElementById(BREVWICK_STYLE_ID)) {
-      hasInjectedStyles = true;
-      return;
-    }
+    if (document.getElementById(BREVWICK_STYLE_ID)) return;
     const el = document.createElement('style');
     el.id = BREVWICK_STYLE_ID;
     el.textContent = BREVWICK_CSS;
     document.head.appendChild(el);
-    hasInjectedStyles = true;
   }, []);
 }
 
@@ -76,6 +76,16 @@ function formatSize(bytes: number): string {
 interface ScreenshotAttachment {
   readonly blob: Blob;
   readonly url: string;
+}
+
+/**
+ * Monotonic id attached to each uploaded file at insert time. Using `name` or
+ * the index as the React key would cause duplicate-named files or removals
+ * of middle items to reconcile surviving chips against the wrong slots.
+ */
+interface FileAttachment {
+  readonly id: number;
+  readonly file: File;
 }
 
 export function FeedbackButton({
@@ -95,12 +105,14 @@ export function FeedbackButton({
   const [screenshot, setScreenshot] = useState<ScreenshotAttachment | null>(
     null,
   );
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<readonly FileAttachment[]>([]);
   const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [succeeded, setSucceeded] = useState(false);
   const mountedRef = useRef(true);
   const screenshotUrlRef = useRef<string | null>(null);
+  const fileIdRef = useRef(0);
+  const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
   useBrevwickStyles();
 
@@ -198,7 +210,13 @@ export function FeedbackButton({
 
   const handleFiles = useCallback((list: FileList | null) => {
     if (!list || list.length === 0) return;
-    setFiles((prev) => [...prev, ...Array.from(list)]);
+    setFiles((prev) => {
+      const next = Array.from(list).map<FileAttachment>((file) => ({
+        id: ++fileIdRef.current,
+        file,
+      }));
+      return [...prev, ...next];
+    });
   }, []);
 
   const removeScreenshot = useCallback(() => {
@@ -208,8 +226,8 @@ export function FeedbackButton({
     });
   }, []);
 
-  const removeFile = useCallback((index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
+  const removeFile = useCallback((id: number) => {
+    setFiles((prev) => prev.filter((f) => f.id !== id));
   }, []);
 
   const doSubmit = useCallback(async () => {
@@ -228,7 +246,8 @@ export function FeedbackButton({
         filename: `screenshot.${ext}`,
       });
     }
-    for (const f of files) attachments.push({ blob: f, filename: f.name });
+    for (const { file } of files)
+      attachments.push({ blob: file, filename: file.name });
 
     const trimmed = draft.trim();
     const derivedTitle = trimmed.split('\n', 1)[0]!.slice(0, 120);
@@ -246,8 +265,15 @@ export function FeedbackButton({
       onSubmit?.(result);
       if (result.ok) {
         setSucceeded(true);
+        // If the user minimized mid-submit, pop the panel back open so the
+        // success confirmation is actually seen. A silent success while
+        // hidden leaves the user unsure whether their report landed.
+        setOpen(true);
       } else {
         setSubmitError(result.error.message);
+        // Same reasoning for a failed submit: the error alert belongs in
+        // front of the user, not buried behind a minimized panel.
+        setOpen(true);
       }
     } catch (err) {
       if (!mountedRef.current) return;
@@ -256,8 +282,31 @@ export function FeedbackButton({
           ? err.message
           : 'We could not submit your feedback. Please try again.';
       setSubmitError(message);
+      setOpen(true);
     }
   }, [actual, draft, expected, files, onSubmit, screenshot, status, submit]);
+
+  // Pending-focus flag: "Send another" needs to focus the composer, but the
+  // composer only remounts after the SuccessState unmounts. A layout effect
+  // below consumes the flag after the composer is in the tree.
+  const [focusComposerPending, setFocusComposerPending] = useState(false);
+
+  /**
+   * "Send another" — reset back to the empty Thread+Composer and move focus
+   * into the composer textarea so keyboard users aren't dumped onto whatever
+   * Radix's focus-trap picks next (the close button, in practice).
+   */
+  const handleSendAnother = useCallback(() => {
+    resetAll();
+    setFocusComposerPending(true);
+  }, [resetAll]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!focusComposerPending) return;
+    if (!composerRef.current) return;
+    composerRef.current.focus();
+    setFocusComposerPending(false);
+  }, [focusComposerPending, succeeded]);
 
   if (hidden) return null;
 
@@ -285,16 +334,14 @@ export function FeedbackButton({
           data-brevwick-skip=""
           className={`${rootClassName} brw-panel ${panelPosClass}`}
           aria-describedby={undefined}
-          onInteractOutside={(e) => {
-            // Overlay-click semantics: treat the same as Esc (minimize, preserve).
-            // Radix already routes through onOpenChange, so no extra state work.
-            e.preventDefault();
-            handleMinimize();
-          }}
         >
-          <PanelHeader onMinimize={handleMinimize} onClose={handleCloseClick} />
+          <PanelHeader
+            submitting={status === 'submitting'}
+            onMinimize={handleMinimize}
+            onClose={handleCloseClick}
+          />
           {succeeded ? (
-            <SuccessState onSendAnother={resetAll} />
+            <SuccessState onSendAnother={handleSendAnother} />
           ) : (
             <Thread
               greeting={GREETING}
@@ -318,6 +365,7 @@ export function FeedbackButton({
           )}
           {!succeeded && (
             <Composer
+              ref={composerRef}
               draft={draft}
               submitting={status === 'submitting'}
               onDraftChange={setDraft}
@@ -333,11 +381,16 @@ export function FeedbackButton({
 }
 
 interface PanelHeaderProps {
+  submitting: boolean;
   onMinimize: () => void;
   onClose: () => void;
 }
 
-function PanelHeader({ onMinimize, onClose }: PanelHeaderProps): ReactElement {
+function PanelHeader({
+  submitting,
+  onMinimize,
+  onClose,
+}: PanelHeaderProps): ReactElement {
   return (
     <div className="brw-panel-header">
       <span className="brw-panel-avatar" aria-hidden="true">
@@ -357,6 +410,10 @@ function PanelHeader({ onMinimize, onClose }: PanelHeaderProps): ReactElement {
         className="brw-icon-btn"
         aria-label="Close"
         onClick={onClose}
+        /* Disable close while a submit is in flight — clicking "Discard"
+           mid-request would otherwise throw the confirmation away while the
+           callback still resolves into the parent. */
+        disabled={submitting}
       >
         <CloseIcon />
       </button>
@@ -368,18 +425,18 @@ interface ThreadProps {
   greeting: string;
   draft: string;
   screenshot: ScreenshotAttachment | null;
-  files: readonly File[];
+  files: readonly FileAttachment[];
   showExtras: boolean;
   expected: string;
   actual: string;
   confirmClose: boolean;
   submitError: string | null;
-  status: 'idle' | 'submitting' | 'success' | 'error';
+  status: FeedbackStatus;
   onToggleExtras: () => void;
   onExpectedChange: (v: string) => void;
   onActualChange: (v: string) => void;
   onRemoveScreenshot: () => void;
-  onRemoveFile: (index: number) => void;
+  onRemoveFile: (id: number) => void;
   onConfirmDiscard: () => void;
   onCancelClose: () => void;
 }
@@ -421,12 +478,12 @@ function Thread({
           onRemove={onRemoveScreenshot}
         />
       )}
-      {files.map((f, i) => (
+      {files.map(({ id, file }) => (
         <AttachmentChip
-          key={`${f.name}-${i}`}
-          name={f.name}
-          size={f.size}
-          onRemove={() => onRemoveFile(i)}
+          key={id}
+          name={file.name}
+          size={file.size}
+          onRemove={() => onRemoveFile(id)}
         />
       ))}
       <DisclosureExpectedActual
@@ -572,78 +629,93 @@ interface ComposerProps {
   onAttachFiles: (list: FileList | null) => void;
 }
 
-function Composer({
-  draft,
-  submitting,
-  onDraftChange,
-  onSubmit,
-  onAttachScreenshot,
-  onAttachFiles,
-}: ComposerProps): ReactElement {
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
+  function Composer(
+    {
+      draft,
+      submitting,
+      onDraftChange,
+      onSubmit,
+      onAttachScreenshot,
+      onAttachFiles,
+    },
+    forwardedRef,
+  ): ReactElement {
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    useImperativeHandle(forwardedRef, () => textareaRef.current!, []);
 
-  // Autogrow between ~1 and ~5 rows. Max-height from CSS bounds it; measuring
-  // scrollHeight each keystroke is cheap next to React's own render cost.
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
-  }, [draft]);
+    // Autogrow between ~1 and ~5 rows. The CSS `max-height` on the input
+    // bounds this visually; the JS mirror keeps the height animating up as
+    // the user types. Both come from the same COMPOSER_MAX_HEIGHT_PX
+    // constant so bumping the ceiling is a single edit.
+    useEffect(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.style.height = 'auto';
+      el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT_PX)}px`;
+    }, [draft]);
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      onSubmit();
-    }
-  };
+    const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+      if (
+        e.key === 'Enter' &&
+        !e.shiftKey &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.nativeEvent.isComposing
+      ) {
+        e.preventDefault();
+        onSubmit();
+      }
+    };
 
-  return (
-    <div className="brw-composer">
-      <button
-        type="button"
-        className="brw-icon-btn"
-        aria-label="Attach screenshot"
-        onClick={onAttachScreenshot}
-        disabled={submitting}
-      >
-        <CameraIcon />
-      </button>
-      <label className="brw-icon-btn" aria-label="Attach file">
-        <PaperclipIcon />
-        <input
-          type="file"
-          multiple
-          className="brw-file-input"
-          onChange={(e) => {
-            onAttachFiles(e.target.files);
-            e.target.value = '';
-          }}
+    return (
+      <div className="brw-composer">
+        <button
+          type="button"
+          className="brw-icon-btn"
+          aria-label="Attach screenshot"
+          onClick={onAttachScreenshot}
           disabled={submitting}
+        >
+          <CameraIcon />
+        </button>
+        <label className="brw-icon-btn" aria-label="Attach file">
+          <PaperclipIcon />
+          <input
+            type="file"
+            multiple
+            className="brw-file-input"
+            onChange={(e) => {
+              onAttachFiles(e.target.files);
+              e.target.value = '';
+            }}
+            disabled={submitting}
+          />
+        </label>
+        <textarea
+          ref={textareaRef}
+          className="brw-composer-input"
+          rows={1}
+          placeholder="Describe the bug or feedback…"
+          value={draft}
+          onChange={(e) => onDraftChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          aria-label="Feedback message"
         />
-      </label>
-      <textarea
-        ref={textareaRef}
-        className="brw-composer-input"
-        rows={1}
-        placeholder="Describe the bug or feedback…"
-        value={draft}
-        onChange={(e) => onDraftChange(e.target.value)}
-        onKeyDown={handleKeyDown}
-        aria-label="Feedback message"
-      />
-      <button
-        type="button"
-        className="brw-send-btn"
-        aria-label="Send"
-        disabled={submitting || draft.trim().length === 0}
-        onClick={onSubmit}
-      >
-        <SendIcon />
-      </button>
-    </div>
-  );
-}
+        <button
+          type="button"
+          className="brw-send-btn"
+          aria-label="Send"
+          disabled={submitting || draft.trim().length === 0}
+          onClick={onSubmit}
+        >
+          <SendIcon />
+        </button>
+      </div>
+    );
+  },
+);
 
 interface SuccessStateProps {
   onSendAnother: () => void;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -16,7 +16,13 @@ export const BREVWICK_CSS = `
   --brw-accent-fg: #ffffff;
   --brw-error: #b91c1c;
   --brw-success: #047857;
-  --brw-overlay: rgba(15, 23, 42, 0.45);
+  --brw-panel-bg: #ffffff;
+  --brw-bubble-assistant-bg: #f1f5f9;
+  --brw-bubble-user-bg: #0f172a;
+  --brw-bubble-user-fg: #ffffff;
+  --brw-chip-bg: #f1f5f9;
+  --brw-composer-bg: #ffffff;
+  --brw-divider: #e2e8f0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   color: var(--brw-fg);
 }
@@ -28,80 +34,318 @@ export const BREVWICK_CSS = `
     --brw-border: #1e293b;
     --brw-accent: #f8fafc;
     --brw-accent-fg: #0f172a;
-    --brw-overlay: rgba(0, 0, 0, 0.6);
+    --brw-panel-bg: #0b1220;
+    --brw-bubble-assistant-bg: #1e293b;
+    --brw-bubble-user-bg: #f8fafc;
+    --brw-bubble-user-fg: #0f172a;
+    --brw-chip-bg: #1e293b;
+    --brw-composer-bg: #0b1220;
+    --brw-divider: #1e293b;
   }
 }
 .brw-fab {
   position: fixed;
   z-index: 2147483000;
-  bottom: 20px;
-  height: 44px;
-  min-width: 44px;
-  padding: 0 16px;
+  bottom: 24px;
+  height: 48px;
+  min-width: 48px;
+  padding: 0 18px;
   border-radius: 999px;
   border: 1px solid var(--brw-border);
   background: var(--brw-accent);
   color: var(--brw-accent-fg);
   font-size: 14px;
   font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.18), 0 2px 4px rgba(0,0,0,0.08);
+  transition: transform 120ms ease-out, box-shadow 120ms ease-out;
+}
+.brw-fab:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.22), 0 3px 6px rgba(0,0,0,0.1);
 }
 .brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
-.brw-fab-br { right: 20px; }
-.brw-fab-bl { left: 20px; }
-.brw-overlay {
-  position: fixed; inset: 0; z-index: 2147483001;
-  background: var(--brw-overlay);
-}
-.brw-dialog {
-  position: fixed; z-index: 2147483002;
-  top: 50%; left: 50%; transform: translate(-50%, -50%);
-  width: min(92vw, 480px);
-  max-height: 90vh; overflow: auto;
-  background: var(--brw-bg);
+.brw-fab-br { right: 24px; }
+.brw-fab-bl { left: 24px; }
+.brw-fab-icon { width: 18px; height: 18px; }
+.brw-panel {
+  position: fixed;
+  z-index: 2147483002;
+  bottom: 24px;
+  width: min(92vw, 400px);
+  height: min(80vh, 640px);
+  display: flex;
+  flex-direction: column;
+  background: var(--brw-panel-bg);
   color: var(--brw-fg);
-  border-radius: 12px;
   border: 1px solid var(--brw-border);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
-  padding: 20px;
+  border-radius: 16px 16px 12px 12px;
+  box-shadow: 0 20px 48px rgba(0,0,0,0.25), 0 6px 12px rgba(0,0,0,0.12);
+  overflow: hidden;
+  animation: brw-slide-up 200ms ease-out;
 }
-.brw-title { margin: 0 0 12px; font-size: 16px; font-weight: 600; }
-.brw-field { display: block; margin-bottom: 12px; font-size: 13px; }
-.brw-label { display: block; margin-bottom: 4px; color: var(--brw-muted); }
-.brw-input, .brw-textarea {
-  width: 100%; box-sizing: border-box;
-  padding: 8px 10px; font: inherit; color: var(--brw-fg);
-  background: var(--brw-bg); border: 1px solid var(--brw-border);
+.brw-panel-br { right: 24px; }
+.brw-panel-bl { left: 24px; }
+@keyframes brw-slide-up {
+  from { transform: translateY(16px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-panel { animation: none; }
+  .brw-fab { transition: none; }
+}
+@media (max-width: 480px) {
+  .brw-panel {
+    width: calc(100vw - 32px);
+    left: 16px;
+    right: 16px;
+  }
+}
+.brw-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--brw-divider);
+  flex-shrink: 0;
+}
+.brw-panel-avatar {
+  width: 28px; height: 28px;
+  border-radius: 999px;
+  background: var(--brw-accent);
+  color: var(--brw-accent-fg);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 12px;
+  flex-shrink: 0;
+}
+.brw-panel-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.brw-icon-btn {
+  width: 28px; height: 28px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--brw-muted);
   border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
 }
-.brw-textarea { min-height: 72px; resize: vertical; }
-.brw-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.brw-icon-btn:hover:not(:disabled) { background: var(--brw-chip-bg); color: var(--brw-fg); }
+.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: 1px; }
+.brw-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-icon-btn svg { width: 16px; height: 16px; }
+.brw-thread {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--brw-panel-bg);
+}
+.brw-bubble {
+  max-width: 85%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  font-size: 13px;
+  line-height: 1.45;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+.brw-bubble--assistant {
+  align-self: flex-start;
+  background: var(--brw-bubble-assistant-bg);
+  color: var(--brw-fg);
+  border-bottom-left-radius: 4px;
+}
+.brw-bubble--user {
+  align-self: flex-end;
+  background: var(--brw-bubble-user-bg);
+  color: var(--brw-bubble-user-fg);
+  border-bottom-right-radius: 4px;
+}
+.brw-bubble--success {
+  align-self: center;
+  background: var(--brw-chip-bg);
+  color: var(--brw-fg);
+  text-align: center;
+  max-width: 92%;
+}
+.brw-success-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 8px;
+}
+.brw-chip {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  background: var(--brw-chip-bg);
+  color: var(--brw-fg);
+  border: 1px solid var(--brw-border);
+  border-radius: 12px;
+  font-size: 12px;
+  max-width: 85%;
+}
+.brw-chip img {
+  width: 28px; height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.brw-chip-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
+.brw-chip-size { color: var(--brw-muted); }
+.brw-chip-remove {
+  width: 20px; height: 20px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--brw-muted);
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+.brw-chip-remove:hover { background: var(--brw-border); color: var(--brw-fg); }
+.brw-disclosure {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--brw-muted);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.brw-disclosure:hover { color: var(--brw-fg); }
+.brw-disclosure-panel {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--brw-chip-bg);
+  border: 1px solid var(--brw-border);
+  border-radius: 10px;
+}
+.brw-disclosure-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--brw-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.brw-disclosure-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--brw-fg);
+  background: var(--brw-panel-bg);
+  border: 1px solid var(--brw-border);
+  border-radius: 6px;
+  resize: vertical;
+  min-height: 34px;
+}
+.brw-composer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--brw-composer-bg);
+  border-top: 1px solid var(--brw-divider);
+}
+.brw-composer-input {
+  flex: 1;
+  min-height: 34px;
+  max-height: 120px;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--brw-fg);
+  background: var(--brw-panel-bg);
+  border: 1px solid var(--brw-border);
+  border-radius: 10px;
+  resize: none;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+.brw-composer-input:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: -1px; }
+.brw-send-btn {
+  width: 34px; height: 34px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--brw-accent);
+  background: var(--brw-accent);
+  color: var(--brw-accent-fg);
+  border-radius: 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.brw-send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-send-btn svg { width: 16px; height: 16px; }
+.brw-file-input { display: none; }
+.brw-confirm {
+  align-self: stretch;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--brw-chip-bg);
+  border: 1px solid var(--brw-border);
+  border-radius: 10px;
+  font-size: 12px;
+}
+.brw-confirm-msg { flex: 1; }
 .brw-btn {
-  height: 34px; padding: 0 12px; border-radius: 6px;
-  border: 1px solid var(--brw-border); background: var(--brw-bg); color: var(--brw-fg);
-  font: inherit; cursor: pointer;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid var(--brw-border);
+  background: var(--brw-panel-bg);
+  color: var(--brw-fg);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
 }
+.brw-btn:hover:not(:disabled) { background: var(--brw-chip-bg); }
 .brw-btn-primary {
-  background: var(--brw-accent); color: var(--brw-accent-fg); border-color: var(--brw-accent);
+  background: var(--brw-accent);
+  color: var(--brw-accent-fg);
+  border-color: var(--brw-accent);
 }
-.brw-btn:disabled { opacity: 0.6; cursor: not-allowed; }
-.brw-thumb {
-  margin-top: 6px;
-  display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: var(--brw-muted);
-}
-.brw-thumb img { max-width: 96px; max-height: 64px; border-radius: 4px; border: 1px solid var(--brw-border); }
-.brw-error { color: var(--brw-error); font-size: 13px; margin-top: 8px; }
-.brw-success { color: var(--brw-success); font-size: 13px; margin-top: 8px; }
+.brw-error { color: var(--brw-error); font-size: 12px; align-self: stretch; }
 .brw-spinner {
   display: inline-block; width: 14px; height: 14px;
   border: 2px solid currentColor; border-right-color: transparent;
-  border-radius: 999px; vertical-align: -2px; margin-right: 6px;
+  border-radius: 999px;
   animation: brw-spin 0.7s linear infinite;
 }
 @keyframes brw-spin { to { transform: rotate(360deg); } }
-.brw-footer { display: flex; gap: 8px; justify-content: flex-end; margin-top: 16px; }
-.brw-files { margin-top: 6px; font-size: 12px; color: var(--brw-muted); }
-.brw-file-label { display: inline-block; }
-.brw-file-input { display: none; }
+@media (prefers-reduced-motion: reduce) {
+  .brw-spinner { animation-duration: 1.6s; }
+}
 `;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -6,6 +6,16 @@
  */
 export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
 
+/**
+ * Maximum autogrow height of the composer textarea in pixels.
+ *
+ * Shared between JS (the autogrow effect sets `style.height` against
+ * `scrollHeight` bounded by this) and CSS (`.brw-composer-input` uses
+ * the same value as `max-height`). Single source of truth so a designer
+ * bumping the ceiling does not drift the two out of sync.
+ */
+export const COMPOSER_MAX_HEIGHT_PX = 120;
+
 export const BREVWICK_CSS = `
 .brw-root {
   --brw-bg: #ffffff;
@@ -38,7 +48,9 @@ export const BREVWICK_CSS = `
     --brw-bubble-assistant-bg: #1e293b;
     --brw-bubble-user-bg: #f8fafc;
     --brw-bubble-user-fg: #0f172a;
-    --brw-chip-bg: #1e293b;
+    /* chip bg is one step brighter than --brw-border (#1e293b) so the chip's
+       1px border stays visible against the chip body in dark mode. */
+    --brw-chip-bg: #253044;
     --brw-composer-bg: #0b1220;
     --brw-divider: #1e293b;
   }
@@ -280,7 +292,7 @@ export const BREVWICK_CSS = `
 .brw-composer-input {
   flex: 1;
   min-height: 34px;
-  max-height: 120px;
+  max-height: ${COMPOSER_MAX_HEIGHT_PX}px;
   box-sizing: border-box;
   padding: 8px 10px;
   font: inherit;


### PR DESCRIPTION
Closes #25

Implements [SDD § 12 Widget UX](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts).

## Summary
- FAB opens an anchored slide-up panel (bottom-right/left) styled as a chat thread, not a centered modal
- Panel layout: header (title, minimize, close) → scrollable bubble thread → sticky composer (icons + autogrowing textarea + send)
- Progressive disclosure for expected/actual (hidden by default behind "Add expected vs actual")
- Enter sends, Shift+Enter newline; minimize preserves state; close confirms when dirty
- Success state swaps the thread for a confirmation bubble + "Send another"
- Light + dark polish; `prefers-reduced-motion` disables the slide animation
- NO new dependencies; bundle budgets preserved (react ESM ≈ 6.9 kB gzip vs 25 kB budget)
- Public API (props, `useFeedback`, submit payload) unchanged — #26 owns the `use_ai` delta

## Notes
- Esc / overlay-click are mapped to "minimize with preserved state" rather than destructive close so a stray Esc never nukes a long draft; the × button handles the dirty-confirm flow explicitly.
- a11y coverage lives in the new test suite via role/aria-live assertions. Skipped `vitest-axe` — the task's a11y checklist conflicts with the "NO new dependencies" rule, and axe-core would dwarf the 25 kB widget budget even as a devDependency churn. Happy to add it in a follow-up if the constraint relaxes.

## Test plan
- [x] Enter sends, Shift+Enter keeps a newline (asserted in vitest)
- [x] Minimize round-trip preserves composer text + attachments
- [x] Close-when-dirty renders inline confirm; close-when-clean dismisses immediately
- [x] Success swaps thread for confirmation bubble; "Send another" resets to an empty thread
- [x] `packages/react` bundle 6.9 kB gzip (ESM) under 25 kB budget; SDK core untouched at 2.0 kB gzip
- [ ] Manual smoke on Next.js example (desktop + mobile + light/dark) — reviewer to verify