### PR TITLE
feat(react): light/dark theming + composer shell polish

### DIFF
--- a/.changeset/theming-composer-shell.md
+++ b/.changeset/theming-composer-shell.md
@@ -1,0 +1,30 @@
+---
+'brevwick-react': minor
+'brevwick-sdk': patch
+---
+
+feat(react): light/dark theming + composer shell polish
+
+- Introduce a `--brw-*` CSS custom-property token set on `:where(:root)`
+  (specificity 0) so any host rule re-themes the widget without
+  `!important`. Surface, text, border, accent, shadow, and divider
+  tokens are covered; status colours (`--brw-error`) stay widget-internal.
+- Light defaults ship out of the box; a
+  `@media (prefers-color-scheme: dark)` override swaps the palette when
+  the host OS reports dark mode. Host overrides persist across modes.
+- Composer controls are wrapped in a rounded `.brw-composer-shell`
+  with a `:focus-within` ring, so the textarea + icon buttons + send +
+  AI toggle read as a single input affordance.
+- Multiline textarea retains the 1–5 row autogrow; `align-items:
+flex-end` keeps the send button pinned to the bottom as the textarea
+  grows.
+- JSDoc on `<FeedbackButton>` documents every public token, including
+  `--brw-bubble-user-fg` and `--brw-divider`.
+- vitest-axe added as a devDep and runs clean on the rendered panel in
+  both light and dark matchMedia stubs.
+- No public API change (props / hooks / payload unchanged); no new
+  runtime dependency.
+
+The `brevwick-sdk` bump is a no-op patch to keep the two packages in
+lockstep per the repo's pre-1.0 versioning policy; the core SDK has
+no code changes in this release.

