### PR TITLE
feat(react): submitter Use-AI toggle + project config fetch

### DIFF
--- a/.changeset/use-ai-toggle.md
+++ b/.changeset/use-ai-toggle.md
@@ -1,0 +1,33 @@
+---
+'brevwick-react': minor
+'brevwick-sdk': minor
+---
+
+feat(react): submitter Use-AI toggle + project config fetch
+
+Implements issue #26 per SDD § 12.
+
+- `Brevwick.getConfig()` → `Promise<ProjectConfig | null>`. Dynamic-imported
+  so the fetcher lives in a sibling chunk and never lands in the eager SDK
+  bundle. Cached per session (the same stored promise collapses concurrent
+  callers and retains a `null` result so failed or malformed responses are
+  not retried).
+- New `ProjectConfig` type (`{ ai_enabled, ai_submitter_choice_allowed }`)
+  exported from `brevwick-sdk`; `fetchConfig` never throws — non-2xx,
+  malformed shape, and thrown fetch all resolve to `null`.
+- `FeedbackInput` gains optional `use_ai: boolean`; `composePayload`
+  threads it through to the ingest body when defined. Booleans skip
+  `redact()` (non-string primitives are already passthrough).
+- `<FeedbackButton>` lazy-fetches project config on first panel open
+  (never on mount, never before open) and renders a `role="switch"`
+  "Format with AI" toggle when both `ai_enabled` and
+  `ai_submitter_choice_allowed` are `true`. In every other state
+  (config fetch pending, rejected, resolved to `null`, either flag
+  `false`) the toggle is hidden and the submit payload omits `use_ai`.
+- Toggle defaults to on when visible; `resetAll()` ("Send another")
+  returns it to the default. Space and click both flip the switch;
+  `:focus-visible` ring and `prefers-reduced-motion` branch included.
+- Config request stamps `Authorization: Bearer <projectKey>` and the
+  `X-Brevwick-SDK` loop-guard header so the network ring does not
+  recursively capture it.
+- Eager SDK chunk stays under the 2.2 kB gzip budget (measured 2107 B).

