### PR TITLE
chore(ci): skip changeset-check on github-actions[bot] PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -13,7 +13,10 @@ concurrency:
 
 jobs:
   check:
-    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'release')
+    if: >
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'github-actions[bot]'
+      && !contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     env:
       BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary

The Changesets release PR (auto-opened on branch `changeset-release/main`) fails the `Changeset check` workflow because it **consumes** all pending `.changeset/*.md` files as part of its job — bumping `package.json` / `CHANGELOG.md` under `packages/**` but leaving zero pending changesets. `pnpm changeset status --since=origin/main` then exits 1 and the guard fails.

Seen on #18: `Some packages have been changed but no changesets were found.`

## Fix

Skip the `Changeset check` job when the PR author is `github-actions[bot]`. Human-authored PRs are unaffected — they still have to ship with a changeset. The existing `release` label escape hatch is preserved for the rare case a human needs to bypass.

Considered:
- Skipping by head ref (`changeset-release/main`) — couples to a Changesets convention that could be renamed.
- Skipping by label — requires a new plumbing step in `release.yml` to tag the bot's PR after it's created, and that step can silently break.

Author-based skip is the shortest path that survives config drift.

## Test plan

- [ ] Merge. On the next `main` push with pending changesets, the auto-opened release PR's `check` job is skipped (currently fails).
- [ ] Open a normal PR without a changeset that touches `packages/**` → check still fails (guard still active for humans).