### PR TITLE
feat(react): theme prop on <FeedbackButton> (light/dark/system)

### DIFF
--- a/.changeset/react-theme-prop.md
+++ b/.changeset/react-theme-prop.md
@@ -10,14 +10,19 @@ feat(react): `theme` prop on `<FeedbackButton>` (light / dark / system)
   `'system'` preserves the pre-existing OS-driven behaviour.
 - The prop stamps `data-brw-theme` on every `.brw-root` element (FAB,
   dialog panel, region-capture overlay). Two new CSS blocks —
-  `.brw-root[data-brw-theme='light'|'dark']` — override the
-  `:where(:root)` defaults and the `@media (prefers-color-scheme: dark)`
-  rule by specificity. Host-level `:root { --brw-*: ... }` overrides
-  still win for the same reason they always have.
+  `.brw-root[data-brw-theme='light'|'dark']` — override the internal
+  `--brw-*-base` defaults set on `:where(:root)` (and the
+  `@media (prefers-color-scheme: dark)` swap).
+- Host-level `:root { --brw-*: ... }` overrides still win even under a
+  forced theme: every widget rule consumes
+  `var(--brw-X, var(--brw-X-base))`, and the forced-theme blocks only
+  rewrite `--brw-X-base`, never the public `--brw-X`. So
+  `theme="dark"` + a consumer `--brw-accent: hotpink` still paints the
+  accent hotpink.
 - `BrevwickTheme` type exported from `brevwick-react` for consumers that
   want to type their own theme-selecting state.
 - SDD § 12 (`brevwick-ops/docs/brevwick-sdd.md`) updated with the new
-  prop + contract in a coordinated PR.
+  prop + dual-variable contract in a coordinated PR.
 
 The `brevwick-sdk` patch bump is a no-op to keep the two packages in
 lockstep per the repo's pre-1.0 versioning policy.

--- a/.changeset/react-theme-prop.md
+++ b/.changeset/react-theme-prop.md
@@ -1,0 +1,23 @@
+---
+'brevwick-react': minor
+'brevwick-sdk': patch
+---
+
+feat(react): `theme` prop on `<FeedbackButton>` (light / dark / system)
+
+- New `theme?: 'light' | 'dark' | 'system'` prop lets consumers force a
+  palette regardless of the OS `prefers-color-scheme` setting. Default
+  `'system'` preserves the pre-existing OS-driven behaviour.
+- The prop stamps `data-brw-theme` on every `.brw-root` element (FAB,
+  dialog panel, region-capture overlay). Two new CSS blocks —
+  `.brw-root[data-brw-theme='light'|'dark']` — override the
+  `:where(:root)` defaults and the `@media (prefers-color-scheme: dark)`
+  rule by specificity. Host-level `:root { --brw-*: ... }` overrides
+  still win for the same reason they always have.
+- `BrevwickTheme` type exported from `brevwick-react` for consumers that
+  want to type their own theme-selecting state.
+- SDD § 12 (`brevwick-ops/docs/brevwick-sdd.md`) updated with the new
+  prop + contract in a coordinated PR.
+
+The `brevwick-sdk` patch bump is a no-op to keep the two packages in
+lockstep per the repo's pre-1.0 versioning policy.

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1204,6 +1204,66 @@ describe('<FeedbackButton> — theming + composer shell', () => {
   });
 });
 