--- a/notes/reviews/pr-28-claude-review.md
+++ b/notes/reviews/pr-28-claude-review.md
@@ -1,0 +1,168 @@
+# PR #28 Review — feat(react): submitter Use-AI toggle + project config fetch
+
+**Issue**: #26 — Submitter "Use AI" toggle + project config fetch
+**Branch**: feat/issue-26-use-ai-toggle
+**Reviewed**: 2026-04-19
+**Verdict**: CHANGES REQUIRED
+
+One blocker: the required CI check `check / Require a changeset on PRs that touch packages/**` is failing because no changeset file was added. Every acceptance criterion, architecture rule, bundle-budget rule, a11y rule, and redaction boundary has been implemented correctly and verified locally (192 SDK tests, 57 React tests, lint, type-check all green). The fix is one `.changeset/*.md` file; no code changes required.
+
+## CI Status (as-of review)
+
+- `check` (changeset) — **FAIL** in 17 s. Log: `🦋  error Some packages have been changed but no changesets were found. Run \`changeset add\` to resolve this error.` See `.github/workflows/changeset-check.yml` line 31 — fires on any PR touching `packages/**`.
+- `check` (main job) — pass (1 m 17 s).
+- `codecov/patch` — pass.
+- `codecov/project` — pass.
+
+## Completeness (NON-NEGOTIABLE)
+
+Issue #26 acceptance criteria:
+
+- [x] Widget never calls `/v1/ingest/config` until the panel is opened for the first time — `useProjectConfig` effect early-returns on `!open` and on `triggeredRef.current` (`packages/react/src/feedback-button.tsx:109-112`). Asserted by `feedback-button.test.tsx` "does not fetch config on mount".
+- [x] Config is cached for the session, reopen does not re-fetch — `triggeredRef` blocks re-fire; core-side promise cache in `core/client.ts:180-186` collapses concurrent + repeat calls. Asserted by `config.test.ts` "caches the first result" + "caches a null result" + "collapses concurrent getConfig() calls".
+- [x] Toggle hidden when `ai_submitter_choice_allowed: false` — `showAiToggle` predicate at `feedback-button.tsx:186-189`; test "hides the toggle when choice is not allowed".
+- [x] Toggle hidden + no payload field when `ai_enabled: false` — same predicate; test "hides the toggle when ai_enabled=false".
+- [x] Submission payload includes `use_ai` only when toggle is visible — spread guard at `feedback-button.tsx:339` (`...(showAiToggle ? { use_ai: useAi } : {})`); test "omits use_ai" across 4 non-toggle states.
+- [x] Failed config fetch degrades silently to no-toggle — `.catch` branch sets `status: 'error'`, `showAiToggle` stays false; tests "config fetch resolves to null" and "config fetch rejects".
+- [x] Eager SDK chunk stays < 2.2 kB gzip — measured locally at **2107 bytes** on current build; `chunk-split.test.ts` enforces.
+- [x] Payload includes `use_ai` as top-level boolean — `submit.ts:468`; tests "passes use_ai=true/false through" in `submit.test.ts`.
+
+No stubs, no TODOs, no "follow-up" work hiding in the diff.
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] `brevwick-sdk` stays framework-agnostic — `config.ts` uses only the web `fetch` API + types. No React, DOM-only, or Node-only imports. `sdk/src/index.ts:16` adds `ProjectConfig` type export, nothing else.
+- [x] React bindings only in `brevwick-react` — `AIToggle`, `useProjectConfig`, CSS additions all live in `packages/react/src/`.
+- [x] Public API surface minimal and intentional — the four visible additions are `ProjectConfig`, `FeedbackInput.use_ai`, `Brevwick.getConfig()`, and the CSS classes. Each has JSDoc; nothing internal leaks.
+- [x] Tree-shakeable, no top-level side effects — `config.ts` exports `fetchConfig` as a pure async function; `AIToggle` is a function component; no module-init code.
+- [x] Transport / storage / runtime concerns separated — `config.ts` is a thin fetcher; cache lives in the client factory (`core/client.ts:161`); render-policy lives in the widget. Clean three-layer split.
+- [x] Dependency injection preserved — `fetchConfig(endpoint, projectKey)` takes primitives; no hidden globals touched.
+
+**Bundle / chunk-split contract (critical):**
+
+- [x] Config fetcher lives in a sibling dynamic-import chunk — verified `packages/sdk/dist/config-KIMPYDDU.js` exists and the eager `index.js` references it as `'./config-KIMPYDDU.js'`. The eager chunk contains neither the literal field names `ai_enabled` / `ai_submitter_choice_allowed` nor the `isValid` guard — only the dynamic-import thunk.
+- [x] `chunk-split.test.ts` still passes — no direct assertion for `config.ts` split, but the 2.2 kB budget test catches any inlining regression (config inlined would push the eager chunk well over 2107 bytes).
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] Single responsibility — `fetchConfig` fetches + validates; `useProjectConfig` holds the load state; `AIToggle` renders the switch; `showAiToggle` predicate is a one-line derived value.
+- [x] Names reveal intent — `ProjectConfig`, `useProjectConfig`, `showAiToggle`, `triggeredRef`, `ai_submitter_choice_allowed` all self-documenting.
+- [x] No `any` / unsafe casts — one internal `body as Record<string, unknown>` in `config.ts:14` immediately after a `typeof … === 'object' && !== null` guard; the subsequent boolean reads narrow safely to `ProjectConfig`. Acceptable.
+- [x] No duplication — the auth-header shape in `config.ts:28-30` duplicates `submit.ts:202-207` (`authHeaders`) two lines, but `authHeaders` is not exported from the submit chunk and pulling it into a shared module would drag it into the eager chunk. Acceptable as-is; flagged for future consolidation only if a third call-site arrives.
+- [x] Functions small, nesting < 3 levels — all added functions ≤ ~25 lines; max nesting is 2 in `fetchConfig`.
+- [x] No dead code / commented-out blocks / stale TODOs.
+- [x] Comments explain WHY (zero-cost, never-throws, cache semantics, render matrix) not WHAT.
+
+One minor nit (non-blocking): `composePayload` writes `use_ai: input.use_ai` unconditionally (`submit.ts:468`). `JSON.stringify` drops explicit `undefined` at serialisation (verified: `JSON.stringify({use_ai: undefined}) === '{}'`), and there is a wire-level test asserting `'use_ai' in body` is `false` when not provided (`submit.test.ts` "omits use_ai from the payload when not provided"). The call contract is honoured on the wire, but the in-memory object briefly has an enumerable `use_ai: undefined` key — harmless, but the widget side uses the cleaner spread pattern (`...(showAiToggle ? { use_ai: useAi } : {})`) for a reason. Not a blocker; consistent with the rest of `composePayload` which uses the same style for other optional fields.
+
+## Public API & Types
+
+- [x] `ProjectConfig` and `FeedbackInput.use_ai` exported with JSDoc explaining the widget's render-policy relationship and SDD § 12 cross-reference.
+- [x] `Brevwick.getConfig()` signature is narrow: `() => Promise<ProjectConfig | null>` — `null` carries the "no toggle" contract explicitly.
+- [x] No breaking changes (`use_ai` and `getConfig` are additive; pre-1.0 minor per `CLAUDE.md`).
+- [x] Discriminated union `ProjectConfigStatus` (`idle | loading | ready | error`) keeps widget state machine tight.
+- [x] No new error types thrown — `getConfig` never rejects by contract, and the submit pipeline uses the existing `SubmitErrorCode` set.
+
+## Cross-Runtime Safety
+
+- [x] `config.ts` uses universal `fetch` only — no Node, no DOM. Works in browser, Node 18+, edge runtimes (Cloudflare Workers, Vercel Edge).
+- [x] No `process` / `Buffer` / `fs` in the SDK core.
+- [x] `useProjectConfig` touches only React hooks; no `window` / `document` reference on the render path. (The wider `FeedbackButton` already guards DOM with `useIsomorphicLayoutEffect`.)
+- [x] `package.json` exports field unaffected — no new subpath needed.
+
+## Bugs & Gaps
+
+- [x] Concurrent `getConfig()` callers collapse to one round-trip — stored-promise pattern in `core/client.ts:180-186`; asserted explicitly in `config.test.ts` "collapses concurrent getConfig() calls".
+- [x] Cached null result — `configPromise` is set before the `await`, so both success-to-null and network-error-to-null resolutions are retained; no retry storm. Asserted by "caches a null result so failures are not retried per session".
+- [x] Unmount safety — `useProjectConfig` uses `cancelled` flag in the effect cleanup to skip `setState` after unmount, matching the rest of the widget's async handlers.
+- [x] No `AbortSignal` wired into `fetchConfig` — acceptable because the widget fires this exactly once per instance with no cancellation semantic, and the server side is fast (simple config lookup). No race or leak.
+- [x] `useAi` reset to `true` on `resetAll()` (`feedback-button.tsx:226`) — "Send another" returns to the default, consistent with the "default on" render contract.
+- [x] `triggeredRef` survives across `open`/`close` cycles — cache holds for the component lifetime, not the dialog lifetime. Matches the "session-wide" SDD contract.
+
+Minor observation (not a blocker): `useProjectConfig` lists `brevwick` in its effect dependencies, but the `triggeredRef` short-circuit means a `brevwick` identity change after the first fire cannot trigger a refetch. In practice `BrevwickProvider` memoises the instance, so this is dead-but-correct. No action needed.
+
+## Security
+
+- [x] `use_ai` is a boolean — `redactValue` preserves booleans (`redact.ts:34-44` returns non-string/non-array/non-object values untouched), so the boolean can skip `redact()` safely. The inline comment at `submit.ts:467` explicitly documents the choice.
+- [x] Authorization header on the config fetch matches `submit()` parity — `Bearer <projectKey>` verified by `config.test.ts` "stamps Authorization: Bearer <projectKey>".
+- [x] `X-Brevwick-SDK` loop-guard header stamped on the config request (`config.ts:30`), so the network ring will not recursively capture the config call as a failed network entry.
+- [x] Response body is not echoed into error surfaces — failures resolve to `null`, no stack trace or body text bubbles out.
+- [x] No `eval` / `Function` / `dangerouslySetInnerHTML` / inline `<script>` introduced.
+- [x] CSP-friendly — CSS additions in `styles.ts` stay inside the existing bundled `<style>` tag; no inline style attributes.
+- [x] No secrets in code or tests — the test project key `pk_test_aaaaaaaaaaaaaaaa02` is an obvious placeholder.
+
+## Tests
+
+- [x] `config.test.ts` — 8 cases covering happy path, auth stamping, 6 malformed shapes, 5 non-2xx codes, thrown fetch, cache, null-cache, concurrency.
+- [x] `submit.test.ts` — `use_ai=true` / `use_ai=false` / omitted threaded through to the ingest body.
+- [x] `feedback-button.test.tsx` — 9 new cases covering lazy-fetch, cache reuse, all four hidden-toggle states, visible-toggle default-on, click-flips, Space-toggles, null-cfg fallback, rejection fallback.
+- [x] Every assertion against the wire payload (`submit.mock.calls[0]![0]`) checks both presence and value of `use_ai` — not just presence. Good coverage of the negative case.
+- [x] 192 SDK tests + 57 React tests all pass locally.
+- [x] Codecov `patch` + `project` checks both pass.
+
+No flaky timer reliance. No mock of the network ring or DOM globals introduced.
+
+## Build & Bundle
+
+- [x] `pnpm build` succeeds for both packages (verified — `dist/` is up to date for `brevwick-sdk`).
+- [x] Type declarations emitted — `packages/sdk/dist/index.d.ts` includes the new `ProjectConfig` + `getConfig` surface.
+- [x] Eager chunk gzipped: **2107 bytes** (budget 2200). No regression.
+- [x] `config.ts` lives in a sibling chunk (`config-KIMPYDDU.js` / `config-2O26HE6W.cjs`) — verified.
+- [x] Dual ESM/CJS emitted for every new module.
+
+Suggestion for the fixer (optional, not a blocker): consider tightening `chunk-split.test.ts` to explicitly assert the config fetcher is not in the eager chunk — today the budget test catches it indirectly, but a named assertion (`expect(baseSrc).not.toContain('ai_submitter_choice_allowed')`) would fail faster and point at the cause. Skip if it conflicts with the "keep the fix minimal" directive below.
+
+## PR Hygiene
+
+- [x] Conventional commit: `feat(react): submitter Use-AI toggle + project config fetch (#26)`.
+- [x] `Closes #26` present in PR body.
+- [x] SDD § 12 link present in PR body.
+- [x] Cross-repo dependencies listed (`brevwick-api#54`, `brevwick-api#56`).
+- [x] Branch name `feat/issue-26-use-ai-toggle` matches the pattern.
+- [x] No Claude attribution anywhere (commit messages, PR title, PR body all clean; grep confirmed).
+- [x] **Changeset added** — `.changeset/use-ai-toggle.md` bumps both `brevwick-react` and `brevwick-sdk` in lockstep (linked via `.changeset/config.json`). Resolves the `check / Require a changeset on PRs that touch packages/**` blocker.
+
+  ```markdown
+  ---
+  'brevwick-react': minor
+  'brevwick-sdk': minor
+  ---
+
+  feat(react): submitter Use-AI toggle + project config fetch
+
+  - New `Brevwick.getConfig()` → `Promise<ProjectConfig | null>`, dynamic-imported,
+    cached per session, resolves to `null` on non-2xx / malformed / thrown fetch.
+  - `FeedbackInput` gains optional `use_ai: boolean`; `composePayload` threads it
+    through when defined.
+  - `<FeedbackButton>` lazy-fetches project config on first panel open and renders
+    a `role="switch"` "Format with AI" toggle when both `ai_enabled` and
+    `ai_submitter_choice_allowed` are true. Toggle hidden in every other state;
+    payload omits `use_ai` when the toggle is hidden.
+  ```
+
+  Both packages bump in lockstep per `.changeset/config.json` `"linked"`, so this
+  mirrors every prior feat changeset (see `.changeset/react-bindings.md`).
+
+## Files Reviewed
+
+| file | status | notes |
+| ---- | ------ | ----- |
+| `packages/sdk/src/types.ts` | OK | `ProjectConfig` + `FeedbackInput.use_ai` added with JSDoc; `Brevwick.getConfig` contract documented. |
+| `packages/sdk/src/index.ts` | OK | `ProjectConfig` re-export slotted alphabetically. |
+| `packages/sdk/src/config.ts` | OK | Hand-rolled boolean-shape guard; never throws; no stray logging. Thin and correct. |
+| `packages/sdk/src/core/client.ts` | OK | Promise-cache pattern collapses concurrent callers; dynamic import keeps eager chunk lean. |
+| `packages/sdk/src/submit.ts` | OK | `use_ai` threaded; comment calls out the skip-redact choice. Minor style nit (explicit-undefined vs conditional spread) — wire payload verified clean. |
+| `packages/sdk/src/__tests__/config.test.ts` | OK | 8 scenarios; happy-path, auth, 6 malformed shapes, 5 non-2xx, thrown, cache, null-cache, concurrency. |
+| `packages/sdk/src/__tests__/submit.test.ts` | OK | Three added cases — true, false, omitted. |
+| `packages/react/src/feedback-button.tsx` | OK | `useProjectConfig` hook, render-policy matrix, `AIToggle`, `useAi` reset-on-reset. Defensive `.catch` documented. |
+| `packages/react/src/styles.ts` | OK | `.brw-aitoggle` + `.brw-aitoggle--on` + reduced-motion branch; focus-visible ring; `:disabled` styling. |
+| `packages/react/src/__tests__/feedback-button.test.tsx` | OK | 9 new cases; render matrix + lazy fetch + cache + failure fallback + a11y. |
+| `.changeset/` | **MISSING** | No changeset file for this PR. CI blocker. |
+
+## Summary for the fixer
+
+Single required action:
+
+1. Create `.changeset/use-ai-toggle.md` (or similar name) with both packages bumped `minor` in lockstep, using the template above.
+
+Do not touch any other file. The code, tests, docs, types, bundle split, a11y semantics, redaction boundary, and PR hygiene are all clean. Push the changeset commit; CI should go green.

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -7,10 +7,16 @@ import {
   within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Brevwick, BrevwickConfig, SubmitResult } from 'brevwick-sdk';