--- a/notes/reviews/pr-33-claude-review.md
+++ b/notes/reviews/pr-33-claude-review.md
@@ -1,0 +1,124 @@
+# PR #33 Review — feat(react): light/dark theming + composer shell polish
+
+**Issue**: #30 — feat(react): light/dark theming + host-app awareness + composer polish
+**Branch**: feat/issue-30-theming
+**Base**: main
+**Reviewed**: 2026-04-20
+**Verdict**: **CHANGES REQUIRED** → all items resolved.
+
+Locally `pnpm --filter brevwick-react test` is green (66/66, +1 for the new contrast guard), `pnpm --filter brevwick-react build` succeeds (8463 B gzip, under the 25 kB budget), `pnpm lint` clean, `pnpm --filter brevwick-react type-check` clean. Remote CI on the follow-up push: both `check` jobs green.
+
+---
+
+## Completeness (NON-NEGOTIABLE)
+
+- [x] Every colour / background / shadow in `styles.ts` reads from a `--brw-*` custom property — the hex-literal audit test enforces this.
+- [x] Light default + `@media (prefers-color-scheme: dark)` swap.
+- [x] Host-override contract: `body { --brw-accent: hotpink }` swaps the send button — `packages/react/src/__tests__/feedback-button.test.tsx:1027` asserts this via `getComputedStyle` on the portaled send button.
+- [x] Composer shell + `:focus-within` ring present at `packages/react/src/styles.ts:315-327`.
+- [x] Textarea autogrow unchanged; `align-items: flex-end` on the shell keeps the send bottom-aligned.
+- [x] Bundle ≤ 25 kB gzip: measured **8341 B** locally (PR body quotes 8347, within rounding).
+- [x] **Public-API contract gap in JSDoc** — JSDoc on `FeedbackButton` now lists `--brw-bubble-user-fg` (paired with `--brw-bubble-user-bg`) and `--brw-divider`; accent pairing-rule documented too.
+- [x] **SDD § 12 not updated.** brevwick-ops PR #21 adds a full "Theming contract" subsection to § 12 (public token table + widget-internal tokens + pairing rules + host-override example + reduced-motion). Cross-repo PR is linked from this PR's body.
+- [x] `use_ai` / submitter-choice code paths untouched.
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] Core SDK (`packages/sdk`) untouched. All changes scoped to `packages/react/src/**`.
+- [x] No React / JSX / DOM leak into core.
+- [x] No new public runtime export added to `packages/react/src/index.ts`; `BREVWICK_CSS` / `BREVWICK_STYLE_ID` / `COMPOSER_MAX_HEIGHT_PX` remain internal (tests import them by module path, not from the package entry). Good.
+- [x] Tree-shakeable; `"sideEffects": false` preserved.
+- [x] DI preserved — no outside-world calls introduced.
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] **Dead token**: `--brw-success` removed from `styles.ts`. `--brw-error` remains (it has a consumer at `.brw-error`).
+- [x] **Dark-mode status tokens missing**: after removing `--brw-success`, only `--brw-error` is declared as a status colour. Added a comment on the light declaration explaining the red reads adequately on the dark `--brw-panel-bg` so the token is intentionally carried through (no dark-block override).
+- [x] **`expect.extend` interposed between imports** — moved to `packages/react/vitest.setup.ts`; feedback-button.test.tsx's imports are now contiguous again.
+- [x] **Flat-out duplicated cast** — replaced by a single ambient `src/__tests__/vitest-axe.d.ts` that augments vitest 4's `Assertion` interface. Both axe specs now call `expect(results).toHaveNoViolations()` directly and type-check.
+- [x] No `any` introduced; casts are narrow and commented.
+- [x] Names reveal intent (`--brw-fg-muted` rename is clearer than the old `--brw-muted`).
+- [x] No commented-out code, no TODOs, no stubs.
+
+## Public API & Types
+
+- [x] **`vitest-axe` type augmentation — cleaner path exists.** Implemented at `packages/react/src/__tests__/vitest-axe.d.ts` (placed under `__tests__` so tsup's dts bundler does not leak it into the published `dist/*` types). Both axe specs now type-check with a direct `expect(results).toHaveNoViolations()` call.
+
+- [x] **JSDoc token list incomplete** — addressed under Completeness.
+
+- [x] No new props added. `FeedbackButtonProps` interface unchanged.
+
+## Cross-Runtime Safety
+
+- [x] `useBrevwickStyles` still guards `typeof document === 'undefined'` (line 64 of `feedback-button.tsx`) — SSR-safe.
+- [x] No new `window`/`document` access added to non-effect code paths.
+- [x] No Node-only globals introduced.
+- [x] `"use client"` banner preserved on `feedback-button.tsx`.
+
+## Bugs & Gaps
+
+- [x] **Hover box-shadow regression on FAB**. Pruned `box-shadow` from the `.brw-fab` transition list — only `transform` was animating anyway, so transitioning a static shadow was wasted paint budget. Design choice: hover lift is transform-only, rest shadow stays; inline comment records the intent.
+- [x] **axe tests do not exercise contrast in either theme.** BOTH remediations applied: (a) added an inline comment in the describe block stating that the axe specs guard structural a11y (role / aria / accessible-name) only, since happy-dom can't evaluate `@media` against stubbed matchMedia and axe marks `color-contrast` inapplicable without a layout engine; (b) added a dedicated `dark-mode bubble-user / accent pairs meet WCAG AA contrast` test that pulls the dark palette straight out of `BREVWICK_CSS`, computes the WCAG 2.x contrast ratio, and asserts ≥ 4.5:1 for `--brw-bubble-user-bg / --brw-bubble-user-fg` and `--brw-accent / --brw-accent-fg`. Works without a layout engine.
+- [x] **Accent/foreground pairing foot-gun**. JSDoc on `FeedbackButton` now explicitly calls out that `--brw-accent` + `--brw-accent-fg` MUST be set together, and `--brw-bubble-user-bg` + `--brw-bubble-user-fg` likewise. The SDD § 12 pairing-rules section mirrors this. Computed contrast-safe accent-fg is intentionally NOT implemented (more complex, review says "not required").
+- [x] No race conditions introduced. The `useBrevwickStyles` effect and autogrow effect unchanged.
+
+## Security
+
+- [x] No `eval` / `Function()` / `dangerouslySetInnerHTML`.
+- [x] Test-only stylesheet injection uses `textContent` (not `innerHTML`) at `feedback-button.test.tsx:1022-1024`. Good.
+- [x] No secrets; no new network paths.
+- [x] **CSP**: ~~acknowledged as "no new CSP risk; flagging for awareness"~~ — the existing SDD `<style>` + nonce-prop-backlog note on § 12 still stands; this PR does not widen the surface.
+
+## Tests
+
+- [x] 65 / 65 tests pass locally (`pnpm --filter brevwick-react test`).
+- [x] New describe block covers the main new surface area: token consumption, shell wrapping, autogrow, hex-audit, and axe smoke.
+- [x] **Brittle hex-audit regex** — replaced the `[\s\S]*?\n\s*}` regex with a `stripTokenBlocks` helper that walks balanced braces from each `:where(:root) {`. Whitespace / single-line / extra-nesting refactors can no longer silently mis-strip the token block and bleed hex defaults into the class-rules residue.
+- [x] **Panel-bg test mixes unmount / remount between assertions.** Reviewer confirms "currently passes, low priority". `screen.getByRole('dialog')` throws on multiple matches under React Testing Library, so a stale portal would surface as a test failure rather than a silent pass — the risk the reviewer flagged cannot manifest silently. No code change needed beyond the acknowledgement.
+- [x] **Autogrow test does NOT verify the autogrow value.** Now spies on `HTMLElement.prototype.scrollHeight` to return a value above `COMPOSER_MAX_HEIGHT_PX`, triggers the autogrow effect, and asserts `style.height === \`${COMPOSER_MAX_HEIGHT_PX}px\`` — catches both a regression that drops the effect (empty string) and one that silently removes the clamp.
+- [x] Cleanup in the describe-local afterEach (lines 998-1018) is thorough.
+
+## Build & Bundle
+
+- [x] `pnpm --filter brevwick-react build` succeeds.
+- [x] `.d.ts` emitted, dual ESM / CJS outputs intact.
+- [x] Gzipped ESM entry: **8341 B** — well under the 25 kB budget.
+- [x] `sideEffects: false` preserved.
+
+## PR Hygiene
+
+- [x] **HARD BLOCKER — missing changeset.** Added `.changeset/theming-composer-shell.md` with `brevwick-react: minor` + `brevwick-sdk: patch` (pre-1.0 lockstep; SDK has no code change in this PR). `changeset-check` CI now passes.
+- [x] Conventional commit subject: `feat(react): ...`.
+- [x] Branch matches `feat/issue-<N>-...`.
+- [x] PR body links `Closes #30` and the SDD § 12 anchor.
+- [x] No Claude / Co-Authored-By attribution anywhere (commit, PR body, code).
+- [x] No new runtime dependency — `vitest-axe` added as devDep only (verified in `packages/react/package.json:60`).
+
+## Files Reviewed
+
+| file | status | notes |
+| ---- | ------ | ----- |
+| `packages/react/src/styles.ts` | resolved | `--brw-success` removed; `--brw-error` light declaration commented (intentionally carried through dark); `.brw-fab` transition list pruned to `transform` only |
+| `packages/react/src/feedback-button.tsx` | resolved | JSDoc documents `--brw-bubble-user-fg` and `--brw-divider`; accent / bubble-user pairing rules spelled out inline |
+| `packages/react/src/__tests__/feedback-button.test.tsx` | resolved | `expect.extend` moved to `vitest.setup.ts`; cast replaced by ambient `.d.ts`; balanced-brace hex-strip; autogrow spies `scrollHeight` and asserts the exact clamp; structural-a11y caveat commented; WCAG-AA contrast guard added |
+| `packages/react/vitest.setup.ts` | new | now hosts `expect.extend(vitest-axe/matchers)` alongside `jest-dom` |
+| `packages/react/src/__tests__/vitest-axe.d.ts` | new | ambient augmentation of vitest 4's `Assertion` so axe matchers type-check; placed under `__tests__` so tsup's dts bundler does not leak into `dist/*` |
+| `packages/react/package.json` | ok | `vitest-axe` devDep is scoped correctly |
+| `pnpm-lock.yaml` | ok | transitive deps appear scoped to axe + vitest-axe |
+| SDD § 12 (cross-repo) | resolved | brevwick-ops PR #21 adds the Theming contract subsection to § 12, linked from this PR's body |
+| `.changeset/theming-composer-shell.md` | resolved | minor for `brevwick-react`, patch for `brevwick-sdk` (lockstep); `changeset-check` CI now green |
+
+---
+
+## Summary
+
+The implementation is architecturally sound and the composer-shell UX is a real improvement. The `:where(:root)` specificity-0 trade-off is defensible and correctly applied. However, before this can merge:
+
+1. **Add a changeset** — CI is red until this lands.
+2. **Update SDD § 12** — the token set is a new public contract; repo rule requires the cross-repo SDD PR in the same change.
+3. **Close the JSDoc / actual-token drift** — `--brw-bubble-user-fg` and `--brw-divider` need to be either documented or marked internal.
+4. **Remove dead `--brw-success`** and either define dark-mode status colours or comment the intentional carry-through.
+5. **Cleanup the test plumbing** — move `expect.extend` to `vitest.setup.ts`, add the single ambient `.d.ts` to drop the duplicated cast, and make either the hex-strip or the autogrow assertion less brittle.
+6. **Be honest about the axe tests** — either add a contrast unit-test against the tokens, or explicitly comment that the happy-dom axe pass is an ARIA guard and not a contrast guard.
+
+None of the above requires rearchitecting. All are small, targeted cleanups on a solid change.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,8 @@
     "@types/react-dom": "^19.2.3",
     "brevwick-sdk": "workspace:*",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "vitest-axe": "^0.1.0"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15"

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -7,6 +7,9 @@ import {
   within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { axe } from 'vitest-axe';
+import * as axeMatchers from 'vitest-axe/matchers';
+expect.extend(axeMatchers);
 import type {
   Brevwick,
   BrevwickConfig,
@@ -61,6 +64,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 const mount = (props: FeedbackButtonProps = {}) =>
@@ -980,3 +984,179 @@ describe('<FeedbackButton> — Use AI toggle', () => {
     expect('use_ai' in input).toBe(false);
   });
 });
+
+describe('<FeedbackButton> — theming + composer shell', () => {
+  /**
+   * The widget's default tokens live in a `:where(:root) { --brw-*: ... }`
+   * declaration at specificity 0, so any host rule (including a direct
+   * inline `style.setProperty` on body) beats it without `!important`. These
+   * tests assert the consumption contract: every surface / accent / focus
+   * affordance must read through a `var(--brw-*)` so host overrides take
+   * effect at mount time.
+   */
+
+  afterEach(() => {
+    // Clean up any host-level token overrides set by individual tests so
+    // they don't leak across the file.
+    const html = document.documentElement;
+    const body = document.body;
+    for (const el of [html, body]) {
+      for (let i = el.style.length - 1; i >= 0; i--) {
+        const prop = el.style.item(i)!;
+        if (prop.startsWith('--brw-')) el.style.removeProperty(prop);
+      }
+      for (const cls of [
+        'brw-test-panel-light',
+        'brw-test-panel-dark',
+      ] as const) {
+        el.classList.remove(cls);
+      }
+    }
+    document
+      .querySelectorAll('style[data-brw-test-stylesheet]')
+      .forEach((el) => el.remove());
+  });
+
+  function injectTestSheet(css: string): void {
+    const el = document.createElement('style');
+    el.setAttribute('data-brw-test-stylesheet', '');
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+
+  it('send button background reads from --brw-accent set on a widget ancestor', () => {
+    // Radix Portal mounts the dialog into document.body, so setting the
+    // token on body propagates via inheritance to the portaled content.
+    document.body.style.setProperty('--brw-accent', 'rgb(255, 0, 0)');
+    mount();
+    openPanel();
+    const sendBtn = screen.getByRole('button', { name: /^send$/i });
+    expect(getComputedStyle(sendBtn).backgroundColor).toBe('rgb(255, 0, 0)');
+  });
+
+  it('panel background reads from --brw-panel-bg (light / dark sentinels swap independently)', () => {
+    // Test-only stylesheet that defines two ancestor classes with distinct
+    // --brw-panel-bg values. Toggling the class on body must flip the
+    // widget panel's computed backgroundColor, proving the consumption path.
+    injectTestSheet(`
+      .brw-test-panel-light { --brw-panel-bg: rgb(1, 2, 3); }
+      .brw-test-panel-dark  { --brw-panel-bg: rgb(4, 5, 6); }
+    `);
+
+    document.body.classList.add('brw-test-panel-light');
+    const lightView = mount();
+    openPanel();
+    expect(getComputedStyle(screen.getByRole('dialog')).backgroundColor).toBe(
+      'rgb(1, 2, 3)',
+    );
+    lightView.unmount();
+
+    document.body.classList.remove('brw-test-panel-light');
+    document.body.classList.add('brw-test-panel-dark');
+    mount();
+    openPanel();
+    expect(getComputedStyle(screen.getByRole('dialog')).backgroundColor).toBe(
+      'rgb(4, 5, 6)',
+    );
+  });
+
+  it('composer children are wrapped in a single .brw-composer-shell div', () => {
+    mount();
+    openPanel();
+    const textarea = screen.getByRole('textbox', {
+      name: /feedback message/i,
+    });
+    const shell = textarea.parentElement as HTMLElement;
+    expect(shell.className).toMatch(/brw-composer-shell/);
+    // All composer controls share this shell parent.
+    expect(
+      within(shell).getByRole('button', { name: /attach screenshot/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(shell).getByRole('button', { name: /^send$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('composer shell declares a :focus-within rule on --brw-border-focus', () => {
+    // happy-dom's computed-style engine does not evaluate the :focus-within
+    // pseudo-class, so the behaviour is pinned via a string guard on the
+    // emitted stylesheet. A regression that drops the rule (or hardcodes a
+    // colour) is caught here.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-composer-shell:focus-within[^{]*\{[^}]*border-color:\s*var\(--brw-border-focus\)/,
+    );
+  });
+
+  it('composer textarea autogrows — input events apply an inline height', () => {
+    mount();
+    openPanel();
+    const textarea = screen.getByRole('textbox', {
+      name: /feedback message/i,
+    }) as HTMLTextAreaElement;
+    // The autogrow effect runs on draft change, setting height to
+    // min(scrollHeight, COMPOSER_MAX_HEIGHT_PX). Regardless of happy-dom's
+    // scrollHeight value (typically 0), the inline style must be applied —
+    // a regression that drops the effect would leave `style.height` empty.
+    fireEvent.change(textarea, {
+      target: { value: 'line 1\nline 2\nline 3\nline 4\nline 5' },
+    });
+    expect(textarea.style.height).toMatch(/px$/);
+  });
+
+  it('every themeable declaration reads from a --brw-* token (no hardcoded hex in class rules)', () => {
+    // Acceptance-criterion guard: shadows, colours, and backgrounds in
+    // class rules must flow through `var(--brw-*)`. Hex literals inside a
+    // class-rule body break the host-override contract. We strip the token
+    // blocks first (those are ALLOWED to hold hex defaults), then assert
+    // the remainder has no hex literals.
+    const stripped = BREVWICK_CSS.replace(
+      /:where\(:root\)\s*\{[\s\S]*?\n\s*\}/g,
+      '',
+    );
+    expect(stripped).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+  });
+
+  it('vitest-axe is clean on the rendered panel in a light matchMedia stub', async () => {
+    stubMatchMedia(false);
+    mount();
+    openPanel();
+    const results = await axe(screen.getByRole('dialog'));
+    // vitest-axe's matcher type declarations target the legacy `Vi` namespace
+    // that vitest 4 no longer uses, so the matcher is valid at runtime but
+    // invisible to tsc. Cast through an interface that names the matcher
+    // shape explicitly — more legible than a blanket `as any`.
+    (
+      expect(results) as unknown as { toHaveNoViolations: () => void }
+    ).toHaveNoViolations();
+  });
+
+  it('vitest-axe is clean on the rendered panel in a dark matchMedia stub', async () => {
+    stubMatchMedia(true);
+    mount();
+    openPanel();
+    const results = await axe(screen.getByRole('dialog'));
+    (
+      expect(results) as unknown as { toHaveNoViolations: () => void }
+    ).toHaveNoViolations();
+  });
+});
+
+/**
+ * Stub window.matchMedia so `(prefers-color-scheme: dark)` reports the
+ * chosen value. happy-dom doesn't re-evaluate `@media` CSS rules against a
+ * stubbed matchMedia, so this is intended for callers that check matchMedia
+ * themselves (e.g. axe's own UA detection). Restored automatically via the
+ * top-level `afterEach` that clears mocks / unstubs globals.
+ */
+function stubMatchMedia(prefersDark: boolean): void {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('prefers-color-scheme: dark') ? prefersDark : false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }));
+}

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1266,9 +1266,11 @@ function extractDarkTokenBlock(css: string): Record<string, string> {
 
 /**
  * WCAG 2.x contrast ratio between two `#RRGGBB` hex colours. Returns a
- * number in [1, 21]; ≥ 4.5 is the AA bar for body text.
+ * number in [1, 21]; ≥ 4.5 is the AA bar for body text. The function is
+ * symmetric in its arguments (lighter / darker is resolved internally), so
+ * parameters are named `aHex` / `bHex` rather than `fg` / `bg`.
  */
-function contrastRatio(fgHex: string, bgHex: string): number {
+function contrastRatio(aHex: string, bHex: string): number {
   const lum = (hex: string): number => {
     const cleaned = hex.trim().replace(/^#/, '');
     const full =
@@ -1285,8 +1287,8 @@ function contrastRatio(fgHex: string, bgHex: string): number {
       c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
     return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b);
   };
-  const L1 = lum(fgHex);
-  const L2 = lum(bgHex);
+  const L1 = lum(aHex);
+  const L2 = lum(bHex);
   const [lighter, darker] = L1 > L2 ? [L1, L2] : [L2, L1];
   return (lighter + 0.05) / (darker + 0.05);
 }

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -7,9 +7,11 @@ import {
   within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// `expect.extend(vitest-axe/matchers)` runs once per process in
+// `vitest.setup.ts`; the matching type augmentation lives in
+// `src/__tests__/vitest-axe.d.ts` so `toHaveNoViolations()` type-checks
+// without per-call casts.
 import { axe } from 'vitest-axe';
-import * as axeMatchers from 'vitest-axe/matchers';
-expect.extend(axeMatchers);
 import type {
   Brevwick,
   BrevwickConfig,
@@ -1087,47 +1089,62 @@ describe('<FeedbackButton> — theming + composer shell', () => {
     );
   });
 
-  it('composer textarea autogrows — input events apply an inline height', () => {
+  it('composer textarea autogrows — input events apply an inline height', async () => {
     mount();
     openPanel();
     const textarea = screen.getByRole('textbox', {
       name: /feedback message/i,
     }) as HTMLTextAreaElement;
-    // The autogrow effect runs on draft change, setting height to
-    // min(scrollHeight, COMPOSER_MAX_HEIGHT_PX). Regardless of happy-dom's
-    // scrollHeight value (typically 0), the inline style must be applied —
-    // a regression that drops the effect would leave `style.height` empty.
-    fireEvent.change(textarea, {
-      target: { value: 'line 1\nline 2\nline 3\nline 4\nline 5' },
-    });
-    expect(textarea.style.height).toMatch(/px$/);
+    // happy-dom reports `scrollHeight === 0` for unmeasured textareas, so
+    // asserting only `/px$/` passes vacuously for `"0px"`. Spy on the
+    // prototype getter so the autogrow effect sees a realistic scrollHeight
+    // and we can assert the exact clamped value applied by the effect.
+    const { COMPOSER_MAX_HEIGHT_PX } = await import('../styles');
+    const fakeScrollHeight = 400; // deliberately above the clamp ceiling
+    const scrollHeightSpy = vi
+      .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+      .mockReturnValue(fakeScrollHeight);
+    try {
+      fireEvent.change(textarea, {
+        target: { value: 'line 1\nline 2\nline 3\nline 4\nline 5' },
+      });
+      // Effect sets height to `min(scrollHeight, COMPOSER_MAX_HEIGHT_PX)`.
+      // With scrollHeight > ceiling, the inline style must equal the
+      // ceiling — catches a regression that silently removes the clamp
+      // OR drops the effect (`style.height === ''`).
+      expect(textarea.style.height).toBe(`${COMPOSER_MAX_HEIGHT_PX}px`);
+    } finally {
+      scrollHeightSpy.mockRestore();
+    }
   });
 
   it('every themeable declaration reads from a --brw-* token (no hardcoded hex in class rules)', () => {
     // Acceptance-criterion guard: shadows, colours, and backgrounds in
     // class rules must flow through `var(--brw-*)`. Hex literals inside a
-    // class-rule body break the host-override contract. We strip the token
-    // blocks first (those are ALLOWED to hold hex defaults), then assert
-    // the remainder has no hex literals.
-    const stripped = BREVWICK_CSS.replace(
-      /:where\(:root\)\s*\{[\s\S]*?\n\s*\}/g,
-      '',
-    );
+    // class-rule body break the host-override contract. We strip the
+    // `:where(:root)` token blocks first (those are ALLOWED to hold hex
+    // defaults) via a balanced-brace walker, so a future refactor that
+    // reformats the block (single-line, extra nesting, etc.) doesn't
+    // silently break the guard.
+    const stripped = stripTokenBlocks(BREVWICK_CSS);
     expect(stripped).not.toMatch(/#[0-9a-fA-F]{3,8}/);
   });
 
+  // The two axe specs below guard structural a11y only (role / aria /
+  // accessible-name). happy-dom does not re-evaluate
+  // `@media (prefers-color-scheme: dark)` against the stubbed matchMedia,
+  // and axe-core's `color-contrast` rule reports `inapplicable` under
+  // happy-dom since the non-layout-engine environment can't resolve
+  // cascaded `color` values. Contrast for the default light + dark
+  // palettes is pinned separately via `dark-mode bubble-user / accent
+  // pairs meet WCAG AA contrast` below, which works directly off the
+  // emitted CSS strings and does not need a layout engine.
   it('vitest-axe is clean on the rendered panel in a light matchMedia stub', async () => {
     stubMatchMedia(false);
     mount();
     openPanel();
     const results = await axe(screen.getByRole('dialog'));
-    // vitest-axe's matcher type declarations target the legacy `Vi` namespace
-    // that vitest 4 no longer uses, so the matcher is valid at runtime but
-    // invisible to tsc. Cast through an interface that names the matcher
-    // shape explicitly — more legible than a blanket `as any`.
-    (
-      expect(results) as unknown as { toHaveNoViolations: () => void }
-    ).toHaveNoViolations();
+    expect(results).toHaveNoViolations();
   });
 
   it('vitest-axe is clean on the rendered panel in a dark matchMedia stub', async () => {
@@ -1135,9 +1152,25 @@ describe('<FeedbackButton> — theming + composer shell', () => {
     mount();
     openPanel();
     const results = await axe(screen.getByRole('dialog'));
-    (
-      expect(results) as unknown as { toHaveNoViolations: () => void }
-    ).toHaveNoViolations();
+    expect(results).toHaveNoViolations();
+  });
+
+  it('dark-mode bubble-user / accent pairs meet WCAG AA contrast', () => {
+    // Guard the default dark palette against silent regressions. Pulls the
+    // hex values straight out of the emitted CSS and computes the WCAG 2.x
+    // relative-luminance contrast ratio. Both the user-bubble and the
+    // accent (send button) need ≥ 4.5:1 for body-text AA.
+    const dark = extractDarkTokenBlock(BREVWICK_CSS);
+    const bubblePair = contrastRatio(
+      dark['--brw-bubble-user-bg']!,
+      dark['--brw-bubble-user-fg']!,
+    );
+    const accentPair = contrastRatio(
+      dark['--brw-accent']!,
+      dark['--brw-accent-fg']!,
+    );
+    expect(bubblePair).toBeGreaterThanOrEqual(4.5);
+    expect(accentPair).toBeGreaterThanOrEqual(4.5);
   });
 });
 
@@ -1159,4 +1192,101 @@ function stubMatchMedia(prefersDark: boolean): void {
     removeEventListener: () => undefined,
     dispatchEvent: () => false,
   }));
+}
+
+/**
+ * Remove every `:where(:root) { ... }` token-default block from the
+ * emitted CSS using a balanced-brace walker. Survives whitespace and
+ * newline refactors that a `[\s\S]*?\n\s*}` regex would silently
+ * mis-strip; used by the "no hardcoded hex in class rules" guard.
+ */
+function stripTokenBlocks(css: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < css.length) {
+    const match = css.slice(i).match(/:where\(:root\)\s*\{/);
+    if (!match) {
+      out.push(css.slice(i));
+      break;
+    }
+    const blockStart = i + match.index!;
+    out.push(css.slice(i, blockStart));
+    // Walk forward from the opening `{`, tracking nesting until the
+    // matching `}` closes this block.
+    let depth = 0;
+    let j = blockStart + match[0].length - 1; // points AT the `{`
+    for (; j < css.length; j++) {
+      const ch = css[j];
+      if (ch === '{') depth++;
+      else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          j++; // consume the closing brace
+          break;
+        }
+      }
+    }
+    i = j;
+  }
+  return out.join('');
+}
+
+/**
+ * Parse the `@media (prefers-color-scheme: dark) :where(:root) { ... }`
+ * block out of the emitted CSS and return every `--brw-*` declaration as
+ * a plain object. Used by the dark-palette contrast guard. Throws on a
+ * missing block so a future refactor that removes the dark palette fails
+ * loudly instead of silently skipping the check.
+ */
+function extractDarkTokenBlock(css: string): Record<string, string> {
+  const openRe = /@media\s*\(prefers-color-scheme:\s*dark\)\s*\{/;
+  const openMatch = css.match(openRe);
+  if (!openMatch) throw new Error('dark media block not found in BREVWICK_CSS');
+  const start = openMatch.index! + openMatch[0].length;
+  // Walk to the matching `}` of the @media wrapper.
+  let depth = 1;
+  let end = start;
+  for (; end < css.length; end++) {
+    const ch = css[end];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  const body = css.slice(start, end);
+  const tokens: Record<string, string> = {};
+  const declRe = /(--brw-[\w-]+)\s*:\s*([^;]+);/g;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(body)) !== null) {
+    tokens[m[1]!] = m[2]!.trim();
+  }
+  return tokens;
+}
+
+/**
+ * WCAG 2.x contrast ratio between two `#RRGGBB` hex colours. Returns a
+ * number in [1, 21]; ≥ 4.5 is the AA bar for body text.
+ */
+function contrastRatio(fgHex: string, bgHex: string): number {
+  const lum = (hex: string): number => {
+    const cleaned = hex.trim().replace(/^#/, '');
+    const full =
+      cleaned.length === 3
+        ? cleaned
+            .split('')
+            .map((c) => c + c)
+            .join('')
+        : cleaned;
+    const r = parseInt(full.slice(0, 2), 16) / 255;
+    const g = parseInt(full.slice(2, 4), 16) / 255;
+    const b = parseInt(full.slice(4, 6), 16) / 255;
+    const ch = (c: number): number =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b);
+  };
+  const L1 = lum(fgHex);
+  const L2 = lum(bgHex);
+  const [lighter, darker] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (lighter + 0.05) / (darker + 0.05);
 }

--- a/packages/react/src/__tests__/vitest-axe.d.ts
+++ b/packages/react/src/__tests__/vitest-axe.d.ts
@@ -1,0 +1,26 @@
+// Ambient type augmentation for vitest-axe.
+//
+// vitest-axe@0.1.0 ships matcher declarations that target the legacy `Vi`
+// namespace; vitest 4 moved the assertion interface to `Assertion` on the
+// main `vitest` module. Without this augmentation TypeScript does not see
+// `toHaveNoViolations` on `expect(...)`, and each test has to cast the
+// return of `expect()` to an ad-hoc interface. Registering the matchers
+// once via `expect.extend(axeMatchers)` in `vitest.setup.ts` wires them at
+// runtime; this file wires them at the type level.
+//
+// This file is test-only: it lives under `__tests__/` and is not reachable
+// from the package entry (`src/index.ts`), so tsup's dts bundler does not
+// emit it into the published `dist/*` types.
+import 'vitest';
+import type { AxeMatchers } from 'vitest-axe/matchers';
+
+declare module 'vitest' {
+  // Augmenting vitest's library interfaces to pull in `AxeMatchers`. The
+  // empty bodies are the idiomatic TS interface-merging shape: the members
+  // come from the `extends` clause. The generic param on `Assertion` must
+  // stay to match the upstream signature.
+  /* eslint-disable @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars */
+  interface Assertion<T = unknown> extends AxeMatchers {}
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+  /* eslint-enable @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars */
+}

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -162,6 +162,9 @@ interface FileAttachment {
  * - `--brw-panel-bg` — dialog panel background
  * - `--brw-bubble-assistant-bg` — assistant bubble background
  * - `--brw-bubble-user-bg` — user bubble background
+ * - `--brw-bubble-user-fg` — foreground on top of `--brw-bubble-user-bg`
+ *   (set as a pair with `--brw-bubble-user-bg` to keep bubble contrast
+ *   WCAG-adequate)
  * - `--brw-chip-bg` — attachment chip + inline panel background
  * - `--brw-composer-bg` — composer shell background
  *
@@ -172,10 +175,13 @@ interface FileAttachment {
  * Border / focus
  * - `--brw-border` — default border colour
  * - `--brw-border-focus` — colour applied on composer `:focus-within`
+ * - `--brw-divider` — hairline between panel header / composer and thread
  *
  * Accent
  * - `--brw-accent` — send button + active AI toggle colour
- * - `--brw-accent-fg` — foreground on top of accent
+ * - `--brw-accent-fg` — foreground on top of accent (set as a pair
+ *   with `--brw-accent` so accent + accent-fg stay contrast-safe; e.g.
+ *   a bright `--brw-accent` must pair with a dark `--brw-accent-fg`)
  *
  * Shadow
  * - `--brw-shadow` — composite drop shadow for FAB + panel

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -145,6 +145,43 @@ interface FileAttachment {
   readonly file: File;
 }
 
+/**
+ * Brevwick feedback widget — a FAB plus a dialog-based submission form.
+ *
+ * ## Theming
+ *
+ * The widget exposes a set of CSS custom properties (`--brw-*`) that any
+ * ancestor can override to re-theme without a rebuild. Light defaults ship
+ * out of the box; a `@media (prefers-color-scheme: dark)` block swaps the
+ * palette when the host OS is in dark mode. Set these as CSS custom
+ * properties on any ancestor (e.g. `:root` or your app shell) to re-theme
+ * the widget without a rebuild — the widget's own `.brw-root` scope never
+ * uses `!important`, so normal cascade wins.
+ *
+ * Surfaces
+ * - `--brw-panel-bg` — dialog panel background
+ * - `--brw-bubble-assistant-bg` — assistant bubble background
+ * - `--brw-bubble-user-bg` — user bubble background
+ * - `--brw-chip-bg` — attachment chip + inline panel background
+ * - `--brw-composer-bg` — composer shell background
+ *
+ * Text
+ * - `--brw-fg` — primary foreground text
+ * - `--brw-fg-muted` — muted / secondary text
+ *
+ * Border / focus
+ * - `--brw-border` — default border colour
+ * - `--brw-border-focus` — colour applied on composer `:focus-within`
+ *
+ * Accent
+ * - `--brw-accent` — send button + active AI toggle colour
+ * - `--brw-accent-fg` — foreground on top of accent
+ *
+ * Shadow
+ * - `--brw-shadow` — composite drop shadow for FAB + panel
+ *
+ * @see SDD § 12 for the React contract.
+ */
 export function FeedbackButton({
   position = 'bottom-right',
   disabled = false,
@@ -798,51 +835,57 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
 
     return (
       <div className="brw-composer">
-        <button
-          type="button"
-          className="brw-icon-btn"
-          aria-label="Attach screenshot"
-          onClick={onAttachScreenshot}
-          disabled={submitting}
-        >
-          <CameraIcon />
-        </button>
-        <label className="brw-icon-btn">
-          <PaperclipIcon />
-          <input
-            type="file"
-            multiple
-            aria-label="Attach file"
-            className="brw-file-input"
-            onChange={(e) => {
-              onAttachFiles(e.target.files);
-              e.target.value = '';
-            }}
+        <div className="brw-composer-shell">
+          <button
+            type="button"
+            className="brw-icon-btn"
+            aria-label="Attach screenshot"
+            onClick={onAttachScreenshot}
             disabled={submitting}
+          >
+            <CameraIcon />
+          </button>
+          <label className="brw-icon-btn">
+            <PaperclipIcon />
+            <input
+              type="file"
+              multiple
+              aria-label="Attach file"
+              className="brw-file-input"
+              onChange={(e) => {
+                onAttachFiles(e.target.files);
+                e.target.value = '';
+              }}
+              disabled={submitting}
+            />
+          </label>
+          <textarea
+            ref={textareaRef}
+            className="brw-composer-input"
+            rows={1}
+            placeholder="Describe the bug or feedback…"
+            value={draft}
+            onChange={(e) => onDraftChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Feedback message"
           />
-        </label>
-        <textarea
-          ref={textareaRef}
-          className="brw-composer-input"
-          rows={1}
-          placeholder="Describe the bug or feedback…"
-          value={draft}
-          onChange={(e) => onDraftChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          aria-label="Feedback message"
-        />
-        {showAiToggle && (
-          <AIToggle on={useAi} disabled={submitting} onChange={onUseAiChange} />
-        )}
-        <button
-          type="button"
-          className="brw-send-btn"
-          aria-label="Send"
-          disabled={submitting || draft.trim().length === 0}
-          onClick={onSubmit}
-        >
-          <SendIcon />
-        </button>
+          {showAiToggle && (
+            <AIToggle
+              on={useAi}
+              disabled={submitting}
+              onChange={onUseAiChange}
+            />
+          )}
+          <button
+            type="button"
+            className="brw-send-btn"
+            aria-label="Send"
+            disabled={submitting || draft.trim().length === 0}
+            onClick={onSubmit}
+          >
+            <SendIcon />
+          </button>
+        </div>
       </div>
     );
   },

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -1,8 +1,15 @@
 /**
  * Styles are injected via a single <style> tag rendered into the tree so the
  * package has zero CSS-loader requirements — consumers can drop the package
- * into any bundler (Next.js, Vite, Webpack) without config. Theming is done
- * through CSS variables and `prefers-color-scheme`.
+ * into any bundler (Next.js, Vite, Webpack) without config.
+ *
+ * Theming is done through `--brw-*` CSS custom properties. Defaults live on
+ * `:where(:root)` so the widget's declarations sit at specificity 0 — any
+ * host rule (including a normal `:root { --brw-accent: hotpink }`, a
+ * `body { ... }`, or any widget ancestor) wins without `!important`. Dark
+ * palette is swapped via `@media (prefers-color-scheme: dark)`; host
+ * overrides persist across modes because they're set on a different
+ * element / higher specificity.
  */
 export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
 
@@ -17,33 +24,33 @@ export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
 export const COMPOSER_MAX_HEIGHT_PX = 120;
 
 export const BREVWICK_CSS = `
-.brw-root {
-  --brw-bg: #ffffff;
-  --brw-fg: #0f172a;
-  --brw-muted: #64748b;
-  --brw-border: #e2e8f0;
-  --brw-accent: #0f172a;
-  --brw-accent-fg: #ffffff;
-  --brw-error: #b91c1c;
-  --brw-success: #047857;
+:where(:root) {
+  /* Surfaces */
   --brw-panel-bg: #ffffff;
   --brw-bubble-assistant-bg: #f1f5f9;
   --brw-bubble-user-bg: #0f172a;
   --brw-bubble-user-fg: #ffffff;
   --brw-chip-bg: #f1f5f9;
   --brw-composer-bg: #ffffff;
+  /* Text */
+  --brw-fg: #0f172a;
+  --brw-fg-muted: #64748b;
+  /* Border / focus */
+  --brw-border: #e2e8f0;
+  --brw-border-focus: #0f172a;
   --brw-divider: #e2e8f0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: var(--brw-fg);
+  /* Accent */
+  --brw-accent: #0f172a;
+  --brw-accent-fg: #ffffff;
+  /* Shadow */
+  --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  /* Status colours — not exposed in the public token list; widget-internal. */
+  --brw-error: #b91c1c;
+  --brw-success: #047857;
 }
 @media (prefers-color-scheme: dark) {
-  .brw-root {
-    --brw-bg: #0f172a;
-    --brw-fg: #f8fafc;
-    --brw-muted: #94a3b8;
-    --brw-border: #1e293b;
-    --brw-accent: #f8fafc;
-    --brw-accent-fg: #0f172a;
+  :where(:root) {
+    /* Surfaces */
     --brw-panel-bg: #0b1220;
     --brw-bubble-assistant-bg: #1e293b;
     --brw-bubble-user-bg: #f8fafc;
@@ -52,8 +59,23 @@ export const BREVWICK_CSS = `
        1px border stays visible against the chip body in dark mode. */
     --brw-chip-bg: #253044;
     --brw-composer-bg: #0b1220;
+    /* Text */
+    --brw-fg: #f8fafc;
+    --brw-fg-muted: #94a3b8;
+    /* Border / focus */
+    --brw-border: #1e293b;
+    --brw-border-focus: #f8fafc;
     --brw-divider: #1e293b;
+    /* Accent */
+    --brw-accent: #f8fafc;
+    --brw-accent-fg: #0f172a;
+    /* Shadow — deeper alpha so the panel still reads as lifted over a dark host */
+    --brw-shadow: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
   }
+}
+.brw-root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  color: var(--brw-fg);
 }
 .brw-fab {
   position: fixed;
@@ -72,12 +94,11 @@ export const BREVWICK_CSS = `
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  box-shadow: 0 6px 20px rgba(0,0,0,0.18), 0 2px 4px rgba(0,0,0,0.08);
+  box-shadow: var(--brw-shadow);
   transition: transform 120ms ease-out, box-shadow 120ms ease-out;
 }
 .brw-fab:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(0,0,0,0.22), 0 3px 6px rgba(0,0,0,0.1);
 }
 .brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
 .brw-fab-br { right: 24px; }
@@ -95,7 +116,7 @@ export const BREVWICK_CSS = `
   color: var(--brw-fg);
   border: 1px solid var(--brw-border);
   border-radius: 16px 16px 12px 12px;
-  box-shadow: 0 20px 48px rgba(0,0,0,0.25), 0 6px 12px rgba(0,0,0,0.12);
+  box-shadow: var(--brw-shadow);
   overflow: hidden;
   animation: brw-slide-up 200ms ease-out;
 }
@@ -149,14 +170,14 @@ export const BREVWICK_CSS = `
   display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid transparent;
   background: transparent;
-  color: var(--brw-muted);
+  color: var(--brw-fg-muted);
   border-radius: 6px;
   cursor: pointer;
   font: inherit;
   line-height: 1;
 }
 .brw-icon-btn:hover:not(:disabled) { background: var(--brw-chip-bg); color: var(--brw-fg); }
-.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: 1px; }
+.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-border-focus); outline-offset: 1px; }
 .brw-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-icon-btn svg { width: 16px; height: 16px; }
 .brw-thread {
@@ -209,7 +230,7 @@ export const BREVWICK_CSS = `
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px 6px 10px;
+  padding: 6px 10px;
   background: var(--brw-chip-bg);
   color: var(--brw-fg);
   border: 1px solid var(--brw-border);
@@ -224,14 +245,14 @@ export const BREVWICK_CSS = `
   flex-shrink: 0;
 }
 .brw-chip-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
-.brw-chip-size { color: var(--brw-muted); }
+.brw-chip-size { color: var(--brw-fg-muted); }
 .brw-chip-remove {
   width: 20px; height: 20px;
   padding: 0;
   display: inline-flex; align-items: center; justify-content: center;
   border: none;
   background: transparent;
-  color: var(--brw-muted);
+  color: var(--brw-fg-muted);
   border-radius: 999px;
   cursor: pointer;
   font: inherit;
@@ -243,7 +264,7 @@ export const BREVWICK_CSS = `
   background: transparent;
   border: none;
   padding: 0;
-  color: var(--brw-muted);
+  color: var(--brw-fg-muted);
   font: inherit;
   font-size: 12px;
   cursor: pointer;
@@ -263,7 +284,7 @@ export const BREVWICK_CSS = `
 .brw-disclosure-label {
   font-size: 11px;
   font-weight: 600;
-  color: var(--brw-muted);
+  color: var(--brw-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -282,30 +303,47 @@ export const BREVWICK_CSS = `
 }
 .brw-composer {
   flex-shrink: 0;
-  display: flex;
-  align-items: flex-end;
-  gap: 6px;
   padding: 8px 10px;
   background: var(--brw-composer-bg);
   border-top: 1px solid var(--brw-divider);
+}
+/* Rounded shell that groups the textarea + icon buttons + send + AI toggle
+   into a single visual input affordance. Border colour lifts to
+   --brw-border-focus when any descendant takes focus, so the whole shell
+   reads as focused without a per-child outline. align-items: flex-end keeps
+   the send button pinned to the bottom as the textarea autogrows. */
+.brw-composer-shell {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--brw-composer-bg);
+  border: 1px solid var(--brw-border);
+  border-radius: 12px;
+  transition: border-color 120ms ease-out;
+}
+.brw-composer-shell:focus-within {
+  border-color: var(--brw-border-focus);
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-composer-shell { transition: none; }
 }
 .brw-composer-input {
   flex: 1;
   min-height: 34px;
   max-height: ${COMPOSER_MAX_HEIGHT_PX}px;
   box-sizing: border-box;
-  padding: 8px 10px;
+  padding: 8px 4px;
   font: inherit;
   font-size: 13px;
   color: var(--brw-fg);
-  background: var(--brw-panel-bg);
-  border: 1px solid var(--brw-border);
-  border-radius: 10px;
+  background: transparent;
+  border: none;
   resize: none;
   overflow-y: auto;
   line-height: 1.4;
 }
-.brw-composer-input:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: -1px; }
+.brw-composer-input:focus-visible { outline: none; }
 .brw-send-btn {
   width: 34px; height: 34px;
   padding: 0;
@@ -327,20 +365,20 @@ export const BREVWICK_CSS = `
   border-radius: 999px;
   border: 1px solid var(--brw-border);
   background: var(--brw-chip-bg);
-  color: var(--brw-muted);
+  color: var(--brw-fg-muted);
   font: inherit;
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   transition: background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
 }
-.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-accent); outline-offset: 1px; }
+.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus); outline-offset: 1px; }
 .brw-aitoggle:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-aitoggle-dot {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: var(--brw-muted);
+  background: var(--brw-fg-muted);
   transition: background-color 120ms ease-out;
 }
 .brw-aitoggle--on {

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -44,7 +44,7 @@ export const BREVWICK_CSS = `
   --brw-accent-fg: #ffffff;
   /* Shadow */
   --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
-  /* Status colours — not exposed in the public token list; widget-internal.
+  /* Status colour — not exposed in the public token list; widget-internal.
      Carried through dark mode (same hue reads adequately on the dark
      --brw-panel-bg); override in the dark block if design ever wants a
      tuned variant. */

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -44,9 +44,11 @@ export const BREVWICK_CSS = `
   --brw-accent-fg: #ffffff;
   /* Shadow */
   --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
-  /* Status colours — not exposed in the public token list; widget-internal. */
+  /* Status colours — not exposed in the public token list; widget-internal.
+     Carried through dark mode (same hue reads adequately on the dark
+     --brw-panel-bg); override in the dark block if design ever wants a
+     tuned variant. */
   --brw-error: #b91c1c;
-  --brw-success: #047857;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
@@ -95,7 +97,9 @@ export const BREVWICK_CSS = `
   gap: 8px;
   cursor: pointer;
   box-shadow: var(--brw-shadow);
-  transition: transform 120ms ease-out, box-shadow 120ms ease-out;
+  /* Only transform animates on hover; box-shadow is static so it is
+     intentionally excluded from the transition list. */
+  transition: transform 120ms ease-out;
 }
 .brw-fab:hover:not(:disabled) {
   transform: translateY(-1px);

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach } from 'vitest';
+import { afterEach, expect } from 'vitest';
+import * as axeMatchers from 'vitest-axe/matchers';
+
+// Register vitest-axe matchers once per test process so individual test
+// files can call `expect(results).toHaveNoViolations()` directly. The
+// corresponding type augmentation lives in `src/types/vitest-axe.d.ts`.
+expect.extend(axeMatchers);
 
 afterEach(() => {
   cleanup();

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -5,7 +5,7 @@ import * as axeMatchers from 'vitest-axe/matchers';
 
 // Register vitest-axe matchers once per test process so individual test
 // files can call `expect(results).toHaveNoViolations()` directly. The
-// corresponding type augmentation lives in `src/types/vitest-axe.d.ts`.
+// corresponding type augmentation lives in `src/__tests__/vitest-axe.d.ts`.
 expect.extend(axeMatchers);
 
 afterEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.4)
 
   packages/sdk:
     devDependencies:
@@ -1508,6 +1511,10 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1559,6 +1566,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2059,6 +2070,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2729,6 +2743,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.1.4:
     resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
@@ -4011,6 +4030,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  axe-core@4.11.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4051,6 +4072,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   chardet@2.1.1: {}
 
@@ -4530,6 +4553,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -5132,6 +5157,16 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
+
+  vitest-axe@0.1.0(vitest@4.1.4):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.3
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@18.0.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7))
 
   vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@18.0.1)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)):
     dependencies:


### PR DESCRIPTION
Closes #30

Implements [SDD § 12 Client SDK contracts](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-client-sdk-contracts). Cross-repo SDD update: **brevwick-ops PR #21** — https://github.com/tatlacas-com/brevwick-ops/pull/21

## Summary
- Introduce `--brw-*` CSS custom-property token set (surfaces, text, border, accent, shadow, divider)
- Light defaults; `@media (prefers-color-scheme: dark)` override swaps the palette
- Host override: any ancestor setting `--brw-accent` (etc.) re-themes the widget with no rebuild — defaults live on `:where(:root)` so they sit at specificity 0
- Composer children wrapped in a rounded shell with `:focus-within` ring — reads as a single input affordance
- Multiline textarea retains 1–5 row autogrow; send button bottom-aligned when rows > 1
- JSDoc on `FeedbackButton` documents every token and the override pattern
- vitest-axe added as a devDep; panel runs clean under both light + dark matchMedia stubs
- Dedicated contrast guard asserts the dark bubble-user and accent pairs hit WCAG AA
- No public API change (props / hooks / payload unchanged); no new runtime dependency

## Bundle size
- React entry gzipped: **~8.3 kB** — well under the 25 kB budget
- SDK core chunk unchanged (this PR does not touch the SDK)

## Test plan
- [x] Send-button background follows `--brw-accent` via `getComputedStyle` (token set on body, inherited through Radix portal)
- [x] Panel background follows `--brw-panel-bg` swapped via test-only stylesheet sentinels (rgb(1,2,3) → rgb(4,5,6))
- [x] Composer-shell `:focus-within` rule pinned in the emitted CSS (happy-dom can't evaluate `:focus-within`, so the guard is a CSS string regex)
- [x] Every class-rule colour/background/shadow reads from a `var(--brw-*)` token (no-hex guard on stripped CSS using a balanced-brace walker)
- [x] Multiline autogrow preserved — `scrollHeight` spy asserts the exact clamped `style.height` matches `min(scrollHeight, COMPOSER_MAX_HEIGHT_PX)`
- [x] vitest-axe clean on rendered panel in both light and dark matchMedia stubs (structural a11y only; see inline comment)
- [x] Dark-mode default palette hits WCAG AA >= 4.5:1 for bubble-user and accent pairs
- [x] Dark-mode `--brw-chip-bg` remains distinct from `--brw-border` (existing contrast guard)
- [x] Changeset added: minor for brevwick-react, patch for brevwick-sdk (lockstep)
- [ ] Manual: OS-theme flip re-themes without reload; `body { --brw-accent: hotpink }` swaps accents at mount
