### PR TITLE
feat(react): redesign feedback panel as continuous chat thread

### DIFF
--- a/.changeset/feedback-thread-continuation.md
+++ b/.changeset/feedback-thread-continuation.md
@@ -1,0 +1,39 @@
+---
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+---
+
+feat(react): redesign feedback panel as continuous chat thread
+
+Refactors `<FeedbackButton>` from a "thread + post-submit takeover" UI
+into a continuous chat thread, closing #52.
+
+- Introduces a module-scope `Message` type and a `messages` state array;
+  `Thread` renders from history (`messages.map(...)`) instead of a
+  hardcoded layout.
+- Drops the live-mirror `<UserBubble>{draft}</UserBubble>` — typing into
+  the composer no longer paints a bubble above it.
+- Removes `SuccessState`, `handleSendAnother`, the `succeeded` flag,
+  and the `focusComposerPending` layout-effect dance. The composer is
+  always mounted; submit success appends a user bubble + an assistant
+  "Thanks — your issue is on its way." bubble, then clears the composer
+  in place. Focus stays put.
+- The assistant receipt bubble carries an "Issue sent · timestamp"
+  footer (`brw-bubble--receipt`) with an inline 16x16 SVG check icon. A
+  tiny in-file `formatRelativeTime` helper avoids pulling in
+  `Intl.RelativeTimeFormat` or `date-fns` so the bundle stays inside
+  the §12 25 kB initial-gzip budget.
+- Closing the panel via `×` (or via "Discard" in the dirty-confirm)
+  resets the thread to just the greeting on next open. Minimize
+  semantics are unchanged — that path skips `resetAll()` so the
+  existing "minimize preserves draft + attachments" contract still
+  holds.
+- Removes the now-unused `.brw-bubble--success` and `.brw-success-wrap`
+  CSS rules; adds `.brw-bubble--receipt` (small inline-flex footer
+  reusing `--brw-fg-muted`, no new tokens).
+- Each new submission still fires its own POST and creates its own
+  ticket; UI continuity ≠ thread continuity, and the receipt marker
+  between bubbles makes that legible.
+
+The `@tatlacas/brevwick-sdk` bump is the lockstep pre-1.0 version (no
+code changes in the SDK for this PR).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           files: packages/sdk/coverage/lcov.info,packages/react/coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
       # Hand the built artefacts to the size-check job so it doesn't have to
       # re-run install + build from scratch.
       - name: Upload package dist artefacts

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -939,6 +939,53 @@ describe('<FeedbackButton>', () => {
     // Title still derived from the first non-empty line so it remains useful.
     expect(input.title).toBe('hello world');
   });
