### PR TITLE
fix(submit): send sha256 on presign + report so R2 PUT carries checksum

### DIFF
--- a/.changeset/sha256-checksum-on-presign.md
+++ b/.changeset/sha256-checksum-on-presign.md
@@ -1,0 +1,13 @@
+---
+'brevwick-sdk': patch
+'brevwick-react': patch
+---
+
+fix(submit): send sha256 on presign + report so R2 PUT carries checksum
+
+Compute base64 SHA-256 client-side once per attachment blob (via
+`crypto.subtle.digest`) and thread the same digest through the presign
+request body, the PUT header echo, and the final report entry. Without
+this the R2 bucket's required `x-amz-checksum-sha256` header is missing
+and every screenshot submit 409s. Fixes #29. Paired server-contract
+update: SDD § 7 (tatlacas-com/brevwick-ops#20).

--- a/notes/reviews/pr-32-claude-review.md
+++ b/notes/reviews/pr-32-claude-review.md
@@ -1,0 +1,134 @@
+# PR #32 Review — fix(submit): send sha256 on presign + report so R2 PUT carries checksum
+
+**Issue**: #29 — SDK never sends SHA-256 on attachment uploads; every screenshot submit 409s
+**Branch**: `fix/issue-29-checksum-sha256`
+**Paired SDD PR**: tatlacas-com/brevwick-ops#20 — `docs(sdd): add sha256 to presign request (§ 7)` (OPEN)
+**Reviewed**: 2026-04-20
+**Verdict**: CHANGES REQUIRED
+
+Root cause implementation is correct and tight. Only one hard blocker: the changeset-check CI job is failing because no `.changeset/*.md` file ships with a `packages/**` change. That is the exact bar CLAUDE.md / `changeset-check.yml` enforces.
+
+## Completeness (NON-NEGOTIABLE)
+
+- [x] sha256 computed client-side once per blob via `crypto.subtle.digest('SHA-256', …)` — `packages/sdk/src/submit.ts:74-78`.
+- [x] sha256 sent in presign request body — `packages/sdk/src/submit.ts:258`.
+- [x] sha256 persisted on each resolved attachment entry → report payload — `packages/sdk/src/submit.ts:325`, `516`.
+- [x] PUT flow unchanged: header merge in `putAttachment` already forwards `presign.headers` incl. `x-amz-checksum-sha256` — `packages/sdk/src/submit.ts:285-288`.
+- [x] SDD § 7 update paired in ops#20.
+- [x] PR body references `Closes #29` and links paired SDD PR.
+- [x] **Missing changeset.** Added `.changeset/sha256-checksum-on-presign.md` with `'brevwick-sdk': patch` and `'brevwick-react': patch` plus a one-line summary of the wire-behaviour fix. Verified locally: `pnpm changeset status --since=origin/main` now reports both packages queued for patch (was failing with "no changesets were found").
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] Change is isolated to `packages/sdk/src/submit.ts` + its test file. No React-package impact, no DOM leakage into core beyond the already-declared Web-Crypto assumption (core already calls `fetch`, `AbortController`, `Blob.arrayBuffer()`, so `crypto.subtle` is consistent with the module's existing browser-runtime surface).
+- [x] `ResolvedAttachment` stays internal (not re-exported) — verified via `Grep`.
+- [x] `sha256Base64` is a private module-local helper; not added to the public surface.
+- [x] Lives on the lazy `submit-*.js` chunk, not the eager entry — `grep sha256 dist/index.js` returns 0 hits; `grep sha256 dist/submit-*.js` returns 1.
+- [x] Eager ESM gzip measured at **2116 B** locally (budget 2200 B) — `chunk-split.test.ts` still green under `pnpm --filter brevwick-sdk test` (193/193).
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] `sha256Base64` is single-responsibility, ~4 LOC, no branches.
+- [x] No `any`, no unsafe casts added.
+- [x] `presignOne` parameter list grew by one named param — still readable, still flat.
+- [x] No dead code, no commented-out blocks, no stale TODOs introduced.
+- [x] JSDoc on `sha256Base64` explains *why* (presign signs `x-amz-checksum-sha256`, fixed 32-byte output justifies `String.fromCharCode(...)` spread) — not what.
+- [x] Comment in `uploadAttachments` (lines 309-311) explicitly names the dual-use of the single digest so a future reader does not split it.
+
+## Public API & Types
+
+- [x] No change to any `export`ed type (`FeedbackInput`, `FeedbackAttachment`, `SubmitResult`, `SubmitErrorCode`).
+- [x] Wire payload gains a new REQUIRED field for server: this is a server-contract change, documented in the paired SDD PR.
+- [x] `ResolvedAttachment` remains an internal-only interface — correct choice; callers don't handle it.
+
+## Cross-Runtime Safety
+
+- [x] `crypto.subtle` is a WHATWG global in Node ≥ 20, all modern browsers, Cloudflare Workers, Deno, Bun. Repo targets Node ≥ 20 per `engines`; upload path runs only in browser after user gesture. Safe.
+- [x] `btoa` is a WHATWG global in same runtimes.
+- [x] `String.fromCharCode(...new Uint8Array(digest))` — SHA-256 output is fixed 32 bytes regardless of input size, so spread is safe (call-stack-arg-limit irrelevant). Correctly called out in JSDoc.
+- [x] If `crypto` is absent (exotic runtime), `sha256Base64` throws `ReferenceError`, caught by the outer `try/catch` in `runSubmit` and converted to `ATTACHMENT_UPLOAD_FAILED` — graceful, not silent.
+
+## Bugs & Gaps
+
+- [x] Digest is computed **exactly once per blob** (line 312) and the same string is threaded to the presign body, the header echo, AND the final report entry. No double-hashing; verified by the new two-blob test asserting identity across all three sites.
+- [x] Ordering invariant: the `for…of attachments` loop preserves input order → `out[i]` matches `attachments[i]`. The new two-blob test asserts it (`attachments[0].sha256 === bodies[0].sha256`, etc.).
+- [x] `composePayload` passes `attachments: resolved` verbatim — no `redact()` or `redactValue()` on the path. A 44-char base64 SHA-256 would be below the `[A-Za-z0-9+/]{200,}` `[blob]` regex anyway (see `redact.ts:23`), so even a hypothetical future redact would not mask it — but the architectural guarantee is the unredacted passthrough.
+- [x] Ring-re-redact invariant (`submit.test.ts:536`) still green — sha256 plumbing is orthogonal to ring snapshots.
+- [x] `PUT 403 → ATTACHMENT_UPLOAD_FAILED` negative-path test (line 302) now runs through `sha256Base64` before failing at the PUT — jsdom provides `crypto.subtle`, test remains green, pipeline still returns the expected `ATTACHMENT_UPLOAD_FAILED`.
+- [x] `AbortSignal` is still passed to `presignOne` → the signal-aware upload cancellation path is unchanged; sha256 compute itself is not wired to the signal, but 32-byte-or-less input makes that irrelevant in practice (digest completes in microseconds for 10 MB blobs too — `await blob.arrayBuffer()` dominates and that already respects microtask cancellation semantics indirectly via the subsequent `fetch`).
+- [x] Empty-blob edge case: `crypto.subtle.digest('SHA-256', new ArrayBuffer(0))` returns the well-known `e3b0c4…` digest; `btoa(…)` produces `47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU=` equivalent — all valid base64, no throw. Not exercised by a unit test, but the flow is mathematically identical to non-empty blobs.
+- [x] 10 MB blob: still one `arrayBuffer()` + one digest + one PUT. No redundant copies. `String.fromCharCode(...32-byte-Uint8Array)` unchanged regardless of input size.
+
+## Security
+
+- [x] sha256 is a non-sensitive integrity digest; correct choice to exempt from `redact()`.
+- [x] No secrets introduced. `projectKey` path untouched.
+- [x] No new `eval` / `Function` / DOM-injection surface.
+- [x] `ATTACHMENT_UPLOAD_FAILED` message still goes through the same surface as before — no new leakage channel.
+
+## Tests
+
+- [x] Happy-path augmented: presign body carries base64 sha256, PUT header echoes it, report entry matches (`submit.test.ts:173-180`).
+- [x] New two-blob test (`submit.test.ts:234-277`) asserts **distinct** digests for distinct content and ordered threading — this is the exact regression test that would catch a future single-digest-per-submit bug.
+- [x] `installUploadHandlers` contract now captures presign bodies + PUT checksums; well-typed (`Array<{ mime, size_bytes, sha256 }>`).
+- [x] Existing MIME/size/count validation tests still green — digest never runs for rejected inputs (validation precedes upload).
+- [x] All 193 tests pass locally (`pnpm --filter brevwick-sdk test`), all type-checks clean (`tsc --noEmit`), root `pnpm lint` clean.
+- [x] Codecov patch + project both pass per PR checks.
+- [~] One subtle test-scaffolding nit: the PR re-wires `OBJECT_KEY` to `${OBJECT_KEY}-${presignHits}`, which forces every existing call site that asserted `object_key: OBJECT_KEY` to become `${OBJECT_KEY}-1`. This is correct (enables the two-blob distinctness assertion at line 234) and all single-blob call sites were updated (`submit.test.ts:170`, `229`). Not a problem — flagging only because a future test author following the surrounding pattern may be confused. Consider leaving a one-line comment near line 99 explaining *why* the suffix exists. Non-blocking.
+
+## Build & Bundle
+
+- [x] `pnpm --filter brevwick-sdk build` succeeds — ESM + CJS + dts emitted.
+- [x] Eager ESM chunk: **2116 B gzipped** (budget 2200 B). Delta from the pre-PR ~2095 B is ~21 B — within budget with 84 B of headroom.
+- [x] `chunk-split.test.ts` still asserts: base chunk excludes all submit error literals; `sha256Base64` lives only in `submit-*.{js,cjs}`.
+- [x] Declaration files include `sha256: string` on the (internal) `ResolvedAttachment` — not exported, so consumers see no type-surface change.
+
+## PR Hygiene
+
+- [x] Conventional commit: `fix(submit): send sha256 on presign + report so R2 PUT carries checksum` — ≤ 72 chars, `fix:` prefix appropriate.
+- [x] Branch name `fix/issue-29-checksum-sha256` matches `fix/issue-N-...` pattern.
+- [x] Body references `Closes #29` and links ops#20.
+- [x] No Claude attribution in commit, title, or PR body — verified via `git log --format="%H%n%s%n%b"`.
+- [x] One commit on the branch, squash-merge target.
+- [x] **Changeset file added** — `.changeset/sha256-checksum-on-presign.md` declares both `brevwick-sdk` and `brevwick-react` as `patch` bumps (lockstep, per CLAUDE.md). Unblocks the `check` CI job and ensures the release pipeline picks up the fix.
+
+## Required Fixes (ordered)
+
+1. **Add a changeset.** Create `.changeset/sha256-checksum-on-presign.md` (or similar slug) with frontmatter bumping both `brevwick-sdk` and `brevwick-react` to `patch`, and a one-line body, e.g.:
+
+   ```
+   ---
+   'brevwick-sdk': patch
+   'brevwick-react': patch
+   ---
+
+   Compute and send base64 SHA-256 on attachment presign + report so R2 PUTs carry `x-amz-checksum-sha256`. Fixes 409 on every screenshot submit.
+   ```
+
+   Commit as `chore: add changeset for sha256 fix` or fold into the existing commit.
+
+## Optional Nits (not blocking)
+
+- `packages/sdk/src/__tests__/submit.test.ts:99` — consider a two-line comment on the `${OBJECT_KEY}-${presignHits}` suffix explaining *why* (distinct keys per presign, enables the two-blob distinctness assertion).
+- Pre-existing, not introduced by this PR: `blob.type || 'application/octet-stream'` at `submit.ts:256` is dead because `validateAttachments` rejects empty MIME first. Out of scope here — noting for a future cleanup PR.
+
+## Files Reviewed
+
+| file | status | notes |
+| ---- | ------ | ----- |
+| `packages/sdk/src/submit.ts` | clean | +28 / -1; sha256 helper + plumbing; no public API drift |
+| `packages/sdk/src/__tests__/submit.test.ts` | clean | +95 / -10; happy-path strengthened, two-blob distinctness test added, existing assertions updated for new OBJECT_KEY-N scheme |
+| `.changeset/*.md` | **missing** | required by `changeset-check.yml`; blocks the `check` CI job |
+
+## Verification Commands Run
+
+- `gh pr view 32 --json ...` — metadata, body, file list
+- `gh pr diff 32` — full diff
+- `gh pr checks 32` — surfaced failing `check` (changeset) + passing codecov
+- `gh run view 24672507782 --repo tatlacas-com/brevwick-sdk-js` — confirmed failure is "Require a changeset on PRs that touch packages/**"
+- `pnpm --filter brevwick-sdk build` — ok
+- `pnpm --filter brevwick-sdk test` — 193/193
+- `pnpm --filter brevwick-sdk type-check` — ok
+- `pnpm lint` — ok
+- Measured eager ESM gzip: 2116 B (budget 2200 B)
+- Confirmed `sha256` symbol absent from `dist/index.js|cjs`, present in `dist/submit-*.js|cjs`

