### PR TITLE
fix(react): redesign AI toggle as sliding switch

### DIFF
--- a/.changeset/ai-toggle-switch-redesign.md
+++ b/.changeset/ai-toggle-switch-redesign.md
@@ -1,0 +1,26 @@
+---
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
+---
+
+fix(react): AI toggle now reads as a switch, aligns with send button
+
+- The composer AI toggle used to be a pill that only changed background
+  colour between on/off, so the off state looked _disabled_ rather than
+  _unchecked_. Redesigned as a track-and-thumb switch: thumb slides
+  left↔right, track fills with `--brw-accent` when on, reduced-motion
+  skips the transition.
+- The "AI" label now sits **outside** the button so the track itself is
+  the unambiguous toggle affordance. The label recolours from
+  `--brw-fg-muted` to `--brw-fg` via `:has(.brw-aitoggle--on)` to
+  reinforce the state.
+- New `.brw-aitoggle-wrap` is 34px tall to match `.brw-send-btn`, so the
+  switch centre and the send-button centre share a baseline under the
+  composer shell's `align-items: flex-end`.
+
+Semantic contract is unchanged — `role="switch"`, `aria-checked`,
+`aria-label="Format with AI"`, Space-to-toggle, and the
+`.brw-aitoggle--on` class all stay put.
+
+The `@tatlacas/brevwick-sdk` patch bump is a no-op to keep the two
+packages in lockstep per the repo's pre-1.0 versioning policy.

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -1011,12 +1011,15 @@ interface AIToggleProps {
 }
 
 /**
- * Inline pill/switch surfaced in the composer footer when the project allows
- * submitters to opt in/out of AI formatting per issue. role="switch" +
- * aria-checked is the narrow semantic the WCAG a11y matrix wants; Space
- * toggles when focused (default browser behaviour on role="button" is Enter
- * and Space, but Space carries fewer collisions with the composer's
- * Enter-to-send shortcut).
+ * Track-and-thumb switch surfaced in the composer footer when the project
+ * allows submitters to opt in/out of AI formatting per issue. The "AI" text
+ * sits outside the button so the switch itself is an unambiguous iOS-style
+ * track — visually obvious that it toggles, not a pressed-button state.
+ *
+ * role="switch" + aria-checked is the narrow semantic the WCAG a11y matrix
+ * wants. Space toggles when focused (default browser behaviour on
+ * role="button" is Enter and Space, but Space carries fewer collisions with
+ * the composer's Enter-to-send shortcut).
  */
 function AIToggle({ on, disabled, onChange }: AIToggleProps): ReactElement {
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>): void => {
@@ -1026,19 +1029,23 @@ function AIToggle({ on, disabled, onChange }: AIToggleProps): ReactElement {
     }
   };
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={on}
-      aria-label="Format with AI"
-      className={`brw-aitoggle${on ? ' brw-aitoggle--on' : ''}`}
-      disabled={disabled}
-      onClick={() => onChange(!on)}
-      onKeyDown={handleKeyDown}
-    >
-      <span className="brw-aitoggle-dot" aria-hidden="true" />
-      <span>AI</span>
-    </button>
+    <span className="brw-aitoggle-wrap">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label="Format with AI"
+        className={`brw-aitoggle${on ? ' brw-aitoggle--on' : ''}`}
+        disabled={disabled}
+        onClick={() => onChange(!on)}
+        onKeyDown={handleKeyDown}
+      >
+        <span className="brw-aitoggle-thumb" aria-hidden="true" />
+      </button>
+      <span className="brw-aitoggle-text" aria-hidden="true">
+        AI
+      </span>
+    </span>
   );
 }
 

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -410,42 +410,63 @@ export const BREVWICK_CSS = `
   cursor: pointer;
   flex-shrink: 0;
 }
-.brw-aitoggle {
+/* Wrap matches .brw-send-btn height (34px) so the switch centre and the
+   send-button centre land on the same baseline under the shell's
+   align-items: flex-end. */
+.brw-aitoggle-wrap {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 26px;
-  padding: 0 10px 0 8px;
+  height: 34px;
+  padding: 0 4px;
+}
+.brw-aitoggle-text {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  line-height: 1;
+  user-select: none;
+  transition: color 120ms ease-out;
+}
+.brw-aitoggle-wrap:has(.brw-aitoggle--on) .brw-aitoggle-text {
+  color: var(--brw-fg, var(--brw-fg-base));
+}
+.brw-aitoggle {
+  position: relative;
+  flex-shrink: 0;
+  width: 30px;
+  height: 18px;
+  padding: 0;
   border-radius: 999px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-chip-bg, var(--brw-chip-bg-base));
-  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
-  font: inherit;
-  font-size: 12px;
-  font-weight: 500;
   cursor: pointer;
-  transition: background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+  transition: background-color 120ms ease-out, border-color 120ms ease-out;
 }
-.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 1px; }
+.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 2px; }
 .brw-aitoggle:disabled { opacity: 0.5; cursor: not-allowed; }
-.brw-aitoggle-dot {
-  width: 10px;
-  height: 10px;
+.brw-aitoggle-thumb {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
   background: var(--brw-fg-muted, var(--brw-fg-muted-base));
-  transition: background-color 120ms ease-out;
+  transform: translateY(-50%);
+  transition: left 140ms ease-out, background-color 120ms ease-out;
 }
 .brw-aitoggle--on {
   background: var(--brw-accent, var(--brw-accent-base));
-  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
-.brw-aitoggle--on .brw-aitoggle-dot {
+.brw-aitoggle--on .brw-aitoggle-thumb {
+  left: calc(100% - 14px);
   background: var(--brw-accent-fg, var(--brw-accent-fg-base));
 }
 @media (prefers-reduced-motion: reduce) {
-  .brw-aitoggle, .brw-aitoggle-dot { transition: none; }
+  .brw-aitoggle, .brw-aitoggle-thumb, .brw-aitoggle-text { transition: none; }
 }
 .brw-send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .brw-send-btn svg { width: 16px; height: 16px; }


### PR DESCRIPTION
## Summary

The composer's AI toggle was a coloured pill whose on/off difference was just a background-colour flip. From the user's eye the off state read as *disabled*, not *unchecked* — they literally asked \"is it a switch or radio button?\" while looking at the on state.

- Swap the pill for a track-and-thumb switch. Thumb slides left↔right with a 140ms transition; track fills with \`--brw-accent\` when on. Reduced-motion media query skips the transitions.
- Move the \"AI\" text *outside* the button so the track itself is the unambiguous toggle affordance. The label recolours from \`--brw-fg-muted\` to \`--brw-fg\` via \`:has(.brw-aitoggle--on)\` to reinforce the state.
- Wrap the switch in a 34px-tall container matching \`.brw-send-btn\`, so the switch centre and the send-button centre share a baseline under the composer shell's \`align-items: flex-end\`.

The semantic contract is unchanged — \`role=\"switch\"\`, \`aria-checked\`, \`aria-label=\"Format with AI\"\`, Space-to-toggle, and the \`.brw-aitoggle--on\` class the tests pin all stay put. All 103 react tests + 204 sdk tests still pass.

## Test plan

- [x] \`pnpm test\` — 307/307 pass
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @tatlacas/brevwick-react build\` — clean; bundle-budget test in \`chunk-split.test.ts\` stays green
- [ ] Manual: open widget, confirm thumb slides between off/on, switch vertically centres with the send button in both light and dark themes, off state no longer reads as disabled.