+
+  it('issue-sent receipt timestamp formats minutes, hours, and days', async () => {
+    // Pin Date.now() so we can advance the wall clock without firing
+    // real timers (which would interfere with the submit pipeline).
+    const SENT_AT = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(SENT_AT);
+    try {
+      submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_clock' });
+      mount();
+      openPanel();
+      typeDraft('clock test');
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+      });
+
+      const findReceiptBubble = (): HTMLElement => {
+        const text = screen.getByText(/thanks — your issue is on its way/i);
+        return text.closest('.brw-bubble') as HTMLElement;
+      };
+
+      // Submit-time render: diff < 60s → "just now".
+      expect(within(findReceiptBubble()).getByText(/just now/i))
+        .toBeInTheDocument();
+
+      // 5 minutes later — typing into the composer triggers a re-render
+      // of the AssistantBubble (its sentAt is unchanged but Date.now()
+      // has moved on).
+      nowSpy.mockReturnValue(SENT_AT + 5 * 60_000);
+      typeDraft('a');
+      expect(within(findReceiptBubble()).getByText(/5 min ago/i))
+        .toBeInTheDocument();
+
+      // 2 hours later → "2 hr ago".
+      nowSpy.mockReturnValue(SENT_AT + 2 * 60 * 60_000);
+      typeDraft('b');
+      expect(within(findReceiptBubble()).getByText(/2 hr ago/i))
+        .toBeInTheDocument();
+
+      // 3 days later → "3 d ago".
+      nowSpy.mockReturnValue(SENT_AT + 3 * 24 * 60 * 60_000);
+      typeDraft('c');
+      expect(within(findReceiptBubble()).getByText(/3 d ago/i))
+        .toBeInTheDocument();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });
 
 describe('<FeedbackButton> — Use AI toggle', () => {

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -152,7 +152,7 @@ describe('<FeedbackButton>', () => {
     expect(link).toHaveTextContent(`Brevwick v${pkg.version}`);
   });
 
-  it('keeps the credit footer visible in the success state', async () => {
+  it('keeps the credit footer visible after a successful submit', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_footer' });
     mount();
     openPanel();
@@ -205,7 +205,7 @@ describe('<FeedbackButton>', () => {
     expect(input.title).toBe('line one');
   });
 
-  it('submits via the Send button and shows success + Send another', async () => {
+  it('submit appends user + assistant bubbles and keeps the composer active', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_ok' });
     mount();
     openPanel();
@@ -219,19 +219,71 @@ describe('<FeedbackButton>', () => {
       ok: true,
       issue_id: 'rep_ok',
     });
-    // Panel stays open, thread replaced with success state.
+    // Panel stays open, thread now contains the submitted user message
+    // and the assistant 'thank you' bubble carrying a receipt marker.
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent(/on its way/i);
-    // Composer is gone in the success state.
-    expect(
-      screen.queryByRole('textbox', { name: /feedback message/i }),
-    ).toBeNull();
+    expect(screen.getByText('Broken flow')).toBeInTheDocument();
+    const receiptText = screen.getByText(
+      /thanks — your issue is on its way/i,
+    );
+    const receiptBubble = receiptText.closest('.brw-bubble') as HTMLElement;
+    expect(receiptBubble).not.toBeNull();
+    expect(within(receiptBubble).getByText(/issue sent/i)).toBeInTheDocument();
+    // Composer survives the submit, draft cleared but textarea active.
+    const composer = getComposer();
+    expect(composer).not.toBeDisabled();
+    expect(composer.value).toBe('');
+    // No "Send another" CTA — the composer itself is the next-message
+    // affordance now.
+    expect(screen.queryByRole('button', { name: /send another/i })).toBeNull();
+  });
 
-    // "Send another" resets to an empty thread.
-    fireEvent.click(screen.getByRole('button', { name: /send another/i }));
-    const fresh = getComposer();
-    expect(fresh.value).toBe('');
-    expect(screen.queryByRole('status')).toBeNull();
+  it('typing into the composer does not append a bubble to the thread', () => {
+    mount();
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    // Greeting bubble is the only thing in the thread on open.
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+
+    typeDraft('still drafting…');
+
+    // The draft only lives in the composer; the thread is unchanged
+    // until the user clicks send.
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+    expect(within(log).queryByText(/still drafting/i)).toBeNull();
+    // The bubble that IS rendered is still the greeting.
+    expect(
+      within(log).getByText(/Hi! Tell us what's happening/i),
+    ).toBeInTheDocument();
+  });
+
+  it('closing and reopening the panel resets the thread to just the greeting', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_reset' });
+    mount();
+    openPanel();
+    typeDraft('first message');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    // Submit lands → thread now has greeting + user + assistant bubbles.
+    expect(
+      screen.getByText(/thanks — your issue is on its way/i),
+    ).toBeInTheDocument();
+
+    // Composer is empty after submit, so × closes immediately (no
+    // discard confirm) and routes through the resetAll path.
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    // Only the greeting remains in the thread.
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+    expect(
+      within(log).getByText(/Hi! Tell us what's happening/i),
+    ).toBeInTheDocument();
+    // Composer is empty as well.
+    expect(getComposer().value).toBe('');
   });
 
   it('does not submit when the composer is empty (send button disabled)', () => {
@@ -484,7 +536,7 @@ describe('<FeedbackButton>', () => {
     expect(log).toHaveAttribute('aria-live', 'polite');
   });
 
-  it('thread log switches to confirmation after success for assistive tech', async () => {
+  it('thread log keeps a polite aria-live region after success for assistive tech', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_live' });
     mount();
     openPanel();
@@ -492,8 +544,14 @@ describe('<FeedbackButton>', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    const log = screen.getByRole('log', { name: /confirmation/i });
+    // Thread is the same `role="log"` region — the new assistant bubble
+    // is announced via the polite live region instead of a separate
+    // confirmation slot.
+    const log = screen.getByRole('log', { name: /conversation/i });
     expect(log).toHaveAttribute('aria-live', 'polite');
+    expect(
+      within(log).getByText(/thanks — your issue is on its way/i),
+    ).toBeInTheDocument();
   });
 
   it('disables composer send + icons while submitting (guards double-send)', async () => {
@@ -522,7 +580,11 @@ describe('<FeedbackButton>', () => {
       release({ ok: true, issue_id: 'rep_done' });
       await Promise.resolve();
     });
-    await waitFor(() => expect(screen.getByRole('status')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText(/thanks — your issue is on its way/i),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('bundles a slide-up animation with a prefers-reduced-motion override', () => {
@@ -587,7 +649,9 @@ describe('<FeedbackButton>', () => {
       await Promise.resolve();
     });
     await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent(/on its way/i),
+      expect(
+        screen.getByText(/thanks — your issue is on its way/i),
+      ).toBeInTheDocument(),
     );
   });
 
@@ -623,24 +687,45 @@ describe('<FeedbackButton>', () => {
     );
   });
 
-  it('"Send another" returns focus to the composer textarea', async () => {
-    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_focus' });
+  it('chained submissions append additional bubbles without remounting the composer', async () => {
     mount();
     openPanel();
-    typeDraft('will send');
+    const composerBefore = getComposer();
+
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_chain_1' });
+    typeDraft('first issue');
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    expect(screen.getByRole('status')).toBeInTheDocument();
 
+    // Same textarea node, draft cleared.
+    const composerAfter1 = getComposer();
+    expect(composerAfter1).toBe(composerBefore);
+    expect(composerAfter1.value).toBe('');
+
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_chain_2' });
+    typeDraft('second issue');
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /send another/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    const textarea = getComposer();
-    expect(document.activeElement).toBe(textarea);
+
+    // Two separate POSTs fired with each draft.
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect((submit.mock.calls[0]![0] as { description: string }).description)
+      .toBe('first issue');
+    expect((submit.mock.calls[1]![0] as { description: string }).description)
+      .toBe('second issue');
+
+    // Thread now contains greeting + (user1, assistant1) + (user2, assistant2).
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(5);
+    expect(within(log).getByText('first issue')).toBeInTheDocument();
+    expect(within(log).getByText('second issue')).toBeInTheDocument();
+    expect(within(log).getAllByText(/thanks — your issue is on its way/i))
+      .toHaveLength(2);
   });
 
-  it('close on a success-state panel dismisses without a confirm', async () => {
+  it('close after a successful submit dismisses without a discard confirm', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_succ_close' });
     mount();
     openPanel();
@@ -648,17 +733,21 @@ describe('<FeedbackButton>', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(
+      screen.getByText(/thanks — your issue is on its way/i),
+    ).toBeInTheDocument();
 
-    // × on the success-state panel: no confirm dialog, panel closes,
-    // next open is empty.
+    // × after a clean submit: composer is empty so no discard confirm
+    // appears, the panel closes, and reopening starts a fresh thread.
     fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
     expect(screen.queryByRole('alert', { name: /discard draft/i })).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
 
     openPanel();
     expect(getComposer().value).toBe('');
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(
+      screen.queryByText(/thanks — your issue is on its way/i),
+    ).toBeNull();
   });
 
   it('close button is disabled while a submit is in flight', async () => {

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -940,6 +940,36 @@ describe('<FeedbackButton>', () => {
     expect(input.title).toBe('hello world');
   });
 
+  it('submits with a file attachment so the doSubmit + snapshot file paths run', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_files' });
+    mount();
+    openPanel();
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['payload'], 'log.txt', { type: 'text/plain' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    fireEvent.change(fileInput, { target: { files: dt.files } });
+
+    typeDraft('with file');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+
+    // Submit payload carries the attached file.
+    const payload = submit.mock.calls[0]![0] as {
+      attachments: Array<{ blob: Blob; filename: string }>;
+    };
+    expect(payload.attachments).toHaveLength(1);
+    expect(payload.attachments[0]!.filename).toBe('log.txt');
+
+    // User bubble persists post-submit, composer is back to empty.
+    expect(screen.getByText('with file')).toBeInTheDocument();
+    expect(getComposer().value).toBe('');
+  });
+
   it('issue-sent receipt timestamp formats minutes, hours, and days', async () => {
     // Pin Date.now() so we can advance the wall clock without firing
     // real timers (which would interfere with the submit pipeline).

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -223,9 +223,7 @@ describe('<FeedbackButton>', () => {
     // and the assistant 'thank you' bubble carrying a receipt marker.
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Broken flow')).toBeInTheDocument();
-    const receiptText = screen.getByText(
-      /thanks — your issue is on its way/i,
-    );
+    const receiptText = screen.getByText(/thanks — your issue is on its way/i);
     const receiptBubble = receiptText.closest('.brw-bubble') as HTMLElement;
     expect(receiptBubble).not.toBeNull();
     expect(within(receiptBubble).getByText(/issue sent/i)).toBeInTheDocument();
@@ -711,18 +709,21 @@ describe('<FeedbackButton>', () => {
 
     // Two separate POSTs fired with each draft.
     expect(submit).toHaveBeenCalledTimes(2);
-    expect((submit.mock.calls[0]![0] as { description: string }).description)
-      .toBe('first issue');
-    expect((submit.mock.calls[1]![0] as { description: string }).description)
-      .toBe('second issue');
+    expect(
+      (submit.mock.calls[0]![0] as { description: string }).description,
+    ).toBe('first issue');
+    expect(
+      (submit.mock.calls[1]![0] as { description: string }).description,
+    ).toBe('second issue');
 
     // Thread now contains greeting + (user1, assistant1) + (user2, assistant2).
     const log = screen.getByRole('log', { name: /conversation/i });
     expect(log.querySelectorAll('.brw-bubble')).toHaveLength(5);
     expect(within(log).getByText('first issue')).toBeInTheDocument();
     expect(within(log).getByText('second issue')).toBeInTheDocument();
-    expect(within(log).getAllByText(/thanks — your issue is on its way/i))
-      .toHaveLength(2);
+    expect(
+      within(log).getAllByText(/thanks — your issue is on its way/i),
+    ).toHaveLength(2);
   });
 
   it('close after a successful submit dismisses without a discard confirm', async () => {
@@ -745,9 +746,7 @@ describe('<FeedbackButton>', () => {
 
     openPanel();
     expect(getComposer().value).toBe('');
-    expect(
-      screen.queryByText(/thanks — your issue is on its way/i),
-    ).toBeNull();
+    expect(screen.queryByText(/thanks — your issue is on its way/i)).toBeNull();
   });
 
   it('close button is disabled while a submit is in flight', async () => {

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -960,28 +960,32 @@ describe('<FeedbackButton>', () => {
       };
 
       // Submit-time render: diff < 60s → "just now".
-      expect(within(findReceiptBubble()).getByText(/just now/i))
-        .toBeInTheDocument();
+      expect(
+        within(findReceiptBubble()).getByText(/just now/i),
+      ).toBeInTheDocument();
 
       // 5 minutes later — typing into the composer triggers a re-render
       // of the AssistantBubble (its sentAt is unchanged but Date.now()
       // has moved on).
       nowSpy.mockReturnValue(SENT_AT + 5 * 60_000);
       typeDraft('a');
-      expect(within(findReceiptBubble()).getByText(/5 min ago/i))
-        .toBeInTheDocument();
+      expect(
+        within(findReceiptBubble()).getByText(/5 min ago/i),
+      ).toBeInTheDocument();
 
       // 2 hours later → "2 hr ago".
       nowSpy.mockReturnValue(SENT_AT + 2 * 60 * 60_000);
       typeDraft('b');
-      expect(within(findReceiptBubble()).getByText(/2 hr ago/i))
-        .toBeInTheDocument();
+      expect(
+        within(findReceiptBubble()).getByText(/2 hr ago/i),
+      ).toBeInTheDocument();
 
       // 3 days later → "3 d ago".
       nowSpy.mockReturnValue(SENT_AT + 3 * 24 * 60 * 60_000);
       typeDraft('c');
-      expect(within(findReceiptBubble()).getByText(/3 d ago/i))
-        .toBeInTheDocument();
+      expect(
+        within(findReceiptBubble()).getByText(/3 d ago/i),
+      ).toBeInTheDocument();
     } finally {
       nowSpy.mockRestore();
     }

--- a/packages/react/src/__tests__/integration/render-submit.test.tsx
+++ b/packages/react/src/__tests__/integration/render-submit.test.tsx
@@ -20,7 +20,13 @@
  * future Provider refactor leaks the React version into the payload
  * without an SDD update.
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { BREVWICK_REACT_VERSION } from '../../index';
 import { BrevwickProvider } from '../../provider';
@@ -96,15 +102,15 @@ function freezeShape(body: Record<string, unknown>): Record<string, unknown> {
 }
 
 describe('integration — Provider + FeedbackButton → MSW ingest', () => {
-  // Single `it` covers both the POST-shape and the success-state-visible
-  // dimensions. Splitting them would force a second open-FAB → type → Send
-  // dance per assertion (each render is ~150 ms with happy-dom + the
-  // BrevwickProvider mount), which would push the React suite past the
-  // < 5 s slice of the 15 s CI budget set in issue #10. Both assertions
-  // are downstream of the same single submit call, so a regression in
-  // either dimension still surfaces with a focused stack — the
-  // captured-body assertion fires before the success-state waitFor.
-  it('click FAB → type → Send produces one POST with the expected shape', async () => {
+  // Single `it` covers the POST-shape, the post-submit thread state, and
+  // the chained-submission flow in one open-FAB → type → Send sequence.
+  // Splitting them would force a second BrevwickProvider mount per
+  // assertion (each render is ~150 ms with happy-dom), which would push
+  // the React suite past the < 5 s slice of the 15 s CI budget set in
+  // issue #10. The chained-submit assertions fan out below the first
+  // submit so a regression in either dimension still surfaces with a
+  // focused stack.
+  it('click FAB → type → Send produces one POST + chained submit appends bubbles without a second open', async () => {
     const captured = installIngestHandlers(server, 'issue_react_itest');
 
     render(
@@ -135,11 +141,8 @@ describe('integration — Provider + FeedbackButton → MSW ingest', () => {
     const textarea = screen.getByRole('textbox', {
       name: /feedback message/i,
     }) as HTMLTextAreaElement;
-    fireEvent.change(textarea, {
-      target: {
-        value: 'broken button on home\nsecond line for the description',
-      },
-    });
+    const firstDraft = 'broken button on home\nsecond line for the description';
+    fireEvent.change(textarea, { target: { value: firstDraft } });
 
     fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
 
@@ -162,9 +165,58 @@ describe('integration — Provider + FeedbackButton → MSW ingest', () => {
     expect(raw).not.toContain('bindings_version');
     expect(raw).not.toContain(`"react_version":"${BREVWICK_REACT_VERSION}"`);
 
-    // Panel flips into the success state when the POST resolves ok.
-    await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent(/on its way/i),
+    // Submitted user message persists as a bubble. Default `getByText`
+    // normalises whitespace so a multiline draft would not match by
+    // string equality — match on the bubble's exact textContent
+    // instead.
+    const log = await waitFor(() =>
+      screen.getByRole('log', { name: /conversation/i }),
     );
+    await waitFor(() => {
+      const userBubble = log.querySelector('.brw-bubble--user');
+      expect(userBubble?.textContent).toBe(firstDraft);
+    });
+
+    // Assistant 'thank you' bubble appears with the receipt marker.
+    const receipt = screen.getByText(/thanks — your issue is on its way/i);
+    expect(receipt).toBeInTheDocument();
+    const receiptBubble = receipt.closest('.brw-bubble') as HTMLElement;
+    expect(receiptBubble).not.toBeNull();
+    expect(within(receiptBubble).getByText(/issue sent/i)).toBeInTheDocument();
+
+    // Composer survives the submit — same textarea node, not disabled,
+    // ready for a chained message. The send button is disabled only
+    // because the composer is now empty.
+    const composerAfterFirst = screen.getByRole('textbox', {
+      name: /feedback message/i,
+    }) as HTMLTextAreaElement;
+    expect(composerAfterFirst).toBe(textarea);
+    expect(composerAfterFirst).not.toBeDisabled();
+    expect(composerAfterFirst.value).toBe('');
+
+    // Chained submission — type a follow-up, click send, expect a
+    // SECOND POST and a second pair of bubbles below the first.
+    const secondDraft = 'follow-up: console error after retry';
+    fireEvent.change(composerAfterFirst, { target: { value: secondDraft } });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(captured.count()).toBe(2));
+    const secondBody = captured.json();
+    expect(secondBody?.description).toBe(secondDraft);
+
+    // Wait for the second pair of bubbles to land in the DOM.
+    await waitFor(() =>
+      expect(screen.getByText(secondDraft)).toBeInTheDocument(),
+    );
+
+    // Thread now contains: greeting + (user1, assistant1) + (user2, assistant2).
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(5);
+
+    // Composer remains empty + active for further submissions.
+    const composerAfterSecond = screen.getByRole('textbox', {
+      name: /feedback message/i,
+    }) as HTMLTextAreaElement;
+    expect(composerAfterSecond.value).toBe('');
+    expect(composerAfterSecond).not.toBeDisabled();
   });
 });

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -32,6 +32,35 @@ import {
 declare const __BREVWICK_REACT_VERSION__: string;
 
 /**
+ * One bubble in the conversation thread. The greeting and submitted-issue
+ * receipt are `assistant` messages; submitted drafts become `user` messages.
+ * `attachments` snapshots the screenshot + files that rode along with the
+ * submit so a follow-up render can show what was sent (currently the bubble
+ * itself just shows text, but the field is there for forward-compat).
+ */
+interface Message {
+  id: string;
+  role: 'assistant' | 'user';
+  text: string;
+  sentAt?: number;
+  issueSent?: boolean;
+  attachments?: {
+    screenshot?: ScreenshotAttachment;
+    files?: readonly FileAttachment[];
+  };
+}
+
+const GREETING_MESSAGE: Message = {
+  id: 'greeting',
+  role: 'assistant',
+  text: "Hi! Tell us what's happening. A screenshot helps if you have one.",
+};
+
+const initialMessages = (): Message[] => [GREETING_MESSAGE];
+
+const ASSISTANT_RECEIPT_TEXT = 'Thanks — your issue is on its way.';
+
+/**
  * Forced-palette choice for {@link FeedbackButton}. `'system'` defers to the
  * OS-level `prefers-color-scheme` media query (the default and pre-existing
  * behaviour); `'light'` / `'dark'` override it regardless of the OS setting.
@@ -67,9 +96,6 @@ export interface FeedbackButtonProps {
   /** Fired with the SDK's `SubmitResult` after every submit (success or failure). */
   onSubmit?: (result: SubmitResult) => void;
 }
-
-const GREETING =
-  "Hi! Tell us what's happening. A screenshot helps if you have one.";
 
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
@@ -248,7 +274,7 @@ export function FeedbackButton({
   const [files, setFiles] = useState<readonly FileAttachment[]>([]);
   const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [succeeded, setSucceeded] = useState(false);
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [regionOpen, setRegionOpen] = useState(false);
   // Submitter's per-issue AI preference. Defaults to true so the toggle
   // renders "on" the first time; only read on submit when the render-policy
@@ -257,7 +283,7 @@ export function FeedbackButton({
   const mountedRef = useRef(true);
   const screenshotUrlRef = useRef<string | null>(null);
   const fileIdRef = useRef(0);
-  const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const messageIdRef = useRef(0);
 
   useBrevwickStyles();
 
@@ -306,7 +332,7 @@ export function FeedbackButton({
     setFiles([]);
     setConfirmClose(false);
     setSubmitError(null);
-    setSucceeded(false);
+    setMessages(initialMessages());
     setUseAi(true);
     reset();
   }, [reset]);
@@ -337,16 +363,12 @@ export function FeedbackButton({
   );
 
   const handleCloseClick = useCallback(() => {
-    if (succeeded) {
-      handleFullClose();
-      return;
-    }
     if (hasContent) {
       setConfirmClose(true);
       return;
     }
     handleFullClose();
-  }, [succeeded, hasContent, handleFullClose]);
+  }, [hasContent, handleFullClose]);
 
   // Split from the historical one-shot capture: the button now only opens
   // the region overlay, and the overlay fans out to either a full-page or
@@ -458,12 +480,56 @@ export function FeedbackButton({
       ...(showAiToggle ? { use_ai: useAi } : {}),
     };
 
+    // Snapshot the current composer state so the success branch can quote
+    // it back into the user bubble even if the user minimized mid-submit
+    // (in which case React's setState below races with whatever they typed
+    // after — the snapshot pins the version of the draft we're submitting).
+    const submittedDraft = draft;
+    const submittedScreenshot = screenshot;
+    const submittedFiles = files;
+
     try {
       const result = await submit(input);
       if (!mountedRef.current) return;
       onSubmit?.(result);
       if (result.ok) {
-        setSucceeded(true);
+        const userMessage: Message = {
+          id: `msg-${++messageIdRef.current}`,
+          role: 'user',
+          text: submittedDraft,
+          attachments:
+            submittedScreenshot || submittedFiles.length > 0
+              ? {
+                  ...(submittedScreenshot
+                    ? { screenshot: submittedScreenshot }
+                    : {}),
+                  ...(submittedFiles.length > 0
+                    ? { files: submittedFiles }
+                    : {}),
+                }
+              : undefined,
+        };
+        const assistantMessage: Message = {
+          id: `msg-${++messageIdRef.current}`,
+          role: 'assistant',
+          text: ASSISTANT_RECEIPT_TEXT,
+          issueSent: true,
+          sentAt: Date.now(),
+        };
+        setMessages((prev) => [...prev, userMessage, assistantMessage]);
+        // Clear the composer in place — composer stays mounted and focus
+        // stays put, so a chained submit reads naturally as the same chat
+        // session continuing.
+        setDraft('');
+        setExpected('');
+        setActual('');
+        setShowExtras(false);
+        setScreenshot((prev) => {
+          if (prev) URL.revokeObjectURL(prev.url);
+          return null;
+        });
+        setFiles([]);
+        setSubmitError(null);
         // If the user minimized mid-submit, pop the panel back open so the
         // success confirmation is actually seen. A silent success while
         // hidden leaves the user unsure whether their issue landed.
@@ -495,28 +561,6 @@ export function FeedbackButton({
     submit,
     useAi,
   ]);
-
-  // Pending-focus flag: "Send another" needs to focus the composer, but the
-  // composer only remounts after the SuccessState unmounts. A layout effect
-  // below consumes the flag after the composer is in the tree.
-  const [focusComposerPending, setFocusComposerPending] = useState(false);
-
-  /**
-   * "Send another" — reset back to the empty Thread+Composer and move focus
-   * into the composer textarea so keyboard users aren't dumped onto whatever
-   * Radix's focus-trap picks next (the close button, in practice).
-   */
-  const handleSendAnother = useCallback(() => {
-    resetAll();
-    setFocusComposerPending(true);
-  }, [resetAll]);
-
-  useIsomorphicLayoutEffect(() => {
-    if (!focusComposerPending) return;
-    if (!composerRef.current) return;
-    composerRef.current.focus();
-    setFocusComposerPending(false);
-  }, [focusComposerPending, succeeded]);
 
   if (hidden) return null;
 
@@ -558,43 +602,35 @@ export function FeedbackButton({
             onMinimize={handleMinimize}
             onClose={handleCloseClick}
           />
-          {succeeded ? (
-            <SuccessState onSendAnother={handleSendAnother} />
-          ) : (
-            <Thread
-              greeting={GREETING}
-              draft={draft}
-              screenshot={screenshot}
-              files={files}
-              showExtras={showExtras}
-              expected={expected}
-              actual={actual}
-              confirmClose={confirmClose}
-              submitError={submitError}
-              status={status}
-              onToggleExtras={() => setShowExtras((v) => !v)}
-              onExpectedChange={setExpected}
-              onActualChange={setActual}
-              onRemoveScreenshot={removeScreenshot}
-              onRemoveFile={removeFile}
-              onConfirmDiscard={handleFullClose}
-              onCancelClose={() => setConfirmClose(false)}
-            />
-          )}
-          {!succeeded && (
-            <Composer
-              ref={composerRef}
-              draft={draft}
-              submitting={status === 'submitting'}
-              showAiToggle={showAiToggle}
-              useAi={useAi}
-              onDraftChange={setDraft}
-              onSubmit={doSubmit}
-              onAttachScreenshot={handleOpenRegionOverlay}
-              onAttachFiles={handleFiles}
-              onUseAiChange={setUseAi}
-            />
-          )}
+          <Thread
+            messages={messages}
+            screenshot={screenshot}
+            files={files}
+            showExtras={showExtras}
+            expected={expected}
+            actual={actual}
+            confirmClose={confirmClose}
+            submitError={submitError}
+            status={status}
+            onToggleExtras={() => setShowExtras((v) => !v)}
+            onExpectedChange={setExpected}
+            onActualChange={setActual}
+            onRemoveScreenshot={removeScreenshot}
+            onRemoveFile={removeFile}
+            onConfirmDiscard={handleFullClose}
+            onCancelClose={() => setConfirmClose(false)}
+          />
+          <Composer
+            draft={draft}
+            submitting={status === 'submitting'}
+            showAiToggle={showAiToggle}
+            useAi={useAi}
+            onDraftChange={setDraft}
+            onSubmit={doSubmit}
+            onAttachScreenshot={handleOpenRegionOverlay}
+            onAttachFiles={handleFiles}
+            onUseAiChange={setUseAi}
+          />
           <PanelFooter />
         </Dialog.Content>
       </Dialog.Portal>
@@ -672,8 +708,7 @@ function PanelFooter(): ReactElement {
 }
 
 interface ThreadProps {
-  greeting: string;
-  draft: string;
+  messages: readonly Message[];
   screenshot: ScreenshotAttachment | null;
   files: readonly FileAttachment[];
   showExtras: boolean;
@@ -692,8 +727,7 @@ interface ThreadProps {
 }
 
 function Thread({
-  greeting,
-  draft,
+  messages,
   screenshot,
   files,
   showExtras,
@@ -710,7 +744,6 @@ function Thread({
   onConfirmDiscard,
   onCancelClose,
 }: ThreadProps): ReactElement {
-  const trimmed = draft.trim();
   return (
     <div
       className="brw-thread"
@@ -718,8 +751,19 @@ function Thread({
       aria-live="polite"
       aria-label="Conversation"
     >
-      <AssistantBubble>{greeting}</AssistantBubble>
-      {trimmed.length > 0 && <UserBubble>{draft}</UserBubble>}
+      {messages.map((message) =>
+        message.role === 'assistant' ? (
+          <AssistantBubble
+            key={message.id}
+            issueSent={message.issueSent}
+            sentAt={message.sentAt}
+          >
+            {message.text}
+          </AssistantBubble>
+        ) : (
+          <UserBubble key={message.id}>{message.text}</UserBubble>
+        ),
+      )}
       {screenshot && (
         <AttachmentChip
           name="screenshot"
@@ -802,12 +846,51 @@ function DiscardConfirm({
   );
 }
 
-function AssistantBubble({ children }: { children: ReactNode }): ReactElement {
-  return <div className="brw-bubble brw-bubble--assistant">{children}</div>;
+interface AssistantBubbleProps {
+  children: ReactNode;
+  issueSent?: boolean;
+  sentAt?: number;
+}
+
+function AssistantBubble({
+  children,
+  issueSent,
+  sentAt,
+}: AssistantBubbleProps): ReactElement {
+  return (
+    <div className="brw-bubble brw-bubble--assistant">
+      {children}
+      {issueSent && (
+        <span className="brw-bubble--receipt">
+          <CheckIcon /> Issue sent · {formatRelativeTime(sentAt)}
+        </span>
+      )}
+    </div>
+  );
 }
 
 function UserBubble({ children }: { children: ReactNode }): ReactElement {
   return <div className="brw-bubble brw-bubble--user">{children}</div>;
+}
+
+/**
+ * Cheap relative-time formatter for the issue-sent receipt. The bubble
+ * doesn't auto-refresh — once rendered the timestamp captures the moment
+ * the issue was queued, which is the only thing that actually matters
+ * (the user reads it within seconds of seeing it appear). Intentionally
+ * does not pull in `Intl.RelativeTimeFormat` or `date-fns` so the
+ * react-bundle gzip stays inside the §12 budget.
+ */
+function formatRelativeTime(ms: number | undefined): string {
+  if (ms === undefined) return 'just now';
+  const diffMs = Date.now() - ms;
+  if (diffMs < 60_000) return 'just now';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
 }
 
 interface AttachmentChipProps {
@@ -1055,33 +1138,6 @@ function AIToggle({ on, disabled, onChange }: AIToggleProps): ReactElement {
   );
 }
 
-interface SuccessStateProps {
-  onSendAnother: () => void;
-}
-
-function SuccessState({ onSendAnother }: SuccessStateProps): ReactElement {
-  return (
-    <div
-      className="brw-thread"
-      role="log"
-      aria-live="polite"
-      aria-label="Confirmation"
-    >
-      <div className="brw-success-wrap">
-        <div className="brw-bubble brw-bubble--success" role="status">
-          Thanks — your issue is on its way.
-        </div>
-        <button
-          type="button"
-          className="brw-btn brw-btn-primary"
-          onClick={onSendAnother}
-        >
-          Send another
-        </button>
-      </div>
-    </div>
-  );
-}
 
 /**
  * Crop a full-page screenshot Blob to the user-selected viewport rectangle.
@@ -1452,6 +1508,24 @@ function SendIcon(): ReactElement {
     >
       <path d="M4 20l16-8L4 4l2 8-2 8z" />
       <path d="M6 12h14" />
+    </svg>
+  );
+}
+
+function CheckIcon(): ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 12l5 5L20 7" />
     </svg>
   );
 }

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -32,6 +32,19 @@ import {
 declare const __BREVWICK_REACT_VERSION__: string;
 
 /**
+ * Stable snapshot of one attachment that rode along with a submit. We store
+ * only the underlying `Blob` (not the live `ScreenshotAttachment.url`),
+ * because the success path revokes the composer's object URL the moment the
+ * snapshot is appended — keeping the URL on the message would leave a
+ * dangling reference. A future render that wants to preview the attachment
+ * can call `URL.createObjectURL(blob)` itself.
+ */
+interface MessageAttachment {
+  blob: Blob;
+  filename?: string;
+}
+
+/**
  * One bubble in the conversation thread. The greeting and submitted-issue
  * receipt are `assistant` messages; submitted drafts become `user` messages.
  * `attachments` snapshots the screenshot + files that rode along with the
@@ -45,8 +58,8 @@ interface Message {
   sentAt?: number;
   issueSent?: boolean;
   attachments?: {
-    screenshot?: ScreenshotAttachment;
-    files?: readonly FileAttachment[];
+    screenshot?: MessageAttachment;
+    files?: readonly MessageAttachment[];
   };
 }
 
@@ -493,19 +506,26 @@ export function FeedbackButton({
       if (!mountedRef.current) return;
       onSubmit?.(result);
       if (result.ok) {
+        const screenshotSnapshot: MessageAttachment | undefined =
+          submittedScreenshot ? { blob: submittedScreenshot.blob } : undefined;
+        const filesSnapshot: readonly MessageAttachment[] | undefined =
+          submittedFiles.length > 0
+            ? submittedFiles.map(({ file }) => ({
+                blob: file,
+                filename: file.name,
+              }))
+            : undefined;
         const userMessage: Message = {
           id: `msg-${++messageIdRef.current}`,
           role: 'user',
           text: submittedDraft,
           attachments:
-            submittedScreenshot || submittedFiles.length > 0
+            screenshotSnapshot || filesSnapshot
               ? {
-                  ...(submittedScreenshot
-                    ? { screenshot: submittedScreenshot }
+                  ...(screenshotSnapshot
+                    ? { screenshot: screenshotSnapshot }
                     : {}),
-                  ...(submittedFiles.length > 0
-                    ? { files: submittedFiles }
-                    : {}),
+                  ...(filesSnapshot ? { files: filesSnapshot } : {}),
                 }
               : undefined,
         };
@@ -861,9 +881,9 @@ function AssistantBubble({
     <div className="brw-bubble brw-bubble--assistant">
       {children}
       {issueSent && (
-        <span className="brw-bubble--receipt">
+        <div className="brw-bubble--receipt">
           <CheckIcon /> Issue sent · {formatRelativeTime(sentAt)}
-        </span>
+        </div>
       )}
     </div>
   );

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -1138,7 +1138,6 @@ function AIToggle({ on, disabled, onChange }: AIToggleProps): ReactElement {
   );
 }
 
-
 /**
  * Crop a full-page screenshot Blob to the user-selected viewport rectangle.
  *

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -271,20 +271,15 @@ export const BREVWICK_CSS = `
   color: var(--brw-bubble-user-fg, var(--brw-bubble-user-fg-base));
   border-bottom-right-radius: 4px;
 }
-.brw-bubble--success {
-  align-self: center;
-  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
-  color: var(--brw-fg, var(--brw-fg-base));
-  text-align: center;
-  max-width: 92%;
-}
-.brw-success-wrap {
-  display: flex;
-  flex-direction: column;
+.brw-bubble--receipt {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 24px 8px;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
 }
+.brw-bubble--receipt svg { flex-shrink: 0; }
 .brw-chip {
   align-self: flex-end;
   display: inline-flex;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -272,7 +272,7 @@ export const BREVWICK_CSS = `
   border-bottom-right-radius: 4px;
 }
 .brw-bubble--receipt {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 4px;
   margin-top: 6px;


### PR DESCRIPTION
Closes #52

Refactors the React feedback panel into a continuous chat thread. The live-typing mirror bubble is gone (it was just rendering composer text twice) and the post-submit "Thanks — your issue is on its way." + "Send another" takeover is replaced with an inline assistant reply that keeps the composer mounted for chained submissions. Each new submit still fires its own POST and creates its own ticket.

## Summary

- Introduced a module-scope `Message` type and a `messages` state array. `Thread` now renders from history (`messages.map(...)`) instead of a hardcoded `AssistantBubble` + live `UserBubble` layout.
- Removed the live-mirror `<UserBubble>{draft}</UserBubble>` render — typing into the composer no longer paints a bubble above it.
- Deleted `SuccessState`, `handleSendAnother`, the `succeeded` flag, the `focusComposerPending` layout-effect dance, and the post-submit `Thread`/`SuccessState` ternary. The composer is always mounted.
- On submit success: append a user `Message` (text snapshot of the draft + attachments snapshot) and an assistant `Message` (`text: 'Thanks — your issue is on its way.'`, `issueSent: true`, `sentAt: Date.now()`). Then clear `draft`, `screenshot`, `files`, `expected`, `actual` in place — composer stays mounted and focus stays put.
- On submit error: existing inline `role="alert"` is preserved; nothing is pushed onto `messages`.
- Assistant "thank-you" bubbles carry an "Issue sent · timestamp" footer (`brw-bubble--receipt`) with an inline 16x16 `<svg>` check icon (no new icon dep). Relative-time formatting is a tiny in-file helper — no `date-fns` / `Intl.RelativeTimeFormat` dependency, so the bundle stays inside budget.
- `resetAll()` now also resets `messages` to `initialMessages()`. Closing the panel via the × button (or via Discard from the dirty-confirm) resets the thread to just the greeting on next open. Minimize semantics are unchanged — the existing "minimize preserves draft + attachments" contract still holds, since that path skips `resetAll()` and was an intentional UX, not part of the issue's reset scope.
- Removed the now-unused `.brw-bubble--success` and `.brw-success-wrap` rules; added `.brw-bubble--receipt` (small inline-flex footer, reuses `--brw-fg-muted`, no new tokens).
- Removed the unused `composerRef` declaration in `FeedbackButton` (dead after the focus dance went away).

## Test plan

- [x] `pnpm type-check`, `pnpm lint`, `pnpm test`, `pnpm build` all green
- [x] Integration test: single submit shows persistent user + assistant bubbles + receipt marker + still-active composer (`packages/react/src/__tests__/integration/render-submit.test.tsx`)
- [x] Integration test: chained second submit fires another POST and appends another pair of bubbles (5 bubbles total: greeting + 2x user + 2x assistant)
- [x] Unit test: typing into the composer does not append a bubble to the thread
- [x] Unit test: closing and reopening the panel resets to just the greeting
- [x] Unit test: chained submissions append additional bubbles without remounting the composer textarea
- [x] No bundle regression for `@tatlacas/brevwick-react` (gzip 9443 B → 9671 B, +228 B; well under the 25 kB initial-gzip budget per § 12)
- [ ] Manual UI walkthrough — `examples/next` is wired to `@tatlacas/brevwick-react` via the workspace symlink, but I could not drive a browser from this run. Reviewer please run `pnpm --filter brevwick-example-next dev` and exercise: open panel → type (no mirror) → send → user bubble persists, thank-you bubble with "Issue sent ✓" appears → type and send a second message → both pairs visible → close panel → reopen → only greeting.

## SDD impact

The user prompt called out "§ 13 (widget UX)", but § 13 in the canonical doc is "Dashboard". The widget-UX surface lives in § 12 ("Client SDK contracts"). § 12's only post-submit copy reads "On success the dialog auto-closes after ~1.5 s; on error the dialog stays open with an inline alert" — the panel has not auto-closed for some time (the prior `SuccessState` + "Send another" UI was a drift past § 12 already). This PR also does not auto-close, but it does the "right thing" by the same UX intent: the success is visible, the composer is ready, and a follow-up submit is one keystroke away. Treating this as UI-only (no SDD update) is consistent with how the prior change landed; if the SDD owner wants the post-submit copy aligned, that belongs in a stand-alone § 12 amendment with the prior behaviour also reconciled.