### PR TITLE
fix: drop redundant --tag beta from release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "size": "size-limit",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only",
-    "release": "pnpm build && changeset publish --tag beta"
+    "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",


### PR DESCRIPTION
## Summary

The release workflow run [24781255778](https://github.com/tatlacas-com/brevwick-sdk-js/actions/runs/24781255778) failed with:

```
🦋  error Releasing under custom tag is not allowed in pre mode
🦋  To resolve this exit the pre mode by running `changeset pre exit`
```

Changesets disallows `publish --tag <name>` while the repo is in pre mode — in pre mode, the dist-tag is taken from `.changeset/pre.json` (`"tag": "beta"` here), so the explicit flag is both redundant and rejected.

## Change

- `package.json`: `release` script drops `--tag beta`. Pre-mode publishes continue to use the `beta` dist-tag via `.changeset/pre.json`.

Staying in pre mode was the chosen direction — no `changeset pre exit`.

## Test plan

- [ ] CI green (`check`)
- [ ] After merge, re-run the release workflow and confirm `changeset publish` completes without the pre-mode error
- [ ] Verify published package on npm carries the `beta` dist-tag