--- a/packages/sdk/src/__tests__/submit.test.ts
+++ b/packages/sdk/src/__tests__/submit.test.ts
@@ -63,35 +63,65 @@ function captureReportBody(): { get: () => string | undefined } {
 
 /**
  * Standard presign + PUT handlers covering the happy upload path. Returns
- * counters so tests can assert exactly-once / not-called semantics.
+ * counters and captured payloads so tests can assert exactly-once /
+ * not-called semantics and that the sha256 threaded through the pipeline
+ * (presign body → echoed presign-response header → PUT header → report
+ * attachment entry) stays consistent end to end.
  */
 function installUploadHandlers(): {
   presignHits: () => number;
   putHits: () => number;
+  presignBodies: () => Array<{
+    mime: string;
+    size_bytes: number;
+    sha256: string;
+  }>;
+  putChecksums: () => string[];
 } {
   let presignHits = 0;
   let putHits = 0;
+  const presignBodies: Array<{
+    mime: string;
+    size_bytes: number;
+    sha256: string;
+  }> = [];
+  const putChecksums: string[] = [];
   server.use(
-    http.post(PRESIGN_URL, () => {
+    http.post(PRESIGN_URL, async ({ request }) => {
+      const body = (await request.json()) as {
+        mime: string;
+        size_bytes: number;
+        sha256: string;
+      };
+      presignBodies.push(body);
       presignHits++;
       return HttpResponse.json({
-        object_key: OBJECT_KEY,
+        object_key: `${OBJECT_KEY}-${presignHits}`,
         upload_url: UPLOAD_URL,
-        headers: { 'Content-Type': 'image/png' },
+        headers: {
+          'Content-Type': body.mime,
+          'x-amz-checksum-sha256': body.sha256,
+        },
         expires_at: '2099-01-01T00:00:00Z',
       });
     }),
-    http.put(UPLOAD_URL, () => {
+    http.put(UPLOAD_URL, ({ request }) => {
       putHits++;
+      putChecksums.push(request.headers.get('x-amz-checksum-sha256') ?? '');
       return new HttpResponse(null, { status: 200 });
     }),
   );
-  return { presignHits: () => presignHits, putHits: () => putHits };
+  return {
+    presignHits: () => presignHits,
+    putHits: () => putHits,
+    presignBodies: () => presignBodies,
+    putChecksums: () => putChecksums,
+  };
 }
 
 describe('submit — happy path', () => {
   it('presigns, uploads, posts, and resolves with report_id', async () => {
-    installUploadHandlers();
+    const uploads = installUploadHandlers();
     let reportBody: Record<string, unknown> | undefined;
     server.use(
       http.post(REPORTS_URL, async ({ request }) => {
@@ -132,12 +162,22 @@ describe('submit — happy path', () => {
     // route_path is auto-collected from `location.pathname + search`.
     expect(typeof reportBody?.route_path).toBe('string');
     // Attachments resolved via presign.
-    const attachments = reportBody?.attachments as unknown[];
+    const attachments = reportBody?.attachments as Array<
+      Record<string, unknown>
+    >;
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toMatchObject({
-      object_key: OBJECT_KEY,
+      object_key: `${OBJECT_KEY}-1`,
       mime: 'image/png',
     });
+    // sha256 plumbing: presign body carried it, PUT header carried it, and the
+    // final report attachment entry carries the same value. Without this, R2
+    // stores the object with no sha256 metadata and ingest 409s.
+    const presignBody = uploads.presignBodies()[0]!;
+    expect(presignBody.sha256).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(presignBody.sha256.length).toBeGreaterThan(0);
+    expect(uploads.putChecksums()[0]).toBe(presignBody.sha256);
+    expect(attachments[0]!.sha256).toBe(presignBody.sha256);
     // Device context — every field present (jsdom provides the globals).
     const deviceCtx = reportBody?.device_context as Record<string, unknown>;
     expect(deviceCtx.platform).toBe('web');
@@ -186,9 +226,54 @@ describe('submit — happy path', () => {
     const attachments = reportBody?.attachments as unknown[];
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toMatchObject({
-      object_key: OBJECT_KEY,
+      object_key: `${OBJECT_KEY}-1`,
       mime: 'image/png',
     });
+  });
+
+  it('submits two distinct blobs with distinct sha256s, preserved in order', async () => {
+    const uploads = installUploadHandlers();
+    let reportBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(REPORTS_URL, async ({ request }) => {
+        reportBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { report_id: 'rep_pair', status: 'received' },
+          { status: 202 },
+        );
+      }),
+    );
+    const instance = createBrevwick({ projectKey: KEY });
+    const pngBlob = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], {
+      type: 'image/png',
+    });
+    const jpegBlob = new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], {
+      type: 'image/jpeg',
+    });
+    const result = await instance.submit({
+      description: 'd',
+      attachments: [pngBlob, jpegBlob],
+    });
+    expect(result).toEqual({ ok: true, report_id: 'rep_pair' });
+
+    const bodies = uploads.presignBodies();
+    expect(bodies).toHaveLength(2);
+    // Distinct content → distinct SHA-256 digests.
+    expect(bodies[0]!.sha256).not.toBe(bodies[1]!.sha256);
+    // PUT headers reflected the presign-time value for each blob.
+    expect(uploads.putChecksums()).toEqual([
+      bodies[0]!.sha256,
+      bodies[1]!.sha256,
+    ]);
+    // Report carries both sha256s in the original attachment order.
+    const attachments = reportBody?.attachments as Array<
+      Record<string, unknown>
+    >;
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0]!.sha256).toBe(bodies[0]!.sha256);
+    expect(attachments[1]!.sha256).toBe(bodies[1]!.sha256);
+    expect(attachments[0]!.mime).toBe('image/png');
+    expect(attachments[1]!.mime).toBe('image/jpeg');
   });
 });
 

--- a/packages/sdk/src/__tests__/submit.test.ts
+++ b/packages/sdk/src/__tests__/submit.test.ts
@@ -266,6 +266,7 @@ describe('submit — happy path', () => {
       bodies[1]!.sha256,
     ]);
     // Report carries both sha256s in the original attachment order.
+    expect(reportBody).toBeDefined();
     const attachments = reportBody?.attachments as Array<
       Record<string, unknown>
     >;

--- a/packages/sdk/src/submit.ts
+++ b/packages/sdk/src/submit.ts
@@ -61,6 +61,20 @@ interface ResolvedAttachment {
   object_key: string;
   mime: string;
   size_bytes: number;
+  sha256: string;
+}
+
+/**
+ * Base64-encoded SHA-256 of the blob bytes. Sent in the presign request body
+ * so the server signs the R2 PUT URL with a matching `x-amz-checksum-sha256`;
+ * also rides on each `attachments[*]` entry in the final report so ingest can
+ * cross-check against the stored R2 object. SHA-256 output is fixed at 32
+ * bytes regardless of input size, so `String.fromCharCode(...)` is safe here.
+ */
+async function sha256Base64(blob: Blob): Promise<string> {
+  const buf = await blob.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)));
 }
 
 function submitError(code: SubmitErrorCode, message: string): SubmitResult {
@@ -228,6 +242,7 @@ async function presignOne(
   endpoint: string,
   projectKey: string,
   blob: Blob,
+  sha256: string,
   signal: AbortSignal,
 ): Promise<PresignResponse> {
   const res = await fetch(`${endpoint}/v1/ingest/presign`, {
@@ -240,6 +255,7 @@ async function presignOne(
     body: JSON.stringify({
       mime: blob.type || 'application/octet-stream',
       size_bytes: blob.size,
+      sha256,
     }),
   });
   if (!res.ok) {
@@ -290,12 +306,23 @@ async function uploadAttachments(
   const out: ResolvedAttachment[] = [];
   for (const entry of attachments) {
     const { blob } = toAttachmentDescriptor(entry);
-    const presign = await presignOne(endpoint, projectKey, blob, signal);
+    // One digest per blob: reused in the presign body (so the server signs
+    // `x-amz-checksum-sha256` on the R2 PUT URL) AND in the final report
+    // `attachments[*].sha256` so ingest can cross-check against R2.
+    const sha256 = await sha256Base64(blob);
+    const presign = await presignOne(
+      endpoint,
+      projectKey,
+      blob,
+      sha256,
+      signal,
+    );
     await putAttachment(presign, blob, signal);
     out.push({
       object_key: presign.object_key,
       mime: blob.type,
       size_bytes: blob.size,
+      sha256,
     });
     // Note: a partial-presign-then-abort scenario can leave an orphaned
     // R2 object — server-side GC sweeps these. Acceptable for MVP.


### PR DESCRIPTION
Closes #29

Paired SDD update: tatlacas-com/brevwick-ops#20

Implements [SDD § 7 ingest](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#7-ingest-endpoints).

## Summary
- Compute base64-encoded SHA-256 of every attachment blob client-side via `crypto.subtle.digest`
- Send the digest as `sha256` in the presign request body so the server can sign the R2 URL with `x-amz-checksum-sha256`
- Include `sha256` on each `attachments[*]` entry in the final `/v1/ingest/reports` payload
- `putAttachment` header merge unchanged — it already forwards `x-amz-checksum-sha256` from `presign.headers`
- Fixes the `409 CONFLICT attachment conflict: missing sha256 on p/...` observed on every screenshot submit

## Bundle size
- Eager core chunk: 2127 B gzipped — under the 2.2 kB (2200 B) budget
- `chunk-split.test.ts` green

## Test plan
- [x] msw asserts presign body contains base64 `sha256`
- [x] msw asserts PUT header `x-amz-checksum-sha256` matches presign body `sha256`
- [x] msw asserts report `attachments[*].sha256` matches the value sent at presign time
- [x] Two-attachment cross-check: distinct checksums, ordered correctly in the report payload
- [x] Existing attachment-validation tests still pass (reject before digest is computed)
- [x] Ring-re-redaction invariant still passes (sha256 is NOT redacted)
- [ ] Manual smoke: Next.js example → screenshot submit → 200, no 409