### PR TITLE
fix(react): hide feedback panel while region-capture overlay is up

### DIFF
--- a/.changeset/hide-panel-during-region-overlay.md
+++ b/.changeset/hide-panel-during-region-overlay.md
@@ -1,0 +1,22 @@
+---
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
+---
+
+fix(react): hide feedback panel while region-capture overlay is up
+
+Clicking the screenshot button opens a drag-to-select overlay over the
+page, but the feedback panel itself stayed painted at its anchor corner
+the whole time — covering page content the user was specifically trying
+to screenshot. Toggle a new `brw-panel-hidden` class
+(`visibility: hidden; pointer-events: none`) on the panel for the
+lifetime of the overlay so the page underneath is fully visible during
+selection. The panel stays mounted, so the composer draft, attachments,
+and Radix focus management survive an open / cancel round-trip; only
+painting and hit-testing are suppressed. The existing
+`data-brevwick-skip` on the panel is unchanged — it still scrubs the
+panel from the rasterised image during the actual capture pass; this
+fix is strictly about pre-capture occlusion.
+
+The `@tatlacas/brevwick-sdk` patch bump is a no-op to keep the two
+packages in lockstep per the repo's pre-1.0 versioning policy.

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1453,6 +1453,83 @@ describe('<FeedbackButton> — region capture overlay', () => {
     ).toBeInTheDocument();
   });
 
+  // Issue #49: with the overlay up, the panel was still painted at its
+  // anchor corner and obscured page content the user was trying to
+  // screenshot. The fix toggles `brw-panel-hidden` (visibility:hidden +
+  // pointer-events:none) on the panel for the lifetime of the overlay.
+  it('hides the feedback panel while the region overlay is open and restores it on cancel', () => {
+    mount();
+    openPanel();
+    const panel = screen
+      .getByText(/send feedback/i)
+      .closest('.brw-panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+    expect(panel.className).not.toMatch(/brw-panel-hidden/);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /capture screenshot of this page/i,
+      }),
+    );
+    expect(panel.className).toMatch(/brw-panel-hidden/);
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(queryOverlay()).toBeNull();
+    expect(panel.className).not.toMatch(/brw-panel-hidden/);
+  });
+
+  it('preserves the composer draft across an open/cancel of the region overlay', () => {
+    mount();
+    openPanel();
+    typeDraft('regression repro for issue 49');
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /capture screenshot of this page/i,
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(getComposer().value).toBe('regression repro for issue 49');
+  });
+
+  it('keeps the panel hidden through a "Capture full page" round-trip', async () => {
+    captureScreenshot.mockResolvedValueOnce(
+      new Blob(['full'], { type: 'image/webp' }),
+    );
+    mount();
+    openPanel();
+    const panel = screen
+      .getByText(/send feedback/i)
+      .closest('.brw-panel') as HTMLElement;
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /capture screenshot of this page/i,
+      }),
+    );
+    expect(panel.className).toMatch(/brw-panel-hidden/);
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /capture full page/i }),
+      );
+    });
+    // Overlay closes, panel is visible again, screenshot landed in composer.
+    expect(queryOverlay()).toBeNull();
+    expect(panel.className).not.toMatch(/brw-panel-hidden/);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /remove screenshot/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('declares brw-panel-hidden as visibility:hidden in the stylesheet', () => {
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-panel-hidden\s*\{[^}]*visibility:\s*hidden/,
+    );
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-panel-hidden\s*\{[^}]*pointer-events:\s*none/,
+    );
+  });
+
   it('pointer drag produces a visible selection rectangle sized to the drag', () => {
     mount();
     openOverlay();

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -544,7 +544,13 @@ export function FeedbackButton({
         <Dialog.Content
           data-brevwick-skip=""
           data-brw-theme={theme}
-          className={`${rootClassName} brw-panel ${panelPosClass}`}
+          // Hide the panel while the region overlay is up so the user can see
+          // (and select a region over) page content the panel would otherwise
+          // cover. The panel stays mounted — visibility:hidden preserves
+          // composer state, focus is owned by the overlay's nested Dialog,
+          // and the existing `data-brevwick-skip` keeps it out of the
+          // captured image.
+          className={`${rootClassName} brw-panel ${panelPosClass}${regionOpen ? ' brw-panel-hidden' : ''}`}
           aria-describedby={undefined}
         >
           <PanelHeader

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -177,6 +177,11 @@ export const BREVWICK_CSS = `
 }
 .brw-panel-br { right: 24px; }
 .brw-panel-bl { left: 24px; }
+/* Toggled while the region-capture overlay is up (issue #49) so the panel
+   stops occluding page content the user is trying to screenshot. The panel
+   stays in the layout to preserve composer state, focus, and React tree;
+   only painting and hit-testing are suppressed. */
+.brw-panel-hidden { visibility: hidden; pointer-events: none; }
 @keyframes brw-slide-up {
   from { transform: translateY(16px); opacity: 0; }
   to { transform: none; opacity: 1; }


### PR DESCRIPTION
## Summary

Closes #49.

When the user clicks the screenshot button in the composer, the region-capture overlay opens so they can drag-select a region (or hit "Capture full page"). Previously the **feedback panel itself stayed painted** at its anchor corner the whole time — covering page content underneath, including content the user was specifically trying to screenshot.

This change toggles a new `brw-panel-hidden` class (`visibility: hidden; pointer-events: none`) on the panel for the lifetime of the overlay. The panel stays mounted, so composer draft, attachments, and focus management are preserved across an open / cancel round-trip. The existing `data-brevwick-skip` on the panel is unchanged — it still removes the panel from the rasterised image during the actual capture pass; this fix is strictly about pre-capture occlusion.

## Why visibility, not unmount

- `display: none` would unmount Radix's focus trap mid-flight and lose composer state.
- The overlay's nested `Dialog.Root` already owns focus while it's open, so `visibility: hidden` doesn't strand a focused element.
- It also keeps the existing capture-time invariant intact: the panel is still in the tree with `data-brevwick-skip`, so any rogue capture that fires while the overlay is up still excludes the panel chrome.

## Test plan

- [x] `pnpm format:check`, `pnpm lint`, `pnpm type-check` clean
- [x] `pnpm test:cover` — all packages pass (107 React tests, full SDK suite)
- [x] `pnpm build` clean across packages and examples
- [x] `pnpm size` — no budget regressions (`@tatlacas/brevwick-react` ESM 9.44 kB, on-widget-open 10.91 kB, both well under their 25 kB ceilings)
- [x] New tests cover: panel gains `brw-panel-hidden` when overlay opens; loses it on Cancel; composer draft survives open/cancel; class persists through "Capture full page"; stylesheet declares `visibility:hidden` + `pointer-events:none`.