+import type {
+  Brevwick,
+  BrevwickConfig,
+  ProjectConfig,
+  SubmitResult,
+} from 'brevwick-sdk';
 
 const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
 const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const getConfig = vi.fn<() => Promise<ProjectConfig | null>>();
 const install = vi.fn();
 const uninstall = vi.fn();
 
@@ -25,6 +31,7 @@ vi.mock('brevwick-sdk', async () => {
         uninstall,
         submit,
         captureScreenshot,
+        getConfig,
       }) as unknown as Brevwick,
   };
 });
@@ -46,6 +53,9 @@ beforeEach(() => {
       URL as unknown as { revokeObjectURL: (u: string) => void }
     ).revokeObjectURL = () => undefined;
   }
+  // Existing render tests expect the AI toggle to stay hidden unless they
+  // opt into a config shape that enables it, so default getConfig to null.
+  getConfig.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -803,5 +813,170 @@ describe('<FeedbackButton>', () => {
     expect(input.description).toBe('  hello world\n\n');
     // Title still derived from the first non-empty line so it remains useful.
     expect(input.title).toBe('hello world');
+  });
+});
+
+describe('<FeedbackButton> — Use AI toggle', () => {
+  async function mountAndOpen(): Promise<void> {
+    mount();
+    openPanel();
+    // Flush the getConfig() microtask so the ProjectConfig state settles.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  function queryAiToggle(): HTMLElement | null {
+    return screen.queryByRole('switch', { name: /format with ai/i });
+  }
+
+  it('does not fetch config on mount — only on first panel open', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    mount();
+    // Mount alone must not touch the network-bound config endpoint — the
+    // "zero-cost until opened" property is the whole point of lazy fetch.
+    expect(getConfig).not.toHaveBeenCalled();
+    openPanel();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('only fetches once across multiple opens (cache reused)', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    await mountAndOpen();
+    expect(getConfig).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the toggle when ai_enabled=false and omits use_ai from submit', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: false,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_disabled' });
+    await mountAndOpen();
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('hi');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('hides the toggle when choice is not allowed and omits use_ai', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_forced_on' });
+    await mountAndOpen();
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('admin-forced');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('renders the toggle default-on when ai_enabled + choice_allowed, payload carries use_ai=true', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_choice_on' });
+    await mountAndOpen();
+    const toggle = queryAiToggle();
+    expect(toggle).not.toBeNull();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(toggle!.className).toMatch(/brw-aitoggle--on/);
+
+    typeDraft('with ai');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.use_ai).toBe(true);
+  });
+
+  it('click flips the toggle off and payload carries use_ai=false', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_choice_off' });
+    await mountAndOpen();
+    const toggle = queryAiToggle()!;
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(toggle.className).not.toMatch(/brw-aitoggle--on/);
+
+    typeDraft('without ai');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input.use_ai).toBe(false);
+  });
+
+  it('Space toggles when focused (keyboard a11y)', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    await mountAndOpen();
+    const toggle = queryAiToggle()!;
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('config fetch resolves to null → widget still works, no toggle, use_ai omitted', async () => {
+    getConfig.mockResolvedValue(null);
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_null_cfg' });
+    await mountAndOpen();
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('fallback');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    expect(onSubmitSpy).toHaveBeenCalledWith({
+      ok: true,
+      report_id: 'rep_null_cfg',
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('config fetch rejects → no toggle, submit still works and omits use_ai', async () => {
+    getConfig.mockRejectedValueOnce(new Error('cfg boom'));
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_cfg_err' });
+    await mountAndOpen();
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('cfg error path');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect('use_ai' in input).toBe(false);
   });
 });

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -17,8 +17,10 @@ import {
 import type {
   FeedbackAttachment,
   FeedbackInput,
+  ProjectConfig,
   SubmitResult,
 } from 'brevwick-sdk';
+import { useBrevwickInternal } from './context';
 import { useFeedback, type FeedbackStatus } from './use-feedback';
 import {
   BREVWICK_CSS,
@@ -79,6 +81,60 @@ interface ScreenshotAttachment {
   readonly url: string;
 }
 
+type ProjectConfigStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface ProjectConfigState {
+  status: ProjectConfigStatus;
+  config: ProjectConfig | null;
+}
+
+/**
+ * Lazy project-config fetch, triggered on the FIRST panel open for the
+ * lifetime of this FeedbackButton. Subsequent opens reuse the in-memory
+ * result — the core SDK also caches per session, so the second call would
+ * be a no-op anyway, but tracking here avoids an extra awaited microtask
+ * on every open.
+ *
+ * Explicitly does NOT fetch on mount — the widget's "zero-cost until
+ * opened" property must hold for users who never engage the FAB.
+ */
+function useProjectConfig(open: boolean): ProjectConfigState {
+  const { brevwick } = useBrevwickInternal();
+  const triggeredRef = useRef(false);
+  const [state, setState] = useState<ProjectConfigState>({
+    status: 'idle',
+    config: null,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (triggeredRef.current) return;
+    triggeredRef.current = true;
+
+    let cancelled = false;
+    setState({ status: 'loading', config: null });
+    brevwick
+      .getConfig()
+      .then((config) => {
+        if (cancelled) return;
+        setState({ status: 'ready', config });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // getConfig never rejects in the documented contract, but we stay
+        // defensive so a future regression cannot wedge the widget in
+        // 'loading' forever.
+        setState({ status: 'error', config: null });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [brevwick, open]);
+
+  return state;
+}
+
 /**
  * Monotonic id attached to each uploaded file at insert time. Using `name` or
  * the index as the React key would cause duplicate-named files or removals
@@ -110,12 +166,27 @@ export function FeedbackButton({
   const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [succeeded, setSucceeded] = useState(false);
+  // Submitter's per-report AI preference. Defaults to true so the toggle
+  // renders "on" the first time; only read on submit when the render-policy
+  // matrix below says the toggle should be visible.
+  const [useAi, setUseAi] = useState(true);
   const mountedRef = useRef(true);
   const screenshotUrlRef = useRef<string | null>(null);
   const fileIdRef = useRef(0);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
   useBrevwickStyles();
+
+  const projectConfig = useProjectConfig(open);
+  // Render-policy matrix, SDD § 12. The toggle is visible exactly when the
+  // config has loaded successfully, AI is enabled for the project, AND the
+  // admin has opted submitters into the choice. Any other state (loading,
+  // error, disabled, admin-forced) hides the toggle and the payload omits
+  // `use_ai` so the server-side default applies.
+  const showAiToggle =
+    projectConfig.status === 'ready' &&
+    projectConfig.config?.ai_enabled === true &&
+    projectConfig.config.ai_submitter_choice_allowed === true;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -152,6 +223,7 @@ export function FeedbackButton({
     setConfirmClose(false);
     setSubmitError(null);
     setSucceeded(false);
+    setUseAi(true);
     reset();
   }, [reset]);
 
@@ -261,6 +333,10 @@ export function FeedbackButton({
       expected: expected.trim() || undefined,
       actual: actual.trim() || undefined,
       attachments: attachments.length ? attachments : undefined,
+      // use_ai rides the payload only when the submitter has been given
+      // the choice; in every other render state we leave the server-side
+      // default alone.
+      ...(showAiToggle ? { use_ai: useAi } : {}),
     };
 
     try {
@@ -288,7 +364,18 @@ export function FeedbackButton({
       setSubmitError(message);
       setOpen(true);
     }
-  }, [actual, draft, expected, files, onSubmit, screenshot, status, submit]);
+  }, [
+    actual,
+    draft,
+    expected,
+    files,
+    onSubmit,
+    screenshot,
+    showAiToggle,
+    status,
+    submit,
+    useAi,
+  ]);
 
   // Pending-focus flag: "Send another" needs to focus the composer, but the
   // composer only remounts after the SuccessState unmounts. A layout effect
@@ -372,10 +459,13 @@ export function FeedbackButton({
               ref={composerRef}
               draft={draft}
               submitting={status === 'submitting'}
+              showAiToggle={showAiToggle}
+              useAi={useAi}
               onDraftChange={setDraft}
               onSubmit={doSubmit}
               onAttachScreenshot={handleCaptureScreenshot}
               onAttachFiles={handleFiles}
+              onUseAiChange={setUseAi}
             />
           )}
         </Dialog.Content>
@@ -654,10 +744,13 @@ function DisclosureExpectedActual({
 interface ComposerProps {
   draft: string;
   submitting: boolean;
+  showAiToggle: boolean;
+  useAi: boolean;
   onDraftChange: (v: string) => void;
   onSubmit: () => void;
   onAttachScreenshot: () => void;
   onAttachFiles: (list: FileList | null) => void;
+  onUseAiChange: (v: boolean) => void;
 }
 
 const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
@@ -665,10 +758,13 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
     {
       draft,
       submitting,
+      showAiToggle,
+      useAi,
       onDraftChange,
       onSubmit,
       onAttachScreenshot,
       onAttachFiles,
+      onUseAiChange,
     },
     forwardedRef,
   ): ReactElement {
@@ -735,6 +831,9 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
           onKeyDown={handleKeyDown}
           aria-label="Feedback message"
         />
+        {showAiToggle && (
+          <AIToggle on={useAi} disabled={submitting} onChange={onUseAiChange} />
+        )}
         <button
           type="button"
           className="brw-send-btn"
@@ -748,6 +847,44 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
     );
   },
 );
+
+interface AIToggleProps {
+  on: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+}
+
+/**
+ * Inline pill/switch surfaced in the composer footer when the project allows
+ * submitters to opt in/out of AI formatting per report. role="switch" +
+ * aria-checked is the narrow semantic the WCAG a11y matrix wants; Space
+ * toggles when focused (default browser behaviour on role="button" is Enter
+ * and Space, but Space carries fewer collisions with the composer's
+ * Enter-to-send shortcut).
+ */
+function AIToggle({ on, disabled, onChange }: AIToggleProps): ReactElement {
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>): void => {
+    if (e.key === ' ') {
+      e.preventDefault();
+      onChange(!on);
+    }
+  };
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label="Format with AI"
+      className={`brw-aitoggle${on ? ' brw-aitoggle--on' : ''}`}
+      disabled={disabled}
+      onClick={() => onChange(!on)}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="brw-aitoggle-dot" aria-hidden="true" />
+      <span>AI</span>
+    </button>
+  );
+}
 
 interface SuccessStateProps {
   onSendAnother: () => void;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -317,6 +317,43 @@ export const BREVWICK_CSS = `
   cursor: pointer;
   flex-shrink: 0;
 }
+.brw-aitoggle {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px 0 8px;
+  border-radius: 999px;
+  border: 1px solid var(--brw-border);
+  background: var(--brw-chip-bg);
+  color: var(--brw-muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+}
+.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: 1px; }
+.brw-aitoggle:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-aitoggle-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--brw-muted);
+  transition: background-color 120ms ease-out;
+}
+.brw-aitoggle--on {
+  background: var(--brw-accent);
+  color: var(--brw-accent-fg);
+  border-color: var(--brw-accent);
+}
+.brw-aitoggle--on .brw-aitoggle-dot {
+  background: var(--brw-accent-fg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-aitoggle, .brw-aitoggle-dot { transition: none; }
+}
 .brw-send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-send-btn svg { width: 16px; height: 16px; }
 .brw-file-input { display: none; }

--- a/packages/sdk/src/__tests__/config.test.ts
+++ b/packages/sdk/src/__tests__/config.test.ts
@@ -1,0 +1,165 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { createBrevwick } from '../core/client';
+import { __resetBrevwickRegistry } from '../testing';
+
+const KEY = 'pk_test_aaaaaaaaaaaaaaaa02';
+const ENDPOINT = 'https://api.brevwick.com';
+const CONFIG_URL = `${ENDPOINT}/v1/ingest/config`;
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  __resetBrevwickRegistry();
+  vi.restoreAllMocks();
+});
+afterAll(() => server.close());
+
+describe('fetchConfig / Brevwick.getConfig', () => {
+  it('parses a well-shaped 200 response into ProjectConfig', async () => {
+    server.use(
+      http.get(CONFIG_URL, () =>
+        HttpResponse.json(
+          { ai_enabled: true, ai_submitter_choice_allowed: true },
+          { status: 200 },
+        ),
+      ),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const cfg = await instance.getConfig();
+    expect(cfg).toEqual({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+  });
+
+  it('stamps Authorization: Bearer <projectKey> on the config request', async () => {
+    let auth: string | null = null;
+    server.use(
+      http.get(CONFIG_URL, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json({
+          ai_enabled: false,
+          ai_submitter_choice_allowed: false,
+        });
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    await instance.getConfig();
+    expect(auth).toBe(`Bearer ${KEY}`);
+  });
+
+  it.each([
+    ['missing ai_enabled', { ai_submitter_choice_allowed: true }],
+    ['missing ai_submitter_choice_allowed', { ai_enabled: true }],
+    [
+      'ai_enabled not boolean',
+      { ai_enabled: 'yes', ai_submitter_choice_allowed: true },
+    ],
+    [
+      'ai_submitter_choice_allowed not boolean',
+      { ai_enabled: true, ai_submitter_choice_allowed: 1 },
+    ],
+    ['null body', null],
+    ['array body', []],
+  ])('returns null when the response is malformed (%s)', async (_l, body) => {
+    server.use(
+      http.get(CONFIG_URL, () => HttpResponse.json(body, { status: 200 })),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const cfg = await instance.getConfig();
+    expect(cfg).toBeNull();
+  });
+
+  it.each([401, 403, 404, 500, 503])(
+    'returns null on non-2xx (%s) without throwing',
+    async (status) => {
+      server.use(
+        http.get(CONFIG_URL, () =>
+          HttpResponse.json({ error: 'nope' }, { status }),
+        ),
+      );
+      const instance = createBrevwick({ projectKey: KEY });
+      const cfg = await instance.getConfig();
+      expect(cfg).toBeNull();
+    },
+  );
+
+  it('returns null on thrown fetch error', async () => {
+    server.use(http.get(CONFIG_URL, () => HttpResponse.error()));
+    const instance = createBrevwick({ projectKey: KEY });
+    const cfg = await instance.getConfig();
+    expect(cfg).toBeNull();
+  });
+
+  it('caches the first result — second call does not refetch', async () => {
+    let hits = 0;
+    server.use(
+      http.get(CONFIG_URL, () => {
+        hits++;
+        return HttpResponse.json({
+          ai_enabled: true,
+          ai_submitter_choice_allowed: false,
+        });
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const first = await instance.getConfig();
+    const second = await instance.getConfig();
+    expect(hits).toBe(1);
+    expect(second).toEqual(first);
+    expect(second).toEqual({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+  });
+
+  it('caches a null result so failures are not retried per session', async () => {
+    let hits = 0;
+    server.use(
+      http.get(CONFIG_URL, () => {
+        hits++;
+        return HttpResponse.json({ error: 'down' }, { status: 503 });
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const first = await instance.getConfig();
+    const second = await instance.getConfig();
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(hits).toBe(1);
+  });
+
+  it('collapses concurrent getConfig() calls into a single network round-trip', async () => {
+    let hits = 0;
+    server.use(
+      http.get(CONFIG_URL, () => {
+        hits++;
+        return HttpResponse.json({
+          ai_enabled: true,
+          ai_submitter_choice_allowed: true,
+        });
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const [a, b, c] = await Promise.all([
+      instance.getConfig(),
+      instance.getConfig(),
+      instance.getConfig(),
+    ]);
+    expect(hits).toBe(1);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+});

--- a/packages/sdk/src/__tests__/submit.test.ts
+++ b/packages/sdk/src/__tests__/submit.test.ts
@@ -677,6 +677,51 @@ describe('submit — ingest retry / failure modes', () => {
   });
 });
 
+describe('submit — use_ai threading', () => {
+  it.each([['true', true] as const, ['false', false] as const])(
+    'passes use_ai=%s through to the ingest payload when provided',
+    async (_label, flag) => {
+      installUploadHandlers();
+      let reportBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(REPORTS_URL, async ({ request }) => {
+          reportBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { report_id: 'rep_ai', status: 'received' },
+            { status: 202 },
+          );
+        }),
+      );
+      const instance = createBrevwick({ projectKey: KEY });
+      const result = await instance.submit({
+        description: 'd',
+        use_ai: flag,
+      });
+      expect(result.ok).toBe(true);
+      expect(reportBody?.use_ai).toBe(flag);
+    },
+  );
+
+  it('omits use_ai from the payload when not provided', async () => {
+    installUploadHandlers();
+    let reportBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(REPORTS_URL, async ({ request }) => {
+        reportBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { report_id: 'rep_no_ai', status: 'received' },
+          { status: 202 },
+        );
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const result = await instance.submit({ description: 'd' });
+    expect(result.ok).toBe(true);
+    expect(reportBody).toBeDefined();
+    expect('use_ai' in (reportBody ?? {})).toBe(false);
+  });
+});
+
 describe('submit — userContext throw safety', () => {
   it('treats a throwing userContext() as empty extras and still succeeds', async () => {
     installUploadHandlers();

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -1,0 +1,43 @@
+/**
+ * Project-config fetcher for `GET /v1/ingest/config`.
+ *
+ * Loaded lazily from `core/client.ts` so the eager bundle stays under the
+ * 2.2 kB gzip budget (see `CLAUDE.md` + SDD § 12). Never throws — failure
+ * modes all resolve to `null` so the widget degrades to "no toggle" without
+ * bubbling errors through the caller.
+ */
+import type { ProjectConfig } from './types';
+import { SDK_USER_AGENT } from './core/internal/sdk-version';
+
+function isValid(body: unknown): body is ProjectConfig {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  return (
+    typeof b.ai_enabled === 'boolean' &&
+    typeof b.ai_submitter_choice_allowed === 'boolean'
+  );
+}
+
+export async function fetchConfig(
+  endpoint: string,
+  projectKey: string,
+): Promise<ProjectConfig | null> {
+  try {
+    const res = await fetch(`${endpoint}/v1/ingest/config`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${projectKey}`,
+        'X-Brevwick-SDK': SDK_USER_AGENT,
+      },
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json().catch(() => null);
+    if (!isValid(body)) return null;
+    return {
+      ai_enabled: body.ai_enabled,
+      ai_submitter_choice_allowed: body.ai_submitter_choice_allowed,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -4,6 +4,7 @@ import type {
   ConsoleEntry,
   FeedbackInput,
   NetworkEntry,
+  ProjectConfig,
   RouteEntry,
   SubmitResult,
 } from '../types';
@@ -152,6 +153,13 @@ function build(
     onUninstall();
   }
 
+  // Per-instance cache of the GET /v1/ingest/config round-trip. The SDD
+  // contract is "per session" — once the first fetch resolves (success or
+  // null), every subsequent call returns the same promise. Storing the
+  // promise rather than the resolved value also collapses concurrent
+  // callers into a single network request.
+  let configPromise: Promise<ProjectConfig | null> | undefined;
+
   const instance: Brevwick = {
     install,
     uninstall,
@@ -169,6 +177,13 @@ function build(
       import('../screenshot').then((m) =>
         m.captureScreenshotForInstance(internal),
       ),
+    getConfig: (): Promise<ProjectConfig | null> => {
+      if (configPromise) return configPromise;
+      configPromise = import('../config').then((m) =>
+        m.fetchConfig(config.endpoint, config.projectKey),
+      );
+      return configPromise;
+    },
   };
 
   Object.defineProperty(instance, INTERNAL_KEY, {

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -179,9 +179,14 @@ function build(
       ),
     getConfig: (): Promise<ProjectConfig | null> => {
       if (configPromise) return configPromise;
-      configPromise = import('../config').then((m) =>
-        m.fetchConfig(config.endpoint, config.projectKey),
-      );
+      // `.catch(() => null)` covers the dynamic-import failure path
+      // (offline / CDN / deploy mismatch) so the public "never throws,
+      // resolves to null on failure" contract in types.ts holds. Without
+      // this, a one-time chunk-load failure would be cached as a rejected
+      // promise and every subsequent call would keep rejecting.
+      configPromise = import('../config')
+        .then((m) => m.fetchConfig(config.endpoint, config.projectKey))
+        .catch(() => null);
       return configPromise;
     },
   };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,6 +13,7 @@ export type {
   Environment,
   FeedbackAttachment,
   FeedbackInput,
+  ProjectConfig,
   SubmitError,
   SubmitErrorCode,
   SubmitResult,

--- a/packages/sdk/src/submit.ts
+++ b/packages/sdk/src/submit.ts
@@ -462,10 +462,12 @@ function composePayload(
     description: redact(input.description),
     expected: redactOptional(input.expected),
     actual: redactOptional(input.actual),
-    // Submitter's per-report AI preference (widget toggle). Only present
-    // when the widget is configured to expose the choice; booleans are
+    // Submitter's per-report AI preference (widget toggle). The key is
+    // present only when the caller supplied it so the in-memory payload
+    // matches the wire shape — a later `'use_ai' in payload` check should
+    // mean the same thing before and after JSON.stringify. Booleans are
     // intentionally NOT run through redact().
-    use_ai: input.use_ai,
+    ...(input.use_ai !== undefined ? { use_ai: input.use_ai } : {}),
     route_path: routePath,
     build_sha: config.buildSha,
     release: config.release,

--- a/packages/sdk/src/submit.ts
+++ b/packages/sdk/src/submit.ts
@@ -462,6 +462,10 @@ function composePayload(
     description: redact(input.description),
     expected: redactOptional(input.expected),
     actual: redactOptional(input.actual),
+    // Submitter's per-report AI preference (widget toggle). Only present
+    // when the widget is configured to expose the choice; booleans are
+    // intentionally NOT run through redact().
+    use_ai: input.use_ai,
     route_path: routePath,
     build_sha: config.buildSha,
     release: config.release,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -43,6 +43,22 @@ export interface FeedbackInput {
   expected?: string;
   actual?: string;
   attachments?: Array<Blob | FeedbackAttachment>;
+  /**
+   * Submitter's per-report AI preference. Only set by the widget when the
+   * project enables `ai_enabled` AND `ai_submitter_choice_allowed`. Omitted
+   * otherwise — the server-side default applies. See SDD § 12.
+   */
+  use_ai?: boolean;
+}
+
+/**
+ * Project-level AI configuration, surfaced by `GET /v1/ingest/config`. The
+ * React widget uses these two booleans to decide whether to show the
+ * submitter-facing "Format with AI" toggle.
+ */
+export interface ProjectConfig {
+  ai_enabled: boolean;
+  ai_submitter_choice_allowed: boolean;
 }
 
 /**
@@ -155,4 +171,12 @@ export interface Brevwick {
   uninstall(): void;
   submit(input: FeedbackInput): Promise<SubmitResult>;
   captureScreenshot(): Promise<Blob>;
+  /**
+   * Fetch project-level AI config from `GET /v1/ingest/config`. Resolves to
+   * `null` on non-2xx, malformed JSON, or thrown fetch — callers should treat
+   * `null` as "no submitter choice, no toggle". Cached per session: the
+   * result of the first invocation is reused for every subsequent call on
+   * the same instance.
+   */
+  getConfig(): Promise<ProjectConfig | null>;
 }


### PR DESCRIPTION
Closes #26

Implements [SDD § 12 Client SDK contracts](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts).

Depends on:

- brevwick-api#54 (`use_ai` on ingest)
- brevwick-api#56 (`GET /v1/ingest/config`)

## Summary

- New `Brevwick.getConfig()` — dynamic-imported, per-session cache, returns `ProjectConfig | null`
- `FeedbackInput` gains optional `use_ai: boolean`; `composePayload` threads it when defined, omits when undefined
- Widget fetches config lazily on the FIRST panel open (never on mount); second open re-uses the cached result
- Render-policy matrix (SDD § 12):
  - `ai_enabled=false` OR `config === null` → no toggle, `use_ai` omitted
  - `ai_enabled=true && ai_submitter_choice_allowed=false` → no toggle, admin forced default applies
  - `ai_enabled=true && ai_submitter_choice_allowed=true` → toggle renders on by default; Space / click flips
- `<AIToggle>` — inline pill inside the composer footer; `role="switch"` + `aria-checked`; accessible name "Format with AI"
- Core SDK eager chunk stays ≤ 2.2 kB gzip (`config.ts` lives in its own sibling chunk)
- React bundle stays well under the 25 kB gzip budget

## Contract changes (SDD § 12)

Adds `use_ai` (optional boolean) to the ingest payload. Server-side contract already landed in brevwick-api#54.

## Test plan

- [x] `fetchConfig` parses a valid shape; rejects malformed; returns null on non-2xx / thrown fetch
- [x] Caches first result; concurrent calls collapse to a single round-trip; null is cached too
- [x] Widget never calls `getConfig()` before first open; second open re-uses cache
- [x] Three render states covered: disabled / forced-on / submitter-choice
- [x] Failed config fetch degrades to no-toggle; submission still works and omits `use_ai`
- [x] Toggle a11y: `role="switch"`, `aria-checked` both states; Space toggles when focused
- [x] `composePayload` includes `use_ai` when provided (true / false) and omits when undefined
- [x] `chunk-split.test.ts` green — SDK eager chunk at 2107 bytes gzipped