+describe('<FeedbackButton> — theme prop', () => {
+  it('defaults to theme="system" on both the FAB and the dialog panel', () => {
+    mount();
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'system');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'system',
+    );
+  });
+
+  it('stamps data-brw-theme="light" when theme="light"', () => {
+    mount({ theme: 'light' });
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'light');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'light',
+    );
+  });
+
+  it('stamps data-brw-theme="dark" when theme="dark"', () => {
+    mount({ theme: 'dark' });
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'dark');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'dark',
+    );
+  });
+
+  it('propagates theme to the region-capture overlay Dialog.Content', async () => {
+    mount({ theme: 'dark' });
+    openPanel();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /capture screenshot of this page/i,
+        }),
+      );
+    });
+    const overlay = screen.getByTestId('brw-region-overlay');
+    expect(overlay).toHaveAttribute('data-brw-theme', 'dark');
+  });
+
+  it('emitted stylesheet defines forced-palette rules for light and dark', () => {
+    // Guards the CSS contract: if someone renames the attribute or drops a
+    // block the forced palettes silently break — this test catches that at
+    // unit-test time instead of in a consumer bug report.
+    expect(BREVWICK_CSS).toMatch(/\.brw-root\[data-brw-theme='light'\]\s*\{/);
+    expect(BREVWICK_CSS).toMatch(/\.brw-root\[data-brw-theme='dark'\]\s*\{/);
+  });
+});
+
 describe('<FeedbackButton> — region capture overlay', () => {
   /**
    * Install a test double for the canvas crop pipeline so the overlay's
@@ -2062,16 +2122,22 @@ function stubMatchMedia(prefersDark: boolean): void {
 }
 
 /**
- * Remove every `:where(:root) { ... }` token-default block from the
- * emitted CSS using a balanced-brace walker. Survives whitespace and
- * newline refactors that a `[\s\S]*?\n\s*}` regex would silently
- * mis-strip; used by the "no hardcoded hex in class rules" guard.
+ * Remove every token-declaration block from the emitted CSS using a
+ * balanced-brace walker. Token blocks are `:where(:root) { ... }`
+ * defaults (including the `@media (prefers-color-scheme: dark)` swap)
+ * and the `.brw-root[data-brw-theme='light'|'dark']` forced-palette
+ * blocks introduced with the `theme` prop — all three hold raw hex
+ * palettes by design. Survives whitespace/newline refactors that a
+ * `[\s\S]*?\n\s*}` regex would silently mis-strip; used by the "no
+ * hardcoded hex in class rules" guard.
  */
 function stripTokenBlocks(css: string): string {
+  const tokenBlockSelector =
+    /(?::where\(:root\)|\.brw-root\[data-brw-theme='[^']+'\])\s*\{/;
   const out: string[] = [];
   let i = 0;
   while (i < css.length) {
-    const match = css.slice(i).match(/:where\(:root\)\s*\{/);
+    const match = css.slice(i).match(tokenBlockSelector);
     if (!match) {
       out.push(css.slice(i));
       break;

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -755,16 +755,18 @@ describe('<FeedbackButton>', () => {
   });
 
   it('dark-mode chip background is distinct from the border colour (contrast)', () => {
-    // Pull the dark-mode block out and assert --brw-chip-bg is not the same
-    // as --brw-border — a regression where they match hides the chip's 1px
-    // border in dark mode.
+    // Pull the dark-mode block out and assert --brw-chip-bg-base is not the
+    // same as --brw-border-base — a regression where they match hides the
+    // chip's 1px border in dark mode. The `-base` suffix is the internal
+    // palette token (see styles.ts JSDoc); widget rules fall back to it
+    // via `var(--brw-X, var(--brw-X-base))`.
     const darkBlock = BREVWICK_CSS.match(
       /@media \(prefers-color-scheme: dark\)[\s\S]*?\n\s*\}\n\s*\}/,
     );
     expect(darkBlock).not.toBeNull();
     const block = darkBlock![0];
-    const borderMatch = block.match(/--brw-border:\s*([^;]+);/);
-    const chipBgMatch = block.match(/--brw-chip-bg:\s*([^;]+);/);
+    const borderMatch = block.match(/--brw-border-base:\s*([^;]+);/);
+    const chipBgMatch = block.match(/--brw-chip-bg-base:\s*([^;]+);/);
     expect(borderMatch).not.toBeNull();
     expect(chipBgMatch).not.toBeNull();
     expect(chipBgMatch![1]!.trim()).not.toBe(borderMatch![1]!.trim());
@@ -1115,7 +1117,7 @@ describe('<FeedbackButton> — theming + composer shell', () => {
     // emitted stylesheet. A regression that drops the rule (or hardcodes a
     // colour) is caught here.
     expect(BREVWICK_CSS).toMatch(
-      /\.brw-composer-shell:focus-within[^{]*\{[^}]*border-color:\s*var\(--brw-border-focus\)/,
+      /\.brw-composer-shell:focus-within[^{]*\{[^}]*border-color:\s*var\(--brw-border-focus,/,
     );
   });
 
@@ -1192,12 +1194,12 @@ describe('<FeedbackButton> — theming + composer shell', () => {
     // accent (send button) need ≥ 4.5:1 for body-text AA.
     const dark = extractDarkTokenBlock(BREVWICK_CSS);
     const bubblePair = contrastRatio(
-      dark['--brw-bubble-user-bg']!,
-      dark['--brw-bubble-user-fg']!,
+      dark['--brw-bubble-user-bg-base']!,
+      dark['--brw-bubble-user-fg-base']!,
     );
     const accentPair = contrastRatio(
-      dark['--brw-accent']!,
-      dark['--brw-accent-fg']!,
+      dark['--brw-accent-base']!,
+      dark['--brw-accent-fg-base']!,
     );
     expect(bubblePair).toBeGreaterThanOrEqual(4.5);
     expect(accentPair).toBeGreaterThanOrEqual(4.5);
@@ -1261,6 +1263,42 @@ describe('<FeedbackButton> — theme prop', () => {
     // unit-test time instead of in a consumer bug report.
     expect(BREVWICK_CSS).toMatch(/\.brw-root\[data-brw-theme='light'\]\s*\{/);
     expect(BREVWICK_CSS).toMatch(/\.brw-root\[data-brw-theme='dark'\]\s*\{/);
+  });
+
+  it('host :root override of --brw-accent wins under a forced dark theme', () => {
+    // Regression guard for the dual-variable contract. A naïve
+    // implementation that writes `--brw-accent` directly on
+    // `.brw-root[data-brw-theme='dark']` would shadow any
+    // host-level `:root { --brw-accent: ... }` inherited down to the
+    // widget. The public theming promise is the opposite — consumer
+    // overrides must keep winning — and this test locks that in.
+    document.body.style.setProperty('--brw-accent', 'rgb(255, 0, 255)');
+    mount({ theme: 'dark' });
+    openPanel();
+    const sendBtn = screen.getByRole('button', { name: /^send$/i });
+    expect(getComputedStyle(sendBtn).backgroundColor).toBe('rgb(255, 0, 255)');
+  });
+
+  it('forced-palette blocks only write --brw-*-base (never public --brw-* names)', () => {
+    // If this ever fails, a future edit is setting the public override
+    // name inside the forced-theme rule, which immediately breaks the
+    // host-override contract. Pulled out as a string guard instead of a
+    // computed-style check so it survives any happy-dom quirks.
+    const forcedBlockRe =
+      /\.brw-root\[data-brw-theme='(?:light|dark)'\]\s*\{([^}]*)\}/g;
+    const matches = [...BREVWICK_CSS.matchAll(forcedBlockRe)];
+    expect(matches.length).toBe(2);
+    for (const match of matches) {
+      const body = match[1]!;
+      // Every declaration inside these blocks must be a `-base` token.
+      // A public `--brw-X:` declaration (without the `-base` suffix)
+      // would shadow a consumer override — that's the bug Copilot
+      // flagged on the initial PR.
+      const publicDeclarations = body.match(
+        /--brw-[a-z-]+(?<!-base):\s*[^;]+;/g,
+      );
+      expect(publicDeclarations).toBeNull();
+    }
   });
 });
 

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -32,6 +32,13 @@ import {
 declare const __BREVWICK_REACT_VERSION__: string;
 
 /**
+ * Forced-palette choice for {@link FeedbackButton}. `'system'` defers to the
+ * OS-level `prefers-color-scheme` media query (the default and pre-existing
+ * behaviour); `'light'` / `'dark'` override it regardless of the OS setting.
+ */
+export type BrevwickTheme = 'light' | 'dark' | 'system';
+
+/**
  * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.
  */
 export interface FeedbackButtonProps {
@@ -45,6 +52,13 @@ export interface FeedbackButtonProps {
   className?: string;
   /** FAB label. Default `'Feedback'`. */
   label?: ReactNode;
+  /**
+   * Force a palette regardless of the OS `prefers-color-scheme` setting.
+   * Default `'system'` — the widget follows the OS. Host-level overrides
+   * of individual `--brw-*` custom properties still win over all three
+   * values, so `theme` selects the base palette and CSS overrides tune it.
+   */
+  theme?: BrevwickTheme;
   /** Fired with the SDK's `SubmitResult` after every submit (success or failure). */
   onSubmit?: (result: SubmitResult) => void;
 }
@@ -209,6 +223,7 @@ export function FeedbackButton({
   hidden = false,
   className,
   label = 'Feedback',
+  theme = 'system',
   onSubmit,
 }: FeedbackButtonProps): ReactElement | null {
   const { submit, captureScreenshot, status, reset } = useFeedback();
@@ -506,6 +521,7 @@ export function FeedbackButton({
         <button
           type="button"
           data-brevwick-skip=""
+          data-brw-theme={theme}
           className={`${rootClassName} brw-fab ${fabPosClass}`}
           disabled={disabled}
           aria-label="Open feedback form"
@@ -517,6 +533,7 @@ export function FeedbackButton({
       <Dialog.Portal>
         <Dialog.Content
           data-brevwick-skip=""
+          data-brw-theme={theme}
           className={`${rootClassName} brw-panel ${panelPosClass}`}
           aria-describedby={undefined}
         >
@@ -567,6 +584,7 @@ export function FeedbackButton({
       </Dialog.Portal>
       <RegionCaptureOverlay
         open={regionOpen}
+        theme={theme}
         onClose={handleCloseRegion}
         onConfirmRegion={handleConfirmRegion}
         onConfirmFull={handleConfirmFull}
@@ -1111,6 +1129,7 @@ interface DragState {
 
 interface RegionCaptureOverlayProps {
   open: boolean;
+  theme: BrevwickTheme;
   onClose: () => void;
   onConfirmRegion: (region: Region) => void;
   onConfirmFull: () => void;
@@ -1131,6 +1150,7 @@ interface RegionCaptureOverlayProps {
  */
 function RegionCaptureOverlay({
   open,
+  theme,
   onClose,
   onConfirmRegion,
   onConfirmFull,
@@ -1257,6 +1277,7 @@ function RegionCaptureOverlay({
         <Dialog.Content
           className={`brw-root brw-region-layer${shake ? ' brw-region-shake' : ''}`}
           data-brevwick-skip=""
+          data-brw-theme={theme}
           data-testid="brw-region-overlay"
           aria-label="Select screenshot region"
           aria-describedby={undefined}

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -54,9 +54,14 @@ export interface FeedbackButtonProps {
   label?: ReactNode;
   /**
    * Force a palette regardless of the OS `prefers-color-scheme` setting.
-   * Default `'system'` — the widget follows the OS. Host-level overrides
-   * of individual `--brw-*` custom properties still win over all three
-   * values, so `theme` selects the base palette and CSS overrides tune it.
+   * Default `'system'` — the widget follows the OS.
+   *
+   * Host-level `:root { --brw-*: ... }` overrides still win over the
+   * forced palette because the stylesheet consumes each public token
+   * via `var(--brw-X, var(--brw-X-base))`: the forced-theme blocks
+   * rewrite only `--brw-X-base`, never the public `--brw-X`. So
+   * `theme="dark"` picks the base palette and a consumer-set
+   * `--brw-accent: hotpink` still wins for the accent.
    */
   theme?: BrevwickTheme;
   /** Fired with the SDK's `SubmitResult` after every submit (success or failure). */
@@ -182,10 +187,15 @@ interface FileAttachment {
  * The widget exposes a set of CSS custom properties (`--brw-*`) that any
  * ancestor can override to re-theme without a rebuild. Light defaults ship
  * out of the box; a `@media (prefers-color-scheme: dark)` block swaps the
- * palette when the host OS is in dark mode. Set these as CSS custom
- * properties on any ancestor (e.g. `:root` or your app shell) to re-theme
- * the widget without a rebuild — the widget's own `.brw-root` scope never
- * uses `!important`, so normal cascade wins.
+ * palette when the host OS is in dark mode. The {@link FeedbackButtonProps.theme}
+ * prop can force `'light'` or `'dark'` regardless of the OS setting.
+ *
+ * Set these as CSS custom properties on any ancestor (e.g. `:root` or your
+ * app shell) to re-theme the widget without a rebuild. Every widget rule
+ * reads each token via `var(--brw-X, var(--brw-X-base))`, so a host
+ * override of the public `--brw-X` name always wins — even under a forced
+ * `theme="light|dark"` (which rewrites the internal `-base` defaults, not
+ * the public names).
  *
  * Surfaces
  * - `--brw-panel-bg` — dialog panel background

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,7 +19,7 @@ export { useFeedback } from './use-feedback';
 export type { FeedbackStatus, UseFeedbackResult } from './use-feedback';
 
 export { FeedbackButton } from './feedback-button';
-export type { FeedbackButtonProps } from './feedback-button';
+export type { BrevwickTheme, FeedbackButtonProps } from './feedback-button';
 
 export type {
   BrevwickConfig,

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -3,20 +3,21 @@
  * package has zero CSS-loader requirements — consumers can drop the package
  * into any bundler (Next.js, Vite, Webpack) without config.
  *
- * Theming is done through `--brw-*` CSS custom properties. Defaults live on
- * `:where(:root)` so the widget's declarations sit at specificity 0 — any
- * host rule (including a normal `:root { --brw-accent: hotpink }`, a
- * `body { ... }`, or any widget ancestor) wins without `!important`. Dark
- * palette is swapped via `@media (prefers-color-scheme: dark)`; host
- * overrides persist across modes because they're set on a different
- * element / higher specificity.
+ * Theming uses a **dual-variable pattern** so the forced-theme prop can
+ * swap palettes without stepping on host-level overrides:
  *
- * The `<FeedbackButton theme="light|dark|system">` prop forces a palette
- * regardless of the OS setting by stamping `data-brw-theme` on every
- * `.brw-root` element; the attribute selector has higher specificity than
- * `:where(:root)` so the forced palette wins the cascade, while host-side
- * `:root { --brw-accent: ... }` overrides still win because they sit on
- * `:root` (not inside `.brw-root`).
+ * - `--brw-*-base` holds the shipped defaults (light + `prefers-color-scheme`
+ *   dark + `<FeedbackButton theme="light|dark">` forced palettes). Set only
+ *   by this stylesheet; consumers should **not** target these.
+ * - `--brw-*` is the public override name. Widget rules consume
+ *   `var(--brw-X, var(--brw-X-base))` — the consumer's `--brw-X` value is
+ *   preferred, and we fall back to the base-palette default when nothing
+ *   is set.
+ *
+ * So a consumer who writes `:root { --brw-accent: hotpink }` keeps their
+ * accent under every palette — including `theme="dark"` — because the
+ * widget asks for `--brw-accent` first. The forced-theme blocks only set
+ * `--brw-*-base`, not `--brw-*`, so they never shadow a consumer override.
  */
 export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
 
@@ -33,98 +34,101 @@ export const COMPOSER_MAX_HEIGHT_PX = 120;
 export const BREVWICK_CSS = `
 :where(:root) {
   /* Surfaces */
-  --brw-panel-bg: #ffffff;
-  --brw-bubble-assistant-bg: #f1f5f9;
-  --brw-bubble-user-bg: #0f172a;
-  --brw-bubble-user-fg: #ffffff;
-  --brw-chip-bg: #f1f5f9;
-  --brw-composer-bg: #ffffff;
+  --brw-panel-bg-base: #ffffff;
+  --brw-bubble-assistant-bg-base: #f1f5f9;
+  --brw-bubble-user-bg-base: #0f172a;
+  --brw-bubble-user-fg-base: #ffffff;
+  --brw-chip-bg-base: #f1f5f9;
+  --brw-composer-bg-base: #ffffff;
   /* Text */
-  --brw-fg: #0f172a;
-  --brw-fg-muted: #64748b;
+  --brw-fg-base: #0f172a;
+  --brw-fg-muted-base: #64748b;
   /* Border / focus */
-  --brw-border: #e2e8f0;
-  --brw-border-focus: #0f172a;
-  --brw-divider: #e2e8f0;
+  --brw-border-base: #e2e8f0;
+  --brw-border-focus-base: #0f172a;
+  --brw-divider-base: #e2e8f0;
   /* Accent */
-  --brw-accent: #0f172a;
-  --brw-accent-fg: #ffffff;
+  --brw-accent-base: #0f172a;
+  --brw-accent-fg-base: #ffffff;
   /* Shadow */
-  --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
-  /* Status colour — not exposed in the public token list; widget-internal.
-     Carried through dark mode (same hue reads adequately on the dark
-     --brw-panel-bg); override in the dark block if design ever wants a
-     tuned variant. */
-  --brw-error: #b91c1c;
+  --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  /* Status colour — widget-internal, not part of the public override
+     contract. No public alias; widget rules consume --brw-error-base
+     directly. Carried through dark mode (same hue reads adequately on
+     the dark --brw-panel-bg); override in the dark block if design ever
+     wants a tuned variant. */
+  --brw-error-base: #b91c1c;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
     /* Surfaces */
-    --brw-panel-bg: #0b1220;
-    --brw-bubble-assistant-bg: #1e293b;
-    --brw-bubble-user-bg: #f8fafc;
-    --brw-bubble-user-fg: #0f172a;
+    --brw-panel-bg-base: #0b1220;
+    --brw-bubble-assistant-bg-base: #1e293b;
+    --brw-bubble-user-bg-base: #f8fafc;
+    --brw-bubble-user-fg-base: #0f172a;
     /* chip bg is one step brighter than --brw-border (#1e293b) so the chip's
        1px border stays visible against the chip body in dark mode. */
-    --brw-chip-bg: #253044;
-    --brw-composer-bg: #0b1220;
+    --brw-chip-bg-base: #253044;
+    --brw-composer-bg-base: #0b1220;
     /* Text */
-    --brw-fg: #f8fafc;
-    --brw-fg-muted: #94a3b8;
+    --brw-fg-base: #f8fafc;
+    --brw-fg-muted-base: #94a3b8;
     /* Border / focus */
-    --brw-border: #1e293b;
-    --brw-border-focus: #f8fafc;
-    --brw-divider: #1e293b;
+    --brw-border-base: #1e293b;
+    --brw-border-focus-base: #f8fafc;
+    --brw-divider-base: #1e293b;
     /* Accent */
-    --brw-accent: #f8fafc;
-    --brw-accent-fg: #0f172a;
+    --brw-accent-base: #f8fafc;
+    --brw-accent-fg-base: #0f172a;
     /* Shadow — deeper alpha so the panel still reads as lifted over a dark host */
-    --brw-shadow: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+    --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
   }
 }
-/* Forced palettes via <FeedbackButton theme="light|dark">. The attribute
-   selector beats :where(:root) (specificity 0) and the @media-scoped
-   :where(:root) block alike, so the chosen palette applies regardless of
-   the OS setting. theme="system" deliberately has no rule — the
-   :where(:root) defaults plus the media query already do the right thing.
-   Values mirror the blocks above; duplicated rather than extracted to a
-   shared preprocessor variable because the stylesheet ships as a literal
-   template string with zero build tooling. */
+/* Forced palettes via <FeedbackButton theme="light|dark">. These rewrite
+   --brw-*-base on .brw-root, so they replace the OS-driven defaults for
+   the widget subtree without ever writing to the public --brw-* names.
+   That preserves host-level :root overrides (the widget consumer path
+   always asks for --brw-X first, with --brw-X-base only as fallback —
+   see the BREVWICK_STYLE_ID jsdoc above). theme="system" deliberately
+   has no rule; the :where(:root) defaults plus the media query already
+   do the right thing. Values duplicated rather than extracted because
+   the stylesheet ships as a literal template string with zero build
+   tooling. */
 .brw-root[data-brw-theme='light'] {
-  --brw-panel-bg: #ffffff;
-  --brw-bubble-assistant-bg: #f1f5f9;
-  --brw-bubble-user-bg: #0f172a;
-  --brw-bubble-user-fg: #ffffff;
-  --brw-chip-bg: #f1f5f9;
-  --brw-composer-bg: #ffffff;
-  --brw-fg: #0f172a;
-  --brw-fg-muted: #64748b;
-  --brw-border: #e2e8f0;
-  --brw-border-focus: #0f172a;
-  --brw-divider: #e2e8f0;
-  --brw-accent: #0f172a;
-  --brw-accent-fg: #ffffff;
-  --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  --brw-panel-bg-base: #ffffff;
+  --brw-bubble-assistant-bg-base: #f1f5f9;
+  --brw-bubble-user-bg-base: #0f172a;
+  --brw-bubble-user-fg-base: #ffffff;
+  --brw-chip-bg-base: #f1f5f9;
+  --brw-composer-bg-base: #ffffff;
+  --brw-fg-base: #0f172a;
+  --brw-fg-muted-base: #64748b;
+  --brw-border-base: #e2e8f0;
+  --brw-border-focus-base: #0f172a;
+  --brw-divider-base: #e2e8f0;
+  --brw-accent-base: #0f172a;
+  --brw-accent-fg-base: #ffffff;
+  --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
 }
 .brw-root[data-brw-theme='dark'] {
-  --brw-panel-bg: #0b1220;
-  --brw-bubble-assistant-bg: #1e293b;
-  --brw-bubble-user-bg: #f8fafc;
-  --brw-bubble-user-fg: #0f172a;
-  --brw-chip-bg: #253044;
-  --brw-composer-bg: #0b1220;
-  --brw-fg: #f8fafc;
-  --brw-fg-muted: #94a3b8;
-  --brw-border: #1e293b;
-  --brw-border-focus: #f8fafc;
-  --brw-divider: #1e293b;
-  --brw-accent: #f8fafc;
-  --brw-accent-fg: #0f172a;
-  --brw-shadow: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+  --brw-panel-bg-base: #0b1220;
+  --brw-bubble-assistant-bg-base: #1e293b;
+  --brw-bubble-user-bg-base: #f8fafc;
+  --brw-bubble-user-fg-base: #0f172a;
+  --brw-chip-bg-base: #253044;
+  --brw-composer-bg-base: #0b1220;
+  --brw-fg-base: #f8fafc;
+  --brw-fg-muted-base: #94a3b8;
+  --brw-border-base: #1e293b;
+  --brw-border-focus-base: #f8fafc;
+  --brw-divider-base: #1e293b;
+  --brw-accent-base: #f8fafc;
+  --brw-accent-fg-base: #0f172a;
+  --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
 }
 .brw-root {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: var(--brw-fg);
+  color: var(--brw-fg, var(--brw-fg-base));
 }
 .brw-fab {
   position: fixed;
@@ -134,16 +138,16 @@ export const BREVWICK_CSS = `
   min-width: 48px;
   padding: 0 18px;
   border-radius: 999px;
-  border: 1px solid var(--brw-border);
-  background: var(--brw-accent);
-  color: var(--brw-accent-fg);
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
   font-size: 14px;
   font-weight: 500;
   display: inline-flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  box-shadow: var(--brw-shadow);
+  box-shadow: var(--brw-shadow, var(--brw-shadow-base));
   /* Only transform animates on hover; box-shadow is static so it is
      intentionally excluded from the transition list. */
   transition: transform 120ms ease-out;
@@ -163,11 +167,11 @@ export const BREVWICK_CSS = `
   height: min(80vh, 640px);
   display: flex;
   flex-direction: column;
-  background: var(--brw-panel-bg);
-  color: var(--brw-fg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 16px 16px 12px 12px;
-  box-shadow: var(--brw-shadow);
+  box-shadow: var(--brw-shadow, var(--brw-shadow-base));
   overflow: hidden;
   animation: brw-slide-up 200ms ease-out;
 }
@@ -193,14 +197,14 @@ export const BREVWICK_CSS = `
   align-items: center;
   gap: 8px;
   padding: 12px 14px;
-  border-bottom: 1px solid var(--brw-divider);
+  border-bottom: 1px solid var(--brw-divider, var(--brw-divider-base));
   flex-shrink: 0;
 }
 .brw-panel-avatar {
   width: 28px; height: 28px;
   border-radius: 999px;
-  background: var(--brw-accent);
-  color: var(--brw-accent-fg);
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
   display: inline-flex; align-items: center; justify-content: center;
   font-weight: 600; font-size: 12px;
   flex-shrink: 0;
@@ -221,14 +225,14 @@ export const BREVWICK_CSS = `
   display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid transparent;
   background: transparent;
-  color: var(--brw-fg-muted);
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   border-radius: 6px;
   cursor: pointer;
   font: inherit;
   line-height: 1;
 }
-.brw-icon-btn:hover:not(:disabled) { background: var(--brw-chip-bg); color: var(--brw-fg); }
-.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-border-focus); outline-offset: 1px; }
+.brw-icon-btn:hover:not(:disabled) { background: var(--brw-chip-bg, var(--brw-chip-bg-base)); color: var(--brw-fg, var(--brw-fg-base)); }
+.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 1px; }
 .brw-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-icon-btn svg { width: 16px; height: 16px; }
 .brw-thread {
@@ -239,7 +243,7 @@ export const BREVWICK_CSS = `
   display: flex;
   flex-direction: column;
   gap: 10px;
-  background: var(--brw-panel-bg);
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
 }
 .brw-bubble {
   max-width: 85%;
@@ -252,20 +256,20 @@ export const BREVWICK_CSS = `
 }
 .brw-bubble--assistant {
   align-self: flex-start;
-  background: var(--brw-bubble-assistant-bg);
-  color: var(--brw-fg);
+  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
   border-bottom-left-radius: 4px;
 }
 .brw-bubble--user {
   align-self: flex-end;
-  background: var(--brw-bubble-user-bg);
-  color: var(--brw-bubble-user-fg);
+  background: var(--brw-bubble-user-bg, var(--brw-bubble-user-bg-base));
+  color: var(--brw-bubble-user-fg, var(--brw-bubble-user-fg-base));
   border-bottom-right-radius: 4px;
 }
 .brw-bubble--success {
   align-self: center;
-  background: var(--brw-chip-bg);
-  color: var(--brw-fg);
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
   text-align: center;
   max-width: 92%;
 }
@@ -282,9 +286,9 @@ export const BREVWICK_CSS = `
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  background: var(--brw-chip-bg);
-  color: var(--brw-fg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 12px;
   font-size: 12px;
   max-width: 85%;
@@ -296,46 +300,46 @@ export const BREVWICK_CSS = `
   flex-shrink: 0;
 }
 .brw-chip-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
-.brw-chip-size { color: var(--brw-fg-muted); }
+.brw-chip-size { color: var(--brw-fg-muted, var(--brw-fg-muted-base)); }
 .brw-chip-remove {
   width: 20px; height: 20px;
   padding: 0;
   display: inline-flex; align-items: center; justify-content: center;
   border: none;
   background: transparent;
-  color: var(--brw-fg-muted);
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   border-radius: 999px;
   cursor: pointer;
   font: inherit;
   line-height: 1;
 }
-.brw-chip-remove:hover { background: var(--brw-border); color: var(--brw-fg); }
+.brw-chip-remove:hover { background: var(--brw-border, var(--brw-border-base)); color: var(--brw-fg, var(--brw-fg-base)); }
 .brw-disclosure {
   align-self: flex-start;
   background: transparent;
   border: none;
   padding: 0;
-  color: var(--brw-fg-muted);
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   font: inherit;
   font-size: 12px;
   cursor: pointer;
   text-decoration: underline;
 }
-.brw-disclosure:hover { color: var(--brw-fg); }
+.brw-disclosure:hover { color: var(--brw-fg, var(--brw-fg-base)); }
 .brw-disclosure-panel {
   align-self: stretch;
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding: 8px 10px;
-  background: var(--brw-chip-bg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 10px;
 }
 .brw-disclosure-label {
   font-size: 11px;
   font-weight: 600;
-  color: var(--brw-fg-muted);
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -345,9 +349,9 @@ export const BREVWICK_CSS = `
   padding: 6px 8px;
   font: inherit;
   font-size: 12px;
-  color: var(--brw-fg);
-  background: var(--brw-panel-bg);
-  border: 1px solid var(--brw-border);
+  color: var(--brw-fg, var(--brw-fg-base));
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 6px;
   resize: vertical;
   min-height: 34px;
@@ -355,8 +359,8 @@ export const BREVWICK_CSS = `
 .brw-composer {
   flex-shrink: 0;
   padding: 8px 10px;
-  background: var(--brw-composer-bg);
-  border-top: 1px solid var(--brw-divider);
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+  border-top: 1px solid var(--brw-divider, var(--brw-divider-base));
 }
 /* Rounded shell that groups the textarea + icon buttons + send + AI toggle
    into a single visual input affordance. Border colour lifts to
@@ -368,13 +372,13 @@ export const BREVWICK_CSS = `
   align-items: flex-end;
   gap: 4px;
   padding: 6px 8px;
-  background: var(--brw-composer-bg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 12px;
   transition: border-color 120ms ease-out;
 }
 .brw-composer-shell:focus-within {
-  border-color: var(--brw-border-focus);
+  border-color: var(--brw-border-focus, var(--brw-border-focus-base));
 }
 @media (prefers-reduced-motion: reduce) {
   .brw-composer-shell { transition: none; }
@@ -387,7 +391,7 @@ export const BREVWICK_CSS = `
   padding: 8px 4px;
   font: inherit;
   font-size: 13px;
-  color: var(--brw-fg);
+  color: var(--brw-fg, var(--brw-fg-base));
   background: transparent;
   border: none;
   resize: none;
@@ -399,9 +403,9 @@ export const BREVWICK_CSS = `
   width: 34px; height: 34px;
   padding: 0;
   display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid var(--brw-accent);
-  background: var(--brw-accent);
-  color: var(--brw-accent-fg);
+  border: 1px solid var(--brw-accent, var(--brw-accent-base));
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
   border-radius: 10px;
   cursor: pointer;
   flex-shrink: 0;
@@ -414,31 +418,31 @@ export const BREVWICK_CSS = `
   height: 26px;
   padding: 0 10px 0 8px;
   border-radius: 999px;
-  border: 1px solid var(--brw-border);
-  background: var(--brw-chip-bg);
-  color: var(--brw-fg-muted);
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   font: inherit;
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   transition: background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
 }
-.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus); outline-offset: 1px; }
+.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 1px; }
 .brw-aitoggle:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-aitoggle-dot {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: var(--brw-fg-muted);
+  background: var(--brw-fg-muted, var(--brw-fg-muted-base));
   transition: background-color 120ms ease-out;
 }
 .brw-aitoggle--on {
-  background: var(--brw-accent);
-  color: var(--brw-accent-fg);
-  border-color: var(--brw-accent);
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+  border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-aitoggle--on .brw-aitoggle-dot {
-  background: var(--brw-accent-fg);
+  background: var(--brw-accent-fg, var(--brw-accent-fg-base));
 }
 @media (prefers-reduced-motion: reduce) {
   .brw-aitoggle, .brw-aitoggle-dot { transition: none; }
@@ -452,8 +456,8 @@ export const BREVWICK_CSS = `
   gap: 8px;
   align-items: center;
   padding: 8px 10px;
-  background: var(--brw-chip-bg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 10px;
   font-size: 12px;
 }
@@ -462,30 +466,30 @@ export const BREVWICK_CSS = `
   height: 30px;
   padding: 0 12px;
   border-radius: 8px;
-  border: 1px solid var(--brw-border);
-  background: var(--brw-panel-bg);
-  color: var(--brw-fg);
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
   font: inherit;
   font-size: 12px;
   cursor: pointer;
 }
-.brw-btn:hover:not(:disabled) { background: var(--brw-chip-bg); }
+.brw-btn:hover:not(:disabled) { background: var(--brw-chip-bg, var(--brw-chip-bg-base)); }
 .brw-btn-primary {
-  background: var(--brw-accent);
-  color: var(--brw-accent-fg);
-  border-color: var(--brw-accent);
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+  border-color: var(--brw-accent, var(--brw-accent-base));
 }
-.brw-error { color: var(--brw-error); font-size: 12px; align-self: stretch; }
+.brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
 .brw-panel-footer {
   flex-shrink: 0;
   padding: 6px 10px 8px;
   text-align: center;
-  background: var(--brw-composer-bg);
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
 }
 .brw-panel-footer-link {
   font-size: 10px;
   letter-spacing: 0.02em;
-  color: var(--brw-fg-muted);
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   text-decoration: none;
   opacity: 0.75;
   transition: opacity 120ms ease-out, color 120ms ease-out;
@@ -493,7 +497,7 @@ export const BREVWICK_CSS = `
 .brw-panel-footer-link:hover,
 .brw-panel-footer-link:focus-visible {
   opacity: 1;
-  color: var(--brw-fg);
+  color: var(--brw-fg, var(--brw-fg-base));
   text-decoration: underline;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -537,7 +541,7 @@ export const BREVWICK_CSS = `
 }
 .brw-region-selection {
   position: fixed;
-  border: 2px solid var(--brw-border-focus);
+  border: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.35);
   pointer-events: none;
 }
@@ -549,10 +553,10 @@ export const BREVWICK_CSS = `
   display: flex;
   gap: 8px;
   padding: 6px;
-  background: var(--brw-panel-bg);
-  border: 1px solid var(--brw-border);
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
   border-radius: 10px;
-  box-shadow: var(--brw-shadow);
+  box-shadow: var(--brw-shadow, var(--brw-shadow-base));
   z-index: 2147483005;
 }
 .brw-region-btn { font: inherit; }

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -10,6 +10,13 @@
  * palette is swapped via `@media (prefers-color-scheme: dark)`; host
  * overrides persist across modes because they're set on a different
  * element / higher specificity.
+ *
+ * The `<FeedbackButton theme="light|dark|system">` prop forces a palette
+ * regardless of the OS setting by stamping `data-brw-theme` on every
+ * `.brw-root` element; the attribute selector has higher specificity than
+ * `:where(:root)` so the forced palette wins the cascade, while host-side
+ * `:root { --brw-accent: ... }` overrides still win because they sit on
+ * `:root` (not inside `.brw-root`).
  */
 export const BREVWICK_STYLE_ID = 'brevwick-react-styles';
 
@@ -74,6 +81,46 @@ export const BREVWICK_CSS = `
     /* Shadow — deeper alpha so the panel still reads as lifted over a dark host */
     --brw-shadow: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
   }
+}
+/* Forced palettes via <FeedbackButton theme="light|dark">. The attribute
+   selector beats :where(:root) (specificity 0) and the @media-scoped
+   :where(:root) block alike, so the chosen palette applies regardless of
+   the OS setting. theme="system" deliberately has no rule — the
+   :where(:root) defaults plus the media query already do the right thing.
+   Values mirror the blocks above; duplicated rather than extracted to a
+   shared preprocessor variable because the stylesheet ships as a literal
+   template string with zero build tooling. */
+.brw-root[data-brw-theme='light'] {
+  --brw-panel-bg: #ffffff;
+  --brw-bubble-assistant-bg: #f1f5f9;
+  --brw-bubble-user-bg: #0f172a;
+  --brw-bubble-user-fg: #ffffff;
+  --brw-chip-bg: #f1f5f9;
+  --brw-composer-bg: #ffffff;
+  --brw-fg: #0f172a;
+  --brw-fg-muted: #64748b;
+  --brw-border: #e2e8f0;
+  --brw-border-focus: #0f172a;
+  --brw-divider: #e2e8f0;
+  --brw-accent: #0f172a;
+  --brw-accent-fg: #ffffff;
+  --brw-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+}
+.brw-root[data-brw-theme='dark'] {
+  --brw-panel-bg: #0b1220;
+  --brw-bubble-assistant-bg: #1e293b;
+  --brw-bubble-user-bg: #f8fafc;
+  --brw-bubble-user-fg: #0f172a;
+  --brw-chip-bg: #253044;
+  --brw-composer-bg: #0b1220;
+  --brw-fg: #f8fafc;
+  --brw-fg-muted: #94a3b8;
+  --brw-border: #1e293b;
+  --brw-border-focus: #f8fafc;
+  --brw-divider: #1e293b;
+  --brw-accent: #f8fafc;
+  --brw-accent-fg: #0f172a;
+  --brw-shadow: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
 }
 .brw-root {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;


### PR DESCRIPTION
## Summary

Adds a `theme` prop to `<FeedbackButton>` so consumers can force a palette instead of always inheriting the OS `prefers-color-scheme` preference.

```tsx
<FeedbackButton theme="dark" />     // always dark
<FeedbackButton theme="light" />    // always light
<FeedbackButton theme="system" />   // OS-driven (default, unchanged behaviour)
```

Backwards compatible — default is `'system'`, which is exactly what the widget did before.

## Implementation

- `styles.ts` gains two forced-palette blocks: `.brw-root[data-brw-theme='light'|'dark']`. The attribute selector has higher specificity than `:where(:root)` (specificity 0) and the `@media (prefers-color-scheme: dark)` block's `:where(:root)`, so the chosen palette wins the cascade. Host-level `:root { --brw-accent: ... }` overrides still win for the same reason they always have (they sit on `:root`, outside `.brw-root`).
- `FeedbackButton` stamps `data-brw-theme={theme}` on **every** `.brw-root` element: the FAB trigger, the dialog panel (rendered in a Radix portal), and the region-capture overlay (its own Dialog in another portal). Portaled subtrees don't inherit from the component tree, so the attribute must be present on each root.
- Exports a new `BrevwickTheme` type from `brevwick-react` for consumers that want to type their own theme-selecting state.

## Scope thought

The `theme` prop lives on `<FeedbackButton>`, not on `<BrevwickProvider>`. Rationale: the Provider is about SDK identity/config (the non-visual side); `FeedbackButton` is the visual surface, same place `position`, `label`, `className`, `disabled` already live. If we ever want a provider-level default with a button-level override, that's an additive future change.

## Test plan

- [x] `pnpm format:check` green
- [x] `pnpm lint` green
- [x] `pnpm type-check` green
- [x] `pnpm test:cover` green — **101 / 101 tests pass** (5 new theme-prop specs)
- [x] `pnpm build` green
- [x] `pnpm size` green — React ESM 8.9 kB gzip vs 25 kB budget, unchanged-in-practice
- [ ] CI green on this PR

## Cross-repo

SDD § 12 is updated in the coordinated docs PR: tatlacas-com/brevwick-ops#<to be filled in after the docs PR opens>