### PR TITLE
feat!: scope packages under @tatlacas org

### DIFF
--- a/.changeset/chat-panel-redesign.md
+++ b/.changeset/chat-panel-redesign.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
 ---
 
 feat(react): chat-thread panel redesign for FeedbackButton
@@ -37,5 +37,5 @@ bottom-left).
 - No new dependencies. Widget ESM bundle ≈ 6.9 kB gzip (well under the
   25 kB budget); core SDK untouched at 2.0 kB gzip.
 
-The `brevwick-sdk` bump is the lockstep pre-1.0 version (no code
+The `@tatlacas/brevwick-sdk` bump is the lockstep pre-1.0 version (no code
 changes in the SDK for this PR).

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [],
-  "linked": [["brevwick-sdk", "brevwick-react"]],
+  "linked": [["@tatlacas/brevwick-sdk", "@tatlacas/brevwick-react"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/console-error-ring.md
+++ b/.changeset/console-error-ring.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 Add the console error ring: patches `console.error` / `console.warn` and listens for `window` `'error'` and `'unhandledrejection'` events, pushing redacted entries into a bounded FIFO buffer (cap 50). Messages and stacks run through `redact()` before storage, stacks are trimmed to the top 20 frames (leader preserved), and identical `message + first-frame` pairs within a 500 ms window dedupe in place via a new optional `count?: number` field on `ConsoleEntry`. The ring is wired into `DEFAULT_RINGS` by direct import so tree-shaking with `"sideEffects": false` stays safe; `uninstall()` restores originals, removes listeners, and clears internal dedupe state. Closes #2.

--- a/.changeset/create-brevwick-core.md
+++ b/.changeset/create-brevwick-core.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 Add `createBrevwick(config)` factory with `install()` / `uninstall()` lifecycle and bounded FIFO ring buffers (console 50, network 50, routes 20). Canonicalises the `endpoint` so typo-equivalents (trailing slash, host casing) collapse to the same singleton key. `uninstall()` evicts the instance from the singleton registry so a subsequent `createBrevwick` call with the same key returns a fresh, installable instance. Ring modules land in follow-up PRs (#2 / #3) and are wired in by direct import, not module-side-effect registration, so the SDK's `"sideEffects": false` contract stays safe under tree-shaking. Freezes the public surface to exactly `createBrevwick`, `Brevwick`, `BrevwickConfig`, `FeedbackInput`, `SubmitResult`, `FeedbackAttachment`, `Environment`.

--- a/.changeset/credit-footer.md
+++ b/.changeset/credit-footer.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': patch
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
 ---
 
 feat(react): credit footer with version + brevwick.dev link
@@ -20,6 +20,6 @@ feat(react): credit footer with version + brevwick.dev link
   no new source of truth.
 - No public API change; props, hooks, and payload are unchanged.
 
-The `brevwick-sdk` bump is a no-op patch to keep both packages in
+The `@tatlacas/brevwick-sdk` bump is a no-op patch to keep both packages in
 lockstep per the repo's pre-1.0 versioning policy; the core SDK has
 no code changes in this release.

--- a/.changeset/integration-msw-coverage.md
+++ b/.changeset/integration-msw-coverage.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': patch
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
 ---
 
 test(integration): MSW + live-API e2e coverage

--- a/.changeset/loopback-http-endpoint.md
+++ b/.changeset/loopback-http-endpoint.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 Allow `http://` endpoints on loopback hostnames (`localhost`, `127.0.0.1`, `[::1]`) so integrators can point `createBrevwick` at a local `brevwick-api` without standing up TLS. Non-loopback hosts still require `https:`. The eager-bundle gzip budget is bumped from < 2 kB to < 2.2 kB to accommodate the three extra hostname checks (SDD § 12 + `CLAUDE.md` updated in lockstep). `.localhost` subdomain aliases are NOT accepted; use `127.0.0.1` instead.

--- a/.changeset/network-ring.md
+++ b/.changeset/network-ring.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 Add the network ring: patches `globalThis.fetch` and `XMLHttpRequest.prototype.open/send/setRequestHeader` on install to capture any request with status ≥ 400 or that throws / aborts / times out. Captured entries include sanitised request + response headers (allow-list only — `content-type`, `accept`, `x-request-id`, etc.), a redacted + capped request body (2 kB) and response body (4 kB), and duration. Sensitive query parameters (`token|auth|key|session|sig`) are stripped from the captured URL. Binary and form-data bodies surface as `[binary N bytes]` / `[form-data]` markers. Requests to the configured ingest endpoint and requests carrying the `X-Brevwick-SDK` header are skipped to avoid submit-time feedback loops; the loop guard matches on origin + path boundary so sibling brand domains such as `api.brevwick.company` are not silently dropped. XHR `abort` and `timeout` are captured alongside `error` with distinct labels.
@@ -9,4 +9,4 @@ Grows the public `NetworkEntry` type (all optional fields): `requestBody`, `resp
 
 The ring module is dynamic-imported from `install()` and lands in its own async chunk — keeping the eager core bundle under the 2 kB gzip budget mandated by `CLAUDE.md`. Async ring loaders that resolve after `uninstall()` now short-circuit via a generation counter, so late-landing imports never re-patch globals against a terminal instance.
 
-Test-only helpers (`__setRingsForTesting`, `__resetBrevwickRegistry`) moved from the package root to a new `brevwick-sdk/testing` entry point so they never ship in the eager production bundle. Not part of the public contract; consumer code must not import them.
+Test-only helpers (`__setRingsForTesting`, `__resetBrevwickRegistry`) moved from the package root to a new `@tatlacas/brevwick-sdk/testing` entry point so they never ship in the eager production bundle. Not part of the public contract; consumer code must not import them.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,8 +2,8 @@
   "mode": "pre",
   "tag": "beta",
   "initialVersions": {
-    "brevwick-react": "0.1.0-beta.1",
-    "brevwick-sdk": "0.1.0-beta.1",
+    "@tatlacas/brevwick-react": "0.1.0-beta.1",
+    "@tatlacas/brevwick-sdk": "0.1.0-beta.1",
     "brevwick-example-next": "0.0.0",
     "brevwick-example-vanilla": "0.0.0"
   },

--- a/.changeset/react-bindings.md
+++ b/.changeset/react-bindings.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
 ---
 
 feat(react): BrevwickProvider + useFeedback + FeedbackButton
@@ -19,5 +19,5 @@ Ships the React bindings per SDD § 12:
 - `data-brevwick-skip` applied to FAB, overlay, and dialog so captured
   screenshots exclude Brevwick's own UI.
 
-The `brevwick-sdk` bump is the lockstep pre-1.0 version (no code change in
+The `@tatlacas/brevwick-sdk` bump is the lockstep pre-1.0 version (no code change in
 the SDK for this PR).

--- a/.changeset/react-theme-prop.md
+++ b/.changeset/react-theme-prop.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': patch
 ---
 
 feat(react): `theme` prop on `<FeedbackButton>` (light / dark / system)
@@ -19,8 +19,8 @@ feat(react): `theme` prop on `<FeedbackButton>` (light / dark / system)
   rewrite `--brw-X-base`, never the public `--brw-X`. So
   `theme="dark"` + a consumer `--brw-accent: hotpink` still paints the
   accent hotpink.
-- `BrevwickTheme` type exported from `brevwick-react` for consumers that
+- `BrevwickTheme` type exported from `@tatlacas/brevwick-react` for consumers that
   want to type their own theme-selecting state.
 
-The `brevwick-sdk` patch bump is a no-op to keep the two packages in
+The `@tatlacas/brevwick-sdk` patch bump is a no-op to keep the two packages in
 lockstep per the repo's pre-1.0 versioning policy.

--- a/.changeset/region-capture.md
+++ b/.changeset/region-capture.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
 ---
 
 feat(react): screenshot icon + drag-to-select region capture
@@ -27,7 +27,7 @@ page"` so keyboard and screen-reader users discover the affordance
   itself has focus; tabbing to Cancel / Capture full page and pressing
   Enter activates the focused button as expected.
 
-The `brevwick-sdk` bump is a no-op minor to keep the two packages in
+The `@tatlacas/brevwick-sdk` bump is a no-op minor to keep the two packages in
 lockstep per the repo's pre-1.0 versioning policy; the core SDK has no
 code changes in this release. `FeedbackButtonProps` is unchanged; no
 new runtime dependency; no SDD § 12 contract change.

--- a/.changeset/rename-reports-to-issues.md
+++ b/.changeset/rename-reports-to-issues.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': major
-'brevwick-react': major
+'@tatlacas/brevwick-sdk': major
+'@tatlacas/brevwick-react': major
 ---
 
 BREAKING: rename Report → Issue across the public API. The SDK now submits

--- a/.changeset/scope-to-tatlacas-org.md
+++ b/.changeset/scope-to-tatlacas-org.md
@@ -1,0 +1,20 @@
+---
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+---
+
+Rename packages to the `@tatlacas` npm scope: `brevwick-sdk` → `@tatlacas/brevwick-sdk` and `brevwick-react` → `@tatlacas/brevwick-react`. The public API surface is unchanged — only the install name differs.
+
+**Consumers must update their `package.json` and imports:**
+
+```diff
+- import { createBrevwick } from 'brevwick-sdk';
++ import { createBrevwick } from '@tatlacas/brevwick-sdk';
+```
+
+```diff
+- import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
++ import { BrevwickProvider, FeedbackButton } from '@tatlacas/brevwick-react';
+```
+
+Wire-level identifiers (the `sdk.name: 'brevwick-sdk'` field in ingest payloads and the `X-Brevwick-SDK` request header) are intentionally preserved, so server-side filters on the SDK identifier continue to match.

--- a/.changeset/screenshot-dialog-title.md
+++ b/.changeset/screenshot-dialog-title.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': patch
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
 ---
 
 fix(react): add hidden Dialog.Title to screenshot region overlay
@@ -12,5 +12,5 @@ the warning. Render a visually-hidden `Dialog.Title` (text: "Select
 screenshot region") to satisfy the primitive without affecting the
 announced name.
 
-The `brevwick-sdk` bump is a no-op patch to keep the two packages in
+The `@tatlacas/brevwick-sdk` bump is a no-op patch to keep the two packages in
 lockstep per the repo's pre-1.0 versioning policy.

--- a/.changeset/screenshot.md
+++ b/.changeset/screenshot.md
@@ -1,11 +1,11 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 feat(screenshot): captureScreenshot() via dynamic import
 
-Adds `captureScreenshot(opts?)` to `brevwick-sdk`. The function dynamically
+Adds `captureScreenshot(opts?)` to `@tatlacas/brevwick-sdk`. The function dynamically
 imports `modern-screenshot` so the base bundle stays below the 2 kB gzip
 budget. `[data-brevwick-skip]` nodes are hidden during capture and restored
 afterwards — even on failure. Capture never throws: a failure resolves with a

--- a/.changeset/sha256-checksum-on-presign.md
+++ b/.changeset/sha256-checksum-on-presign.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': patch
-'brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
 ---
 
 fix(submit): send sha256 on presign + issue so R2 PUT carries checksum

--- a/.changeset/size-limit-budgets.md
+++ b/.changeset/size-limit-budgets.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': patch
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
 ---
 
 Internal: enable `minify: true` in the React package's tsup build (~2 kB
@@ -9,4 +9,4 @@ change). Adds `size-limit` budgets enforced in CI: core eager chunk ≤ 2.2 kB
 gzip, screenshot wrapper ≤ 1.5 kB gzip, React bundle ≤ 25 kB gzip, and a
 re-bundled "on-widget-open" measurement (screenshot wrapper + resolved
 `modern-screenshot` peer) ≤ 25 kB gzip. SDK source unchanged; bumped in
-lockstep with `brevwick-react` per the project's lockstep policy.
+lockstep with `@tatlacas/brevwick-react` per the project's lockstep policy.

--- a/.changeset/submit-pipeline.md
+++ b/.changeset/submit-pipeline.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-sdk': minor
-'brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
 ---
 
 Add `submit(input)` pipeline: presigns each attachment, PUTs to the returned URL, then POSTs `/v1/ingest/issues` under a 30 s `AbortController` budget with one initial attempt + two retries on 5xx / network errors. Public type `SubmitResult` becomes a tagged union — `{ ok: true; issue_id: string } | { ok: false; error: { code: SubmitErrorCode; message: string } }` — so callers discriminate on `ok` and the pipeline never throws (breaking change versus the prior `{ issueId }` shape). New exports: `SubmitError`, `SubmitErrorCode`, and `FeedbackAttachment` (which widens `FeedbackInput.attachments` to `Array<Blob | FeedbackAttachment>`). All free-form text and `user_context` extras run through `redact()` before the wire; `config.user.email` is masked as `a***@d***.tld`; ring snapshots flow through unchanged because they were redacted at capture. Attachments are validated client-side (≤5 count, ≤10 MB each, MIME ∈ {image/png, image/jpeg, image/webp, video/webm}) before any presign round-trip. The submit pipeline lives in its own dynamic-import chunk so the eager core stays under the 2 kB gzip budget.

--- a/.changeset/theming-composer-shell.md
+++ b/.changeset/theming-composer-shell.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': patch
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': patch
 ---
 
 feat(react): light/dark theming + composer shell polish
@@ -25,6 +25,6 @@ flex-end` keeps the send button pinned to the bottom as the textarea
 - No public API change (props / hooks / payload unchanged); no new
   runtime dependency.
 
-The `brevwick-sdk` bump is a no-op patch to keep the two packages in
+The `@tatlacas/brevwick-sdk` bump is a no-op patch to keep the two packages in
 lockstep per the repo's pre-1.0 versioning policy; the core SDK has
 no code changes in this release.

--- a/.changeset/use-ai-toggle.md
+++ b/.changeset/use-ai-toggle.md
@@ -1,6 +1,6 @@
 ---
-'brevwick-react': minor
-'brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
 ---
 
 feat(react): submitter Use-AI toggle + project config fetch
@@ -13,7 +13,7 @@ Implements issue #26 per SDD § 12.
   callers and retains a `null` result so failed or malformed responses are
   not retried).
 - New `ProjectConfig` type (`{ ai_enabled, ai_submitter_choice_allowed }`)
-  exported from `brevwick-sdk`; `fetchConfig` never throws — non-2xx,
+  exported from `@tatlacas/brevwick-sdk`; `fetchConfig` never throws — non-2xx,
   malformed shape, and thrown fetch all resolve to `null`.
 - `FeedbackInput` gains optional `use_ai: boolean`; `composePayload`
   threads it through to the ingest body when defined. Booleans skip

--- a/.claude/agents/pr-review-fixer.md
+++ b/.claude/agents/pr-review-fixer.md
@@ -6,11 +6,11 @@ color: green
 memory: project
 ---
 
-You are an elite remediation specialist for **brevwick-sdk-js** (pnpm workspace, `brevwick-sdk` + `brevwick-react`, tsup, Vitest). You take the review checklist and resolve every item.
+You are an elite remediation specialist for **brevwick-sdk-js** (pnpm workspace, `@tatlacas/brevwick-sdk` + `@tatlacas/brevwick-react`, tsup, Vitest). You take the review checklist and resolve every item.
 
 ## Non-Negotiables
 
-1. **Clean architecture compliance** — core stays framework-agnostic, React stays in `brevwick-react`, public API minimal and tree-shakeable. A fix that violates this is itself a defect.
+1. **Clean architecture compliance** — core stays framework-agnostic, React stays in `@tatlacas/brevwick-react`, public API minimal and tree-shakeable. A fix that violates this is itself a defect.
 2. **Clean code** — SOLID, DRY, KISS, strict TS, no `any`, meaningful names.
 3. **Completeness** — every review item resolved. Public API changes also update the SDD. No `DEFERRED`, no new tracking issues to cover missed work.
 
@@ -58,7 +58,7 @@ If the original issue or `worktree.md` called for it, it ships here. If a bug / 
 1. Read full source before editing
 2. Apply the correct, layered fix:
    - Core stays framework-agnostic
-   - React-only code lives in `brevwick-react`
+   - React-only code lives in `@tatlacas/brevwick-react`
    - Strict TS, no `any`
    - Public API minimal and documented with JSDoc
    - Tree-shakeable; `"sideEffects": false` respected

--- a/.claude/agents/pr-review-validator.md
+++ b/.claude/agents/pr-review-validator.md
@@ -10,7 +10,7 @@ You are the last line of defence before merge on **brevwick-sdk-js**. The review
 
 ## Non-Negotiables
 
-1. **Clean architecture compliance** — core framework-agnostic, React-only in `brevwick-react`, tree-shakeable public API. Any regression → reject.
+1. **Clean architecture compliance** — core framework-agnostic, React-only in `@tatlacas/brevwick-react`, tree-shakeable public API. Any regression → reject.
 2. **Clean code** — no new duplication / dead code / `any` / magic numbers / deep nesting / poor names → reject.
 3. **Completeness** — every item resolved. Every `- [x]` real. Every `~~struck~~` legitimate. Any remaining `- [ ]` → fail.
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -6,13 +6,13 @@ color: purple
 memory: project
 ---
 
-You are an uncompromising principal engineer reviewing a pull request on **brevwick-sdk-js** — a pnpm workspace publishing two npm packages: `brevwick-sdk` (core, framework-agnostic) and `brevwick-react` (React bindings). Built with tsup, tested with Vitest. Your review feeds directly into an automated fix pipeline.
+You are an uncompromising principal engineer reviewing a pull request on **brevwick-sdk-js** — a pnpm workspace publishing two npm packages: `@tatlacas/brevwick-sdk` (core, framework-agnostic) and `@tatlacas/brevwick-react` (React bindings). Built with tsup, tested with Vitest. Your review feeds directly into an automated fix pipeline.
 
 ## Non-Negotiables
 
 HARD blockers. Any violation → **CHANGES REQUIRED**.
 
-1. **Clean architecture compliance** — `brevwick-sdk` stays framework-agnostic. React types / hooks / JSX belong ONLY in `brevwick-react`. No leaking React, DOM, or Node-only APIs into the core. Public API surface is intentional and tree-shakeable. Module boundaries in `CLAUDE.md` are absolute.
+1. **Clean architecture compliance** — `@tatlacas/brevwick-sdk` stays framework-agnostic. React types / hooks / JSX belong ONLY in `@tatlacas/brevwick-react`. No leaking React, DOM, or Node-only APIs into the core. Public API surface is intentional and tree-shakeable. Module boundaries in `CLAUDE.md` are absolute.
 2. **Clean code** — SOLID, DRY, KISS, meaningful names, single responsibility, small functions, no dead code, no commented-out code, no `any`, no stale TODOs, no deep nesting.
 3. **Completeness** — every acceptance criterion implemented. No stubs / placeholders / "follow-up" work.
 
@@ -36,8 +36,8 @@ HARD blockers. Any violation → **CHANGES REQUIRED**.
 
 **B. Clean Architecture (CRITICAL)**
 
-- `brevwick-sdk` has zero React / DOM / Node-only imports (unless it's a Node-only sub-entry, documented)
-- React bindings live only in `brevwick-react` and depend on `brevwick-sdk`, never the reverse
+- `@tatlacas/brevwick-sdk` has zero React / DOM / Node-only imports (unless it's a Node-only sub-entry, documented)
+- React bindings live only in `@tatlacas/brevwick-react` and depend on `@tatlacas/brevwick-sdk`, never the reverse
 - Public API (`export`) surface is minimal and intentional; internal helpers not exported
 - Tree-shakeable: no side effects at import time; `"sideEffects": false` honoured
 - Transport / storage / runtime concerns separated (no fetch calls mixed into domain types)

--- a/.github/prompts/pr-reviewer.prompt.md
+++ b/.github/prompts/pr-reviewer.prompt.md
@@ -5,13 +5,13 @@ description: Independent second-opinion review of an open PR on brevwick-sdk-js.
 
 # Copilot Reviewer — brevwick-sdk-js
 
-You are an uncompromising principal engineer providing an **independent second opinion** on a PR on **brevwick-sdk-js** (pnpm workspace: `brevwick-sdk` core + `brevwick-react` bindings; tsup; Vitest).
+You are an uncompromising principal engineer providing an **independent second opinion** on a PR on **brevwick-sdk-js** (pnpm workspace: `@tatlacas/brevwick-sdk` core + `@tatlacas/brevwick-react` bindings; tsup; Vitest).
 
 Your review is consumed by Claude's `pr-review-fixer`, which merges your findings with Claude's own review and actions both. **You do not fix code. You do not invoke any other agent.** Your value is catching what the other reviewer missed.
 
 ## Non-Negotiables
 
-1. **Clean architecture compliance** — `brevwick-sdk` stays framework-agnostic; React / DOM-only APIs live ONLY in `brevwick-react` or a documented sub-entry; public API intentional and tree-shakeable.
+1. **Clean architecture compliance** — `@tatlacas/brevwick-sdk` stays framework-agnostic; React / DOM-only APIs live ONLY in `@tatlacas/brevwick-react` or a documented sub-entry; public API intentional and tree-shakeable.
 2. **Clean code** — SOLID, DRY, KISS, strict TS, no `any`, meaningful names, small functions, no dead code, no commented-out code, no stale TODOs, nesting ≤ 3 levels.
 3. **Completeness** — every acceptance criterion, every `worktree.md` item shipped here; SDD § 12 updated when public API changed; redaction test added for every new context field. Stubs / placeholders / "follow-up" are CRITICAL failures.
 
@@ -21,7 +21,7 @@ Your review is consumed by Claude's `pr-review-fixer`, which merges your finding
 2. **Load standards** — `CLAUDE.md`, `eslint.config.mjs`, `tsconfig.base.json`, `pnpm-workspace.yaml`, per-package configs.
 3. **Review every changed file** against:
    - Completeness · Clean Architecture · Clean Code
-   - Package boundary (no React / DOM imports inside `brevwick-sdk` core)
+   - Package boundary (no React / DOM imports inside `@tatlacas/brevwick-sdk` core)
    - Public API surface (intentional exports only; JSDoc on every public export; tree-shakeable; `"sideEffects": false` honoured)
    - Bundle budget (core initial chunk < 2 kB gzip; on-widget-open chunk < 25 kB gzip — heavy deps dynamic-imported)
    - Cross-runtime safety (no `process` / `Buffer` / `fs` in browser modules, no `window` / `document` in universal)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
       - run: pnpm lint
-      # Build brevwick-sdk first so brevwick-react's tsc + vitest can resolve
+      # Build @tatlacas/brevwick-sdk first so @tatlacas/brevwick-react's tsc + vitest can resolve
       # the workspace dep via its published "types"/"import" export entries
       # (packages/sdk/dist/index.d.ts etc.). Without this, a clean CI checkout
-      # fails type-check with TS2307 on every `from 'brevwick-sdk'` import.
-      - run: pnpm --filter brevwick-sdk build
+      # fails type-check with TS2307 on every `from '@tatlacas/brevwick-sdk'` import.
+      - run: pnpm --filter @tatlacas/brevwick-sdk build
       - run: pnpm type-check
       - run: pnpm test:cover
       - run: pnpm build

--- a/.github/workflows/sdk-e2e-live.yml
+++ b/.github/workflows/sdk-e2e-live.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter brevwick-sdk build
+      - run: pnpm --filter @tatlacas/brevwick-sdk build
 
       # No-op smoke. Until upstream pieces (1)–(3) above land, every
       # dispatch path is a deliberate green: the job exists so the

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -35,12 +35,12 @@ const fileEntry = (name, path, limit) => ({ name, path, limit, ...FILE_MODE });
 export default [
   // ── Core eager chunk (≤ 2.2 kB gzip) ─────────────────────────────────────
   fileEntry(
-    'brevwick-sdk core eager (ESM)',
+    '@tatlacas/brevwick-sdk core eager (ESM)',
     'packages/sdk/dist/index.js',
     '2.2 kB',
   ),
   fileEntry(
-    'brevwick-sdk core eager (CJS)',
+    '@tatlacas/brevwick-sdk core eager (CJS)',
     'packages/sdk/dist/index.cjs',
     '2.2 kB',
   ),
@@ -51,19 +51,27 @@ export default [
   // size ~896 B; 1.5 kB leaves room for small additions but flags any large
   // wrapper bloat.
   fileEntry(
-    'brevwick-sdk screenshot wrapper (ESM)',
+    '@tatlacas/brevwick-sdk screenshot wrapper (ESM)',
     'packages/sdk/dist/screenshot-*.js',
     '1.5 kB',
   ),
   fileEntry(
-    'brevwick-sdk screenshot wrapper (CJS)',
+    '@tatlacas/brevwick-sdk screenshot wrapper (CJS)',
     'packages/sdk/dist/screenshot-*.cjs',
     '1.5 kB',
   ),
 
   // ── React bundle (≤ 25 kB gzip) ──────────────────────────────────────────
-  fileEntry('brevwick-react (ESM)', 'packages/react/dist/index.js', '25 kB'),
-  fileEntry('brevwick-react (CJS)', 'packages/react/dist/index.cjs', '25 kB'),
+  fileEntry(
+    '@tatlacas/brevwick-react (ESM)',
+    'packages/react/dist/index.js',
+    '25 kB',
+  ),
+  fileEntry(
+    '@tatlacas/brevwick-react (CJS)',
+    'packages/react/dist/index.cjs',
+    '25 kB',
+  ),
 
   // ── On-widget-open total weight (≤ 25 kB gzip) ───────────────────────────
   // Bundled-import mode: esbuild re-bundles the screenshot module + its
@@ -71,7 +79,7 @@ export default [
   // the async chunk that loads when the user clicks the FAB. This is what
   // CLAUDE.md and SDD § 11.8 actually mean by "on widget open < 25 kB gzip".
   {
-    name: 'brevwick-sdk on widget open (screenshot + modern-screenshot)',
+    name: '@tatlacas/brevwick-sdk on widget open (screenshot + modern-screenshot)',
     path: 'packages/sdk/dist/index.js',
     import: '{ captureScreenshot }',
     limit: '25 kB',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cd ../brevwick-sdk-js-issue-<N>
 
 ## Project Overview
 
-pnpm workspace publishing two npm packages: `brevwick-sdk` (core, framework-agnostic) and `brevwick-react` (React bindings).
+pnpm workspace publishing two npm packages: `@tatlacas/brevwick-sdk` (core, framework-agnostic) and `@tatlacas/brevwick-react` (React bindings).
 
 **GitHub:** https://github.com/tatlacas-com/brevwick-sdk-js
 
@@ -55,13 +55,13 @@ pnpm format
 Per-package:
 
 ```bash
-pnpm --filter brevwick-sdk build
-pnpm --filter brevwick-react test
+pnpm --filter @tatlacas/brevwick-sdk build
+pnpm --filter @tatlacas/brevwick-react test
 ```
 
 ## Bundle Budget — DO NOT EXCEED
 
-- Core `brevwick-sdk` initial chunk: **< 2.2 kB gzip** (bumped from 2 kB in issue-9 with the loopback-http carve-out in `canonicaliseHttpsUrl`; enforced by `packages/sdk/src/__tests__/chunk-split.test.ts` and mirrored in SDD § 12)
+- Core `@tatlacas/brevwick-sdk` initial chunk: **< 2.2 kB gzip** (bumped from 2 kB in issue-9 with the loopback-http carve-out in `canonicaliseHttpsUrl`; enforced by `packages/sdk/src/__tests__/chunk-split.test.ts` and mirrored in SDD § 12)
 - On widget open (`modern-screenshot` dynamic-imported): **< 25 kB gzip**
 
 Anything heavy must be dynamic-imported (`await import('modern-screenshot')`) so it doesn't ship until the user clicks the FAB.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in Brevwick. This repo publishes two npm packages (`brevwick-sdk`, `brevwick-react`) from a pnpm workspace.
+Thanks for your interest in Brevwick. This repo publishes two npm packages (`@tatlacas/brevwick-sdk`, `@tatlacas/brevwick-react`) from a pnpm workspace.
 
 ## Prerequisites
 
@@ -28,8 +28,8 @@ pnpm size            # size-limit gate
 ### Per-package
 
 ```bash
-pnpm --filter brevwick-sdk build
-pnpm --filter brevwick-react test
+pnpm --filter @tatlacas/brevwick-sdk build
+pnpm --filter @tatlacas/brevwick-react test
 ```
 
 ## Bundle budgets
@@ -38,7 +38,7 @@ Hard limits enforced by `size-limit` and unit tests. **Do not exceed.**
 
 | Scope                                       | Budget (gzip) |
 | ------------------------------------------- | ------------- |
-| `brevwick-sdk` initial chunk                | ≤ 2.2 kB      |
+| `@tatlacas/brevwick-sdk` initial chunk      | ≤ 2.2 kB      |
 | On widget open (`modern-screenshot` loaded) | ≤ 25 kB       |
 
 Anything heavy must be dynamic-imported (`await import('modern-screenshot')`) so it stays out of the initial bundle.
@@ -60,13 +60,13 @@ Then in the consumer's `package.json`:
 ```json
 {
   "dependencies": {
-    "brevwick-sdk": "1.0.0-beta.2",
-    "brevwick-react": "1.0.0-beta.2"
+    "@tatlacas/brevwick-sdk": "1.0.0-beta.2",
+    "@tatlacas/brevwick-react": "1.0.0-beta.2"
   },
   "pnpm": {
     "overrides": {
-      "brevwick-sdk": "file:/abs/path/to/brevwick-sdk-js/packages/sdk/brevwick-sdk-1.0.0-beta.2.tgz",
-      "brevwick-react": "file:/abs/path/to/brevwick-sdk-js/packages/react/brevwick-react-1.0.0-beta.2.tgz"
+      "@tatlacas/brevwick-sdk": "file:/abs/path/to/brevwick-sdk-js/packages/sdk/brevwick-sdk-1.0.0-beta.2.tgz",
+      "@tatlacas/brevwick-react": "file:/abs/path/to/brevwick-sdk-js/packages/react/brevwick-react-1.0.0-beta.2.tgz"
     }
   }
 }
@@ -135,18 +135,18 @@ CI's `changeset-check` fails the PR if no changeset is present (except when the 
 
 ### npm dist-tags
 
-- `npm install brevwick-sdk@beta` — canonical install during the beta line.
-- `npm install brevwick-sdk` — resolves to `latest` once stabilisation ships. `latest` is intentionally unpopulated during the beta line. Full policy in SDD § 12.
+- `npm install @tatlacas/brevwick-sdk@beta` — canonical install during the beta line.
+- `npm install @tatlacas/brevwick-sdk` — resolves to `latest` once stabilisation ships. `latest` is intentionally unpopulated during the beta line. Full policy in SDD § 12.
 
 ## Repo secrets
 
 Configured under **Settings → Secrets and variables → Actions**.
 
-| Secret          | Purpose                                                                                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NPM_TOKEN`     | Automation token with publish rights for `brevwick-sdk` and `brevwick-react`. `id-token: write` is also granted so npm provenance can attest the build. A move to [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) is on the roadmap. |
-| `GITHUB_TOKEN`  | Provided by Actions. The workflow requests `contents: write` and `pull-requests: write` so Changesets can open the Version Packages PR and create releases.                                                                                              |
-| `CODECOV_TOKEN` | Coverage upload.                                                                                                                                                                                                                                         |
+| Secret          | Purpose                                                                                                                                                                                                                                                                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NPM_TOKEN`     | Automation token with publish rights for `@tatlacas/brevwick-sdk` and `@tatlacas/brevwick-react`. `id-token: write` is also granted so npm provenance can attest the build. A move to [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers) is on the roadmap. |
+| `GITHUB_TOKEN`  | Provided by Actions. The workflow requests `contents: write` and `pull-requests: write` so Changesets can open the Version Packages PR and create releases.                                                                                                                  |
+| `CODECOV_TOKEN` | Coverage upload.                                                                                                                                                                                                                                                             |
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Brevwick JS SDK
 
-[![npm (sdk)](https://img.shields.io/npm/v/brevwick-sdk/beta?label=brevwick-sdk%40beta)](https://www.npmjs.com/package/brevwick-sdk)
-[![npm (react)](https://img.shields.io/npm/v/brevwick-react/beta?label=brevwick-react%40beta)](https://www.npmjs.com/package/brevwick-react)
+[![npm (sdk)](https://img.shields.io/npm/v/@tatlacas/brevwick-sdk/beta?label=@tatlacas/brevwick-sdk%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
+[![npm (react)](https://img.shields.io/npm/v/@tatlacas/brevwick-react/beta?label=@tatlacas/brevwick-react%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-react)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 Ship feedback from any browser app straight into clean, AI-formatted GitHub issues. Drop in a floating button, collect a description + screenshot + the console/network rings that preceded the bug, and Brevwick turns it all into a triage-ready issue on your repo.
@@ -10,10 +10,10 @@ Ship feedback from any browser app straight into clean, AI-formatted GitHub issu
 
 ## Packages
 
-| Package                              | Description                                                             | API reference                                          |
-| ------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------ |
-| [`brevwick-sdk`](./packages/sdk)     | Framework-agnostic core: submit, screenshot, rings.                     | [packages/sdk/README.md](./packages/sdk/README.md)     |
-| [`brevwick-react`](./packages/react) | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19. | [packages/react/README.md](./packages/react/README.md) |
+| Package                                        | Description                                                             | API reference                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
+| [`@tatlacas/brevwick-sdk`](./packages/sdk)     | Framework-agnostic core: submit, screenshot, rings.                     | [packages/sdk/README.md](./packages/sdk/README.md)     |
+| [`@tatlacas/brevwick-react`](./packages/react) | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19. | [packages/react/README.md](./packages/react/README.md) |
 
 ## Install
 
@@ -21,10 +21,10 @@ Pick the one that matches your stack.
 
 ```bash
 # Any browser app (framework-agnostic)
-npm install brevwick-sdk@beta
+npm install @tatlacas/brevwick-sdk@beta
 
-# React / Next.js / Remix — pulls brevwick-sdk in as a peer dep
-npm install brevwick-react@beta brevwick-sdk@beta
+# React / Next.js / Remix — pulls @tatlacas/brevwick-sdk in as a peer dep
+npm install @tatlacas/brevwick-react@beta @tatlacas/brevwick-sdk@beta
 ```
 
 Works with `pnpm add`, `yarn add`, `bun add` — same package names.
@@ -34,7 +34,7 @@ Works with `pnpm add`, `yarn add`, `bun add` — same package names.
 ### React
 
 ```tsx
-import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
+import { BrevwickProvider, FeedbackButton } from '@tatlacas/brevwick-react';
 
 export default function App() {
   return (
@@ -53,7 +53,7 @@ Full API and theming → [packages/react/README.md](./packages/react/README.md).
 ### Vanilla / any framework
 
 ```ts
-import { createBrevwick } from 'brevwick-sdk';
+import { createBrevwick } from '@tatlacas/brevwick-sdk';
 
 const bw = createBrevwick({
   projectKey: 'pk_live_...',

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,7 +1,7 @@
 # brevwick-example-next
 
 Next.js 16 (App Router) example wired up with
-[`brevwick-react`](../../packages/react)&rsquo;s `<BrevwickProvider>` and
+[`@tatlacas/brevwick-react`](../../packages/react)&rsquo;s `<BrevwickProvider>` and
 `<FeedbackButton>`.
 
 ## Works locally
@@ -20,7 +20,7 @@ Next.js 16 (App Router) example wired up with
 3. From the repo root, build the SDKs and run the example:
    ```bash
    pnpm install
-   pnpm --filter brevwick-sdk --filter brevwick-react build
+   pnpm --filter @tatlacas/brevwick-sdk --filter @tatlacas/brevwick-react build
    pnpm --filter brevwick-example-next dev
    ```
 4. Open http://localhost:3000 and click the floating **Feedback** button.

--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "brevwick-react": "workspace:*",
-    "brevwick-sdk": "workspace:*",
+    "@tatlacas/brevwick-react": "workspace:*",
+    "@tatlacas/brevwick-sdk": "workspace:*",
     "next": "^16.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/examples/next/src/app/configured-widget.tsx
+++ b/examples/next/src/app/configured-widget.tsx
@@ -7,8 +7,8 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
-import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
-import type { BrevwickConfig } from 'brevwick-sdk';
+import { BrevwickProvider, FeedbackButton } from '@tatlacas/brevwick-react';
+import type { BrevwickConfig } from '@tatlacas/brevwick-sdk';
 
 export interface ConfiguredWidgetProps {
   projectKey: string;

--- a/examples/next/src/app/layout.tsx
+++ b/examples/next/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactElement, ReactNode } from 'react';
 
 export const metadata: Metadata = {
   title: 'Brevwick — Next.js example',
-  description: 'Minimal Next.js app wired up with brevwick-react.',
+  description: 'Minimal Next.js app wired up with @tatlacas/brevwick-react.',
 };
 
 export const viewport: Viewport = {

--- a/examples/next/src/app/page.tsx
+++ b/examples/next/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { ConfiguredWidget } from './configured-widget';
 
-// Mirrors the shape enforced by `brevwick-sdk`'s `validateConfig`. Shape-check
+// Mirrors the shape enforced by `@tatlacas/brevwick-sdk`'s `validateConfig`. Shape-check
 // on the server so the Provider is never mounted with a key that would throw
 // synchronously from `createBrevwick(...)` in the client bundle — that would
 // surface as a blank React crash instead of the friendly banner below.
@@ -70,9 +70,9 @@ export default function Home(): ReactElement {
         <h1 style={{ marginTop: 0 }}>Brevwick — Next.js example</h1>
         <p>
           The floating <strong>Feedback</strong> button is rendered by{' '}
-          <code>&lt;FeedbackButton /&gt;</code> from <code>brevwick-react</code>
-          . Click it, fill the dialog, submit, and check{' '}
-          <code>brevwick-web</code>&rsquo;s inbox.
+          <code>&lt;FeedbackButton /&gt;</code> from{' '}
+          <code>@tatlacas/brevwick-react</code>. Click it, fill the dialog,
+          submit, and check <code>brevwick-web</code>&rsquo;s inbox.
         </p>
         {error === 'missing-key' && (
           <p style={{ color: '#b42318' }}>

--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -1,7 +1,7 @@
 # brevwick-example-vanilla
 
 Plain HTML + Vite + TypeScript example that imports
-[`brevwick-sdk`](../../packages/sdk) directly and submits a hard-coded
+[`@tatlacas/brevwick-sdk`](../../packages/sdk) directly and submits a hard-coded
 issue when a button is clicked.
 
 ## Works locally
@@ -20,7 +20,7 @@ issue when a button is clicked.
 3. From the repo root, build the SDK and run the example:
    ```bash
    pnpm install
-   pnpm --filter brevwick-sdk build
+   pnpm --filter @tatlacas/brevwick-sdk build
    pnpm --filter brevwick-example-vanilla dev
    ```
 4. Open http://localhost:5173 and click **Send feedback**.

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -54,7 +54,7 @@
       <h1>Brevwick vanilla example</h1>
       <p>
         Click the button to submit a hard-coded issue via
-        <code>brevwick-sdk</code>.
+        <code>@tatlacas/brevwick-sdk</code>.
       </p>
       <button id="send" type="button">Send feedback</button>
       <div id="result" aria-live="polite"></div>

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "brevwick-sdk": "workspace:*"
+    "@tatlacas/brevwick-sdk": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -1,4 +1,4 @@
-import { createBrevwick } from 'brevwick-sdk';
+import { createBrevwick } from '@tatlacas/brevwick-sdk';
 
 const PLACEHOLDER_KEY = 'pk_test_replace_me';
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,19 +1,19 @@
-# brevwick-react
+# @tatlacas/brevwick-react
 
-[![npm](https://img.shields.io/npm/v/brevwick-react/beta?label=brevwick-react%40beta)](https://www.npmjs.com/package/brevwick-react)
+[![npm](https://img.shields.io/npm/v/@tatlacas/brevwick-react/beta?label=@tatlacas/brevwick-react%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-react)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 React bindings for [Brevwick](https://brevwick.dev) — a provider, a drop-in floating feedback button, and a `useFeedback` hook for custom UIs.
 
-Wraps [`brevwick-sdk`](https://www.npmjs.com/package/brevwick-sdk) — all configuration and submit semantics live there. This package adds the React ergonomics.
+Wraps [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk) — all configuration and submit semantics live there. This package adds the React ergonomics.
 
 ## Install
 
 ```bash
-npm install brevwick-react@beta brevwick-sdk@beta
+npm install @tatlacas/brevwick-react@beta @tatlacas/brevwick-sdk@beta
 ```
 
-`brevwick-sdk` is a peer dependency. Installers that respect peer deps (npm 7+, pnpm, yarn 3+) will pull it in automatically.
+`@tatlacas/brevwick-sdk` is a peer dependency. Installers that respect peer deps (npm 7+, pnpm, yarn 3+) will pull it in automatically.
 
 **React:** 18.x and 19.x are supported.
 
@@ -22,7 +22,7 @@ npm install brevwick-react@beta brevwick-sdk@beta
 ### Drop-in floating button
 
 ```tsx
-import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
+import { BrevwickProvider, FeedbackButton } from '@tatlacas/brevwick-react';
 
 export default function App() {
   return (
@@ -40,7 +40,7 @@ export default function App() {
 // app/providers.tsx
 'use client';
 
-import { BrevwickProvider, FeedbackButton } from 'brevwick-react';
+import { BrevwickProvider, FeedbackButton } from '@tatlacas/brevwick-react';
 
 const config = { projectKey: 'pk_live_...' };
 
@@ -83,10 +83,10 @@ Top-level provider. Creates a single SDK instance, installs rings on mount, unin
 <BrevwickProvider config={brevwickConfig}>{children}</BrevwickProvider>
 ```
 
-| Prop       | Type             | Description                                                                                                                                          |
-| ---------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `config`   | `BrevwickConfig` | SDK config — see the [core SDK config reference](https://www.npmjs.com/package/brevwick-sdk#brevwickconfig). **Reference-stable**: hoist or memoise. |
-| `children` | `ReactNode`      | Your tree.                                                                                                                                           |
+| Prop       | Type             | Description                                                                                                                                                    |
+| ---------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`   | `BrevwickConfig` | SDK config — see the [core SDK config reference](https://www.npmjs.com/package/@tatlacas/brevwick-sdk#brevwickconfig). **Reference-stable**: hoist or memoise. |
+| `children` | `ReactNode`      | Your tree.                                                                                                                                                     |
 
 ## `FeedbackButton`
 
@@ -160,7 +160,7 @@ Example:
 
 ### Hiding sensitive content from screenshots
 
-The widget captures the page via `brevwick-sdk`'s `captureScreenshot()`. Any element tagged `data-brevwick-skip` is hidden before capture and restored after:
+The widget captures the page via `@tatlacas/brevwick-sdk`'s `captureScreenshot()`. Any element tagged `data-brevwick-skip` is hidden before capture and restored after:
 
 ```tsx
 <input data-brevwick-skip type="password" />
@@ -174,7 +174,7 @@ The FAB, dialog, and region overlay all carry `data-brevwick-skip` themselves, s
 Hook for building a custom feedback UI against the `BrevwickProvider` instance.
 
 ```tsx
-import { useFeedback } from 'brevwick-react';
+import { useFeedback } from '@tatlacas/brevwick-react';
 
 function MyCustomReporter() {
   const { submit, captureScreenshot, status, reset } = useFeedback();
@@ -205,12 +205,12 @@ function MyCustomReporter() {
 
 ### Return value
 
-| Field               | Type                                              | Description                                                                |
-| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
-| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union `brevwick-sdk` returns.     |
-| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a DOM screenshot. Never throws — returns a placeholder on failure. |
-| `status`            | `'idle' \| 'submitting' \| 'success' \| 'error'`  | Current submission lifecycle.                                              |
-| `reset`             | `() => void`                                      | Reset `status` back to `'idle'`. Does not cancel an in-flight submit.      |
+| Field               | Type                                              | Description                                                                      |
+| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union `@tatlacas/brevwick-sdk` returns. |
+| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a DOM screenshot. Never throws — returns a placeholder on failure.       |
+| `status`            | `'idle' \| 'submitting' \| 'success' \| 'error'`  | Current submission lifecycle.                                                    |
+| `reset`             | `() => void`                                      | Reset `status` back to `'idle'`. Does not cancel an in-flight submit.            |
 
 Throws synchronously on mount when rendered outside a `BrevwickProvider`.
 
@@ -219,8 +219,8 @@ Throws synchronously on mount when rendered outside a `BrevwickProvider`.
 Exported semver string of the installed package — useful for including in error reports or diagnostics.
 
 ```ts
-import { BREVWICK_REACT_VERSION } from 'brevwick-react';
-console.log('brevwick-react', BREVWICK_REACT_VERSION);
+import { BREVWICK_REACT_VERSION } from '@tatlacas/brevwick-react';
+console.log('@tatlacas/brevwick-react', BREVWICK_REACT_VERSION);
 ```
 
 ## SSR
@@ -240,12 +240,12 @@ import type {
   BrevwickTheme,
   FeedbackStatus,
   UseFeedbackResult,
-  // from brevwick-sdk, re-exported for convenience:
+  // from @tatlacas/brevwick-sdk, re-exported for convenience:
   BrevwickConfig,
   FeedbackAttachment,
   FeedbackInput,
   SubmitResult,
-} from 'brevwick-react';
+} from '@tatlacas/brevwick-react';
 ```
 
 ## Bundle
@@ -260,7 +260,7 @@ ES2020 evergreen (Chrome/Edge 90+, Firefox 90+, Safari 15+). Matches the core SD
 
 ## Links
 
-- **Core SDK:** [`brevwick-sdk`](https://www.npmjs.com/package/brevwick-sdk)
+- **Core SDK:** [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
 - **Docs / dashboard:** [brevwick.dev](https://brevwick.dev)
 - **Source:** [github.com/tatlacas-com/brevwick-sdk-js](https://github.com/tatlacas-com/brevwick-sdk-js)
 - **Issues:** [github.com/tatlacas-com/brevwick-sdk-js/issues](https://github.com/tatlacas-com/brevwick-sdk-js/issues)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "brevwick-react",
+  "name": "@tatlacas/brevwick-react",
   "version": "1.0.0-beta.2",
   "description": "Brevwick React bindings — provider, FAB, useFeedback hook. Drop-in for any React app.",
   "license": "MIT",
@@ -45,7 +45,7 @@
     "provenance": true
   },
   "peerDependencies": {
-    "brevwick-sdk": "workspace:*",
+    "@tatlacas/brevwick-sdk": "workspace:*",
     "react": ">=18 <20",
     "react-dom": ">=18 <20"
   },
@@ -54,7 +54,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "brevwick-sdk": "workspace:*",
+    "@tatlacas/brevwick-sdk": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "vitest-axe": "^0.1.0"

--- a/packages/react/src/__tests__/bundle-size.test.ts
+++ b/packages/react/src/__tests__/bundle-size.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect } from 'vitest';
  * `size-limit` (`.size-limit.js` at repo root). Skipped when `dist/` is
  * absent so plain `pnpm test` (no prior build) still passes.
  */
-describe('brevwick-react bundle ceiling', () => {
+describe('@tatlacas/brevwick-react bundle ceiling', () => {
   const dist = resolve(__dirname, '../../dist');
   const baseEsm = resolve(dist, 'index.js');
   const baseCjs = resolve(dist, 'index.cjs');

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -17,7 +17,7 @@ import type {
   BrevwickConfig,
   ProjectConfig,
   SubmitResult,
-} from 'brevwick-sdk';
+} from '@tatlacas/brevwick-sdk';
 import pkg from '../../package.json' with { type: 'json' };
 
 const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
@@ -26,9 +26,10 @@ const getConfig = vi.fn<() => Promise<ProjectConfig | null>>();
 const install = vi.fn();
 const uninstall = vi.fn();
 
-vi.mock('brevwick-sdk', async () => {
-  const actual =
-    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
+vi.mock('@tatlacas/brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
+    '@tatlacas/brevwick-sdk',
+  );
   return {
     ...actual,
     createBrevwick: (_config: BrevwickConfig) =>

--- a/packages/react/src/__tests__/integration/render-submit.test.tsx
+++ b/packages/react/src/__tests__/integration/render-submit.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Renders `<BrevwickProvider><FeedbackButton/></BrevwickProvider>` against
- * the REAL core SDK (no `vi.mock('brevwick-sdk', ...)`) and lets MSW
+ * the REAL core SDK (no `vi.mock('@tatlacas/brevwick-sdk', ...)`) and lets MSW
  * intercept the ingest wire. The existing suite in
  * `../feedback-button.test.tsx` mocks `createBrevwick` so it never
  * exercises the submit pipeline end-to-end; this file closes that gap by

--- a/packages/react/src/__tests__/integration/setup.ts
+++ b/packages/react/src/__tests__/integration/setup.ts
@@ -2,8 +2,8 @@
  * Shared MSW scaffolding for the React integration suite. Parallels
  * `packages/sdk/src/__tests__/integration/setup.ts`.
  *
- * Why a separate file rather than a shared `brevwick-sdk/testing/msw`
- * subpath export (the precedent set by `brevwick-sdk/testing` for the
+ * Why a separate file rather than a shared `@tatlacas/brevwick-sdk/testing/msw`
+ * subpath export (the precedent set by `@tatlacas/brevwick-sdk/testing` for the
  * registry mutators):
  *
  * - The React variant adds a `GET /v1/ingest/config` handler returning

--- a/packages/react/src/__tests__/provider.test.tsx
+++ b/packages/react/src/__tests__/provider.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { Brevwick, BrevwickConfig } from 'brevwick-sdk';
+import type { Brevwick, BrevwickConfig } from '@tatlacas/brevwick-sdk';
 
 const install = vi.fn();
 const uninstall = vi.fn();
@@ -8,9 +8,10 @@ const submit = vi.fn();
 const captureScreenshot = vi.fn();
 const createBrevwick = vi.fn<(config: BrevwickConfig) => Brevwick>();
 
-vi.mock('brevwick-sdk', async () => {
-  const actual =
-    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
+vi.mock('@tatlacas/brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
+    '@tatlacas/brevwick-sdk',
+  );
   return {
     ...actual,
     createBrevwick: (config: BrevwickConfig) => createBrevwick(config),

--- a/packages/react/src/__tests__/use-feedback.test.tsx
+++ b/packages/react/src/__tests__/use-feedback.test.tsx
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { Brevwick, BrevwickConfig, SubmitResult } from 'brevwick-sdk';
+import type {
+  Brevwick,
+  BrevwickConfig,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
 import type { ReactNode } from 'react';
 
 const submit = vi.fn<(input: unknown) => Promise<SubmitResult>>();
@@ -8,9 +12,10 @@ const captureScreenshot = vi.fn<() => Promise<Blob>>();
 const install = vi.fn();
 const uninstall = vi.fn();
 
-vi.mock('brevwick-sdk', async () => {
-  const actual =
-    await vi.importActual<typeof import('brevwick-sdk')>('brevwick-sdk');
+vi.mock('@tatlacas/brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
+    '@tatlacas/brevwick-sdk',
+  );
   return {
     ...actual,
     createBrevwick: (_config: BrevwickConfig) =>

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { Brevwick } from 'brevwick-sdk';
+import type { Brevwick } from '@tatlacas/brevwick-sdk';
 
 /**
  * Internal context value carried by {@link BrevwickProvider}. The provider

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -20,7 +20,7 @@ import type {
   FeedbackInput,
   ProjectConfig,
   SubmitResult,
-} from 'brevwick-sdk';
+} from '@tatlacas/brevwick-sdk';
 import { useBrevwickInternal } from './context';
 import { useFeedback, type FeedbackStatus } from './use-feedback';
 import {

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import pkg from '../package.json' with { type: 'json' };
 import { BREVWICK_REACT_VERSION } from './index';
 
-describe('brevwick-react', () => {
+describe('@tatlacas/brevwick-react', () => {
   it('exports a version string that matches package.json', () => {
     expect(BREVWICK_REACT_VERSION).toBe(pkg.version);
   });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,7 +5,7 @@
 declare const __BREVWICK_REACT_VERSION__: string;
 
 /**
- * Semantic version of the installed `brevwick-react` package. Surfaced at
+ * Semantic version of the installed `@tatlacas/brevwick-react` package. Surfaced at
  * runtime so consumers can include it in bug issues or diagnostics.
  */
 export const BREVWICK_REACT_VERSION: string = __BREVWICK_REACT_VERSION__;
@@ -24,4 +24,4 @@ export type {
   FeedbackAttachment,
   FeedbackInput,
   SubmitResult,
-} from 'brevwick-sdk';
+} from '@tatlacas/brevwick-sdk';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -5,7 +5,7 @@ import {
   createBrevwick,
   type Brevwick,
   type BrevwickConfig,
-} from 'brevwick-sdk';
+} from '@tatlacas/brevwick-sdk';
 import { BrevwickContext, type BrevwickContextValue } from './context';
 
 /**

--- a/packages/react/src/use-feedback.ts
+++ b/packages/react/src/use-feedback.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import type { FeedbackInput, SubmitResult } from 'brevwick-sdk';
+import type { FeedbackInput, SubmitResult } from '@tatlacas/brevwick-sdk';
 import { useBrevwickInternal } from './context';
 
 /**

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   // it — we rely on @radix-ui's tree-shakable exports for dead-code removal.
   treeshake: false,
   splitting: false,
-  external: ['react', 'react-dom', 'brevwick-sdk'],
+  external: ['react', 'react-dom', '@tatlacas/brevwick-sdk'],
   target: 'es2020',
   define: {
     __BREVWICK_REACT_VERSION__: JSON.stringify(pkg.version),

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,16 +1,16 @@
-# brevwick-sdk
+# @tatlacas/brevwick-sdk
 
-[![npm](https://img.shields.io/npm/v/brevwick-sdk/beta?label=brevwick-sdk%40beta)](https://www.npmjs.com/package/brevwick-sdk)
+[![npm](https://img.shields.io/npm/v/@tatlacas/brevwick-sdk/beta?label=@tatlacas/brevwick-sdk%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 Framework-agnostic core SDK for [Brevwick](https://brevwick.dev). Submit issues from any browser app — screenshot, redact, send. AI-formatted into clean, triage-ready GitHub issues.
 
-For React apps, use [`brevwick-react`](https://www.npmjs.com/package/brevwick-react) (provider, hook, floating-action-button widget). This package is the underlying primitive and ships the entire wire protocol.
+For React apps, use [`@tatlacas/brevwick-react`](https://www.npmjs.com/package/@tatlacas/brevwick-react) (provider, hook, floating-action-button widget). This package is the underlying primitive and ships the entire wire protocol.
 
 ## Install
 
 ```bash
-npm install brevwick-sdk@beta
+npm install @tatlacas/brevwick-sdk@beta
 ```
 
 Or with pnpm / yarn / bun — same name. Pre-1.0 releases track the `beta` dist-tag.
@@ -18,7 +18,7 @@ Or with pnpm / yarn / bun — same name. Pre-1.0 releases track the `beta` dist-
 ## Quick start
 
 ```ts
-import { createBrevwick } from 'brevwick-sdk';
+import { createBrevwick } from '@tatlacas/brevwick-sdk';
 
 const bw = createBrevwick({
   projectKey: 'pk_live_...',
@@ -170,7 +170,7 @@ const blob = await bw.captureScreenshot({
 A tree-shakable top-level `captureScreenshot` is also exported for standalone use (no Brevwick instance required). It's dynamically imported on first call so `modern-screenshot` stays out of your initial bundle:
 
 ```ts
-import { captureScreenshot } from 'brevwick-sdk';
+import { captureScreenshot } from '@tatlacas/brevwick-sdk';
 const blob = await captureScreenshot({ quality: 0.9 });
 ```
 
@@ -226,7 +226,7 @@ import type {
   SubmitError,
   SubmitErrorCode,
   SubmitResult,
-} from 'brevwick-sdk';
+} from '@tatlacas/brevwick-sdk';
 ```
 
 ## Browser support
@@ -236,7 +236,7 @@ ES2020 targets — modern evergreen browsers (Chrome/Edge 90+, Firefox 90+, Safa
 ## Links
 
 - **Docs / dashboard:** [brevwick.dev](https://brevwick.dev)
-- **React bindings:** [`brevwick-react`](https://www.npmjs.com/package/brevwick-react)
+- **React bindings:** [`@tatlacas/brevwick-react`](https://www.npmjs.com/package/@tatlacas/brevwick-react)
 - **Source:** [github.com/tatlacas-com/brevwick-sdk-js](https://github.com/tatlacas-com/brevwick-sdk-js)
 - **Issues:** [github.com/tatlacas-com/brevwick-sdk-js/issues](https://github.com/tatlacas-com/brevwick-sdk-js/issues)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "brevwick-sdk",
+  "name": "@tatlacas/brevwick-sdk",
   "version": "1.0.0-beta.2",
   "description": "Brevwick core SDK — submit issues from any browser app. AI-formatted into clean GitHub-ready issues.",
   "license": "MIT",

--- a/packages/sdk/src/__tests__/chunk-split.test.ts
+++ b/packages/sdk/src/__tests__/chunk-split.test.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 /**
- * Chunk-split guard: after `pnpm --filter brevwick-sdk build`, the base chunk
+ * Chunk-split guard: after `pnpm --filter @tatlacas/brevwick-sdk build`, the base chunk
  * must not reference `modern-screenshot` — that dependency is loaded only
  * from a dynamically-imported sibling chunk. Both ESM and CJS outputs are
  * asserted so the invariant holds regardless of how consumers load the SDK.

--- a/packages/sdk/src/__tests__/integration/setup.ts
+++ b/packages/sdk/src/__tests__/integration/setup.ts
@@ -11,7 +11,7 @@
  *
  * The React package ships a near-twin of this file at
  * `packages/react/src/__tests__/integration/setup.ts`. The two are
- * intentionally not collapsed into a `brevwick-sdk/testing/msw` subpath
+ * intentionally not collapsed into a `@tatlacas/brevwick-sdk/testing/msw` subpath
  * export — see that file's header for the structural reason (React
  * variant adds a config handler the SDK suite has no use for).
  */

--- a/packages/sdk/src/testing.ts
+++ b/packages/sdk/src/testing.ts
@@ -1,5 +1,5 @@
 /**
- * Test-only entry point for `brevwick-sdk`.
+ * Test-only entry point for `@tatlacas/brevwick-sdk`.
  *
  * Exports mutators that rebind the internal registry backing
  * {@link createBrevwick}. Kept in its own entry so these helpers never ship

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,10 +62,10 @@ importers:
 
   examples/next:
     dependencies:
-      brevwick-react:
+      '@tatlacas/brevwick-react':
         specifier: workspace:*
         version: link:../../packages/react
-      brevwick-sdk:
+      '@tatlacas/brevwick-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
       next:
@@ -93,7 +93,7 @@ importers:
 
   examples/vanilla:
     dependencies:
-      brevwick-sdk:
+      '@tatlacas/brevwick-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
     devDependencies:
@@ -110,6 +110,9 @@ importers:
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
+      '@tatlacas/brevwick-sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -122,9 +125,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      brevwick-sdk:
-        specifier: workspace:*
-        version: link:../sdk
       react:
         specifier: ^19.2.4
         version: 19.2.5


### PR DESCRIPTION
## Summary

Rename the two published packages from unscoped to org-scoped so they're genuinely owned by the `@tatlacas` org on npm:

- `brevwick-sdk` → `@tatlacas/brevwick-sdk`
- `brevwick-react` → `@tatlacas/brevwick-react`

**Why:** npm doesn't have first-class org ownership for unscoped package names — an unscoped package is always owned by individual user accounts. `npm owner add @tatlacas <pkg>` fails with 404 (npm resolves org names as users). Scoping is the only way for the packages to be **owned by** the org as a first-class entity on npm.

Nothing is publicly published yet (the prior name is reserved to `tathove` personally from a local publish/unpublish cycle), so this is a pure rename with no migration pain for external consumers.

## What changed

- `packages/{sdk,react}/package.json`: `name` + workspace dep entries
- `packages/react/src/**`: `from 'brevwick-sdk'` → `'@tatlacas/brevwick-sdk'`
- `packages/react/tsup.config.ts`: `external` entry
- `examples/{next,vanilla}`: deps in `package.json` + imports in source/HTML
- `.github/workflows/{ci,sdk-e2e-live}.yml`: `pnpm --filter` targets
- `.changeset/{config.json,pre.json}` + all pending `.changeset/*.md` frontmatter
- `.size-limit.js` entry labels (file paths unchanged)
- READMEs, CONTRIBUTING.md, CLAUDE.md, `.claude/agents/*`, `.github/prompts/*`

## What's preserved

Wire-level identifiers stay as `brevwick-sdk` so server-side filters keep matching:

- `sdk.name: 'brevwick-sdk'` field in every ingest payload (`packages/sdk/src/submit.ts:508`)
- `X-Brevwick-SDK` request header value (`SDK_USER_AGENT` in `sdk-version.ts`)
- `x-brevwick-sdk` lower-case header key in the network ring + its assertions
- Both `composed-payload.json` test fixtures

Other intentional holdouts:

- `packages/{sdk,react}/CHANGELOG.md` — historical entries reflect the names in effect at publish time
- `BREVWICK_STYLE_ID = 'brevwick-react-styles'` — DOM id, not a package identifier

## Post-merge / publish steps

1. Verify the `NPM_TOKEN` secret is a token under your personal account (`tathove`) with **Granular Access Token → Organization `@tatlacas` → read-write + bypass 2FA**. If it's still the older token, regenerate with the org scope.
2. Add a real changeset for whatever feature work is queued behind this rename, or merge the Version Packages PR that changesets/action will open after this lands.
3. On first publish, the packages appear under `@tatlacas` on npmjs.com.

## Test plan

- [x] `pnpm format:check` green
- [x] `pnpm lint` green
- [x] `pnpm type-check` green
- [x] `pnpm test:cover` — 103 tests pass (2 skipped as before), coverage unchanged
- [x] `pnpm build` green for sdk, react, vanilla, next
- [x] `pnpm size` — core eager 1.6 kB, React bundle 9.1 kB, on-widget-open 10.9 kB, all under budget
- [ ] CI green on the PR (`check`, `size-check`, `verify-signatures`, changeset-check)
- [ ] After merge: release workflow publishes `@tatlacas/brevwick-sdk` and `@tatlacas/brevwick-react` successfully