### PR TITLE
feat(react): credit footer with version + brevwick.dev link

### DIFF
--- a/.changeset/credit-footer.md
+++ b/.changeset/credit-footer.md
@@ -1,0 +1,25 @@
+---
+'brevwick-react': patch
+'brevwick-sdk': patch
+---
+
+feat(react): credit footer with version + brevwick.dev link
+
+- Thin `Brevwick v<x.y.z>` credit anchored below the composer, rendered
+  inside the existing `<FeedbackButton>` panel in both compose and
+  success states.
+- Single link to https://brevwick.dev with `target="_blank"` and
+  `rel="noopener noreferrer"`; label reads as one affordance rather
+  than two competing elements.
+- Muted 10 px styling driven by `--brw-fg-muted` + `--brw-composer-bg`,
+  so the footer sits quietly in both light and dark themes. Hover/focus
+  lifts opacity and underlines, keeping it discoverable without
+  intruding.
+- Version text comes from the existing `__BREVWICK_REACT_VERSION__`
+  build-time constant that already powers `BREVWICK_REACT_VERSION` —
+  no new source of truth.
+- No public API change; props, hooks, and payload are unchanged.
+
+The `brevwick-sdk` bump is a no-op patch to keep both packages in
+lockstep per the repo's pre-1.0 versioning policy; the core SDK has
+no code changes in this release.

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -18,6 +18,7 @@ import type {
   ProjectConfig,
   SubmitResult,
 } from 'brevwick-sdk';
+import pkg from '../../package.json' with { type: 'json' };
 
 const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
 const captureScreenshot = vi.fn<() => Promise<Blob>>();
@@ -113,6 +114,37 @@ describe('<FeedbackButton>', () => {
     expect(
       screen.getByText(/Hi! Tell us what's happening/i),
     ).toBeInTheDocument();
+  });
+
+  it('renders a Brevwick credit footer linking to brevwick.dev on open', () => {
+    mount();
+    openPanel();
+
+    const link = screen.getByRole('link', { name: /brevwick v/i });
+    expect(link).toHaveAttribute('href', 'https://brevwick.dev');
+    expect(link).toHaveAttribute('target', '_blank');
+    // noopener is a hard requirement for external target=_blank links — without
+    // it the opened tab can hijack window.opener on older engines. rel must
+    // carry both tokens, in either order.
+    expect(link.getAttribute('rel')).toMatch(/noopener/);
+    expect(link.getAttribute('rel')).toMatch(/noreferrer/);
+    expect(link).toHaveTextContent(`Brevwick v${pkg.version}`);
+  });
+
+  it('keeps the credit footer visible in the success state', async () => {
+    submit.mockResolvedValueOnce({ ok: true, report_id: 'rep_footer' });
+    mount();
+    openPanel();
+    typeDraft('Hello');
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    expect(screen.getByRole('link', { name: /brevwick v/i })).toHaveAttribute(
+      'href',
+      'https://brevwick.dev',
+    );
   });
 
   it('applies the bottom-left position class to FAB and panel', () => {

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -28,6 +28,8 @@ import {
   COMPOSER_MAX_HEIGHT_PX,
 } from './styles';
 
+declare const __BREVWICK_REACT_VERSION__: string;
+
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.
  */
@@ -511,6 +513,7 @@ export function FeedbackButton({
               onUseAiChange={setUseAi}
             />
           )}
+          <PanelFooter />
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
@@ -554,6 +557,27 @@ function PanelHeader({
       >
         <CloseIcon />
       </button>
+    </div>
+  );
+}
+
+/**
+ * Thin "Brevwick v<x.y.z>" credit anchored below the composer. The whole
+ * label is a single link to brevwick.dev so the footer reads as one
+ * affordance rather than two competing elements; styling keeps it muted
+ * and small so it sits quietly at the bottom of the panel.
+ */
+function PanelFooter(): ReactElement {
+  return (
+    <div className="brw-panel-footer">
+      <a
+        className="brw-panel-footer-link"
+        href="https://brevwick.dev"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Brevwick v{__BREVWICK_REACT_VERSION__}
+      </a>
     </div>
   );
 }

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -429,6 +429,29 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent);
 }
 .brw-error { color: var(--brw-error); font-size: 12px; align-self: stretch; }
+.brw-panel-footer {
+  flex-shrink: 0;
+  padding: 6px 10px 8px;
+  text-align: center;
+  background: var(--brw-composer-bg);
+}
+.brw-panel-footer-link {
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: var(--brw-fg-muted);
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity 120ms ease-out, color 120ms ease-out;
+}
+.brw-panel-footer-link:hover,
+.brw-panel-footer-link:focus-visible {
+  opacity: 1;
+  color: var(--brw-fg);
+  text-decoration: underline;
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-panel-footer-link { transition: none; }
+}
 .brw-spinner {
   display: inline-block; width: 14px; height: 14px;
   border: 2px solid currentColor; border-right-color: transparent;


### PR DESCRIPTION
## Summary

- Adds a thin "Brevwick v<x.y.z>" credit strip below the composer, linking to https://brevwick.dev (target=_blank + rel=noopener noreferrer).
- Version string comes from the same `__BREVWICK_REACT_VERSION__` build-time constant already powering `BREVWICK_REACT_VERSION`, so no new source of truth.
- Muted 10 px text, inherits `--brw-fg-muted` / `--brw-composer-bg`, so it lands cleanly in both light and dark themes introduced in #33. Hover/focus lifts opacity and underlines the link — still unobtrusive, still discoverable.
- Footer renders in both the compose and success states so the credit is consistent for the full widget lifetime.

Design intent: small, single-line, one clickable affordance — not a second CTA fighting for attention.

## Test plan

- [x] `pnpm format:check`, `pnpm lint`, `pnpm type-check`, `pnpm test:cover`, `pnpm build` all green locally (mirrors `.github/workflows/ci.yml`)
- [x] New tests in `feedback-button.test.tsx`:
  - renders the credit footer on panel open with `href=https://brevwick.dev`, `target=_blank`, `rel` containing both `noopener` and `noreferrer`, and body text `Brevwick v<pkg.version>`
  - footer remains visible after a successful submit (success state)
- [ ] Visual check in the Next example after publish

## SDD

Credit footer is UI chrome inside the existing `<FeedbackButton>` surface; no public API change, no SDD § 12 update needed.