### PR TITLE
feat(react): multi-screenshot, in-flight capture indicator, tap-to-preview

### DIFF
--- a/.changeset/feedback-attachments-ux.md
+++ b/.changeset/feedback-attachments-ux.md
@@ -18,13 +18,13 @@ legible end-to-end:
 
 - **Multiple screenshots per submission** (#56). The composer now keeps
   a bounded array of screenshots instead of a single field; each capture
-  appends rather than replacing the previous one. The combined screenshot
-  + file total caps at 5 (mirrors the SDK's `MAX_ATTACHMENT_COUNT`); the
-  attach buttons disable with an explanatory `aria-label` once the cap
-  is reached. Single-screenshot submissions keep the historical
-  `screenshot.<ext>` wire filename; multi-screenshot submissions
-  disambiguate as `screenshot-1.<ext>`, `screenshot-2.<ext>`, in capture
-  order.
+  appends rather than replacing the previous one. The combined
+  screenshot/file total caps at 5 (mirrors the SDK's
+  `MAX_ATTACHMENT_COUNT`); the attach buttons disable with an explanatory
+  `aria-label` once the cap is reached. Single-screenshot submissions
+  keep the historical `screenshot.<ext>` wire filename; multi-screenshot
+  submissions disambiguate as `screenshot-1.<ext>`, `screenshot-2.<ext>`,
+  in capture order.
 
 - **Tap thumbnail to preview** (#57). The screenshot chip's image is now
   a button that opens a Radix `Dialog` preview at viewport-fit size. Esc,

--- a/.changeset/feedback-attachments-ux.md
+++ b/.changeset/feedback-attachments-ux.md
@@ -1,0 +1,37 @@
+---
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': patch
+---
+
+feat(react): multi-screenshot, in-flight capture indicator, tap-to-preview
+
+Three feedback-panel UX fixes that together make the screenshot flow
+legible end-to-end:
+
+- **In-flight capture indicator** (#55). The region-capture overlay closes
+  the moment the user clicks Capture, but `captureScreenshot()` plus the
+  optional crop step is async — previously the panel re-appeared with no
+  thumbnail and no explanation for the gap. A new `capturing` state
+  surfaces a "Capturing screenshot…" bubble in the thread and disables
+  the screenshot + file-attach controls so a second click cannot stack
+  on top of the first.
+
+- **Multiple screenshots per submission** (#56). The composer now keeps
+  a bounded array of screenshots instead of a single field; each capture
+  appends rather than replacing the previous one. The combined screenshot
+  + file total caps at 5 (mirrors the SDK's `MAX_ATTACHMENT_COUNT`); the
+  attach buttons disable with an explanatory `aria-label` once the cap
+  is reached. Single-screenshot submissions keep the historical
+  `screenshot.<ext>` wire filename; multi-screenshot submissions
+  disambiguate as `screenshot-1.<ext>`, `screenshot-2.<ext>`, in capture
+  order.
+
+- **Tap thumbnail to preview** (#57). The screenshot chip's image is now
+  a button that opens a Radix `Dialog` preview at viewport-fit size. Esc,
+  the close button, and the backdrop dismiss; focus restores to the chip
+  on close. The chip's × remove stays a sibling so it never opens the
+  preview, and removing a screenshot whose preview is open auto-closes
+  the dialog.
+
+The `@tatlacas/brevwick-sdk` patch bump is a no-op to keep the two
+packages in lockstep per the repo's pre-1.0 versioning policy.

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1139,6 +1139,96 @@ describe('<FeedbackButton> — multi-screenshot + preview', () => {
     );
   });
 
+  it('blocks Enter-to-send while a capture is in flight (no submit without the pending screenshot)', async () => {
+    let release: (b: Blob) => void = () => undefined;
+    captureScreenshot.mockReturnValueOnce(
+      new Promise<Blob>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    typeDraft('partial draft');
+    await captureFullPage();
+
+    // Send button is disabled because Capture is in flight; Enter-to-send
+    // is independently guarded inside doSubmit so the keyboard path can't
+    // race past the disabled-button protection.
+    expect(screen.getByRole('button', { name: /^send$/i })).toBeDisabled();
+    fireEvent.keyDown(getComposer(), { key: 'Enter' });
+    expect(submit).not.toHaveBeenCalled();
+
+    await act(async () => {
+      release(new Blob(['x'], { type: 'image/png' }));
+      await Promise.resolve();
+    });
+    // After capture resolves, Send re-enables and submission works
+    // normally — the guard only fires while `capturing` is true.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /^send$/i }),
+      ).not.toBeDisabled(),
+    );
+  });
+
+  it('surfaces an error when a capture lands after the cap was reached', async () => {
+    // Hit the defence-in-depth branch in performCapture by gating the second
+    // capture on a pending promise: open the region overlay → click Capture
+    // (capture #2 is in flight) → race the cap-fill: in production the cap
+    // fills via concurrent file-attaches, but the easier reproduction is to
+    // attach four files between the click and the resolve so the cap is at
+    // 5 (4 files + 1 first screenshot) when capture #2 lands.
+    const first = new Blob(['1'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(first);
+    let releaseSecond: (b: Blob) => void = () => undefined;
+    captureScreenshot.mockReturnValueOnce(
+      new Promise<Blob>((resolve) => {
+        releaseSecond = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    // Kick off capture #2 (still pending).
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /capture screenshot of this page/i,
+        }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /capture full page/i }),
+      );
+    });
+
+    // Fill the remaining 4 slots with files while capture #2 is in flight.
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const dt = new DataTransfer();
+    for (let i = 0; i < 4; i++) {
+      dt.items.add(new File(['f'], `f${i}.png`, { type: 'image/png' }));
+    }
+    fireEvent.change(fileInput, { target: { files: dt.files } });
+
+    // Resolve capture #2 — performCapture's cap guard rejects the new
+    // capture and surfaces the error message.
+    await act(async () => {
+      releaseSecond(new Blob(['2'], { type: 'image/png' }));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(/maximum 5 attachments reached/i, {
+          selector: '[role="alert"]',
+        }),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it('tapping a screenshot thumbnail opens a preview dialog with the captured image', async () => {
     const blob = new Blob(['x'], { type: 'image/png' });
     captureScreenshot.mockResolvedValueOnce(blob);

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1022,6 +1022,217 @@ describe('<FeedbackButton>', () => {
   });
 });
 
+/**
+ * Issues #55 / #56 / #57 — multi-screenshot, in-flight loading indicator,
+ * and tap-to-preview thumbnails. The pre-existing single-screenshot tests
+ * above pin the "one capture" wire format; this block locks in the array
+ * shape, the cap, the capturing bubble, and the preview dialog wiring.
+ */
+describe('<FeedbackButton> — multi-screenshot + preview', () => {
+  it('keeps both captures (no replace) and disambiguates filenames on submit', async () => {
+    const first = new Blob(['1'], { type: 'image/png' });
+    const second = new Blob(['2'], { type: 'image/webp' });
+    captureScreenshot.mockResolvedValueOnce(first);
+    captureScreenshot.mockResolvedValueOnce(second);
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_multi' });
+    mount();
+    openPanel();
+
+    await captureFullPage();
+    await captureFullPage();
+
+    expect(
+      screen.getByRole('button', { name: /remove screenshot 1/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /remove screenshot 2/i }),
+    ).toBeInTheDocument();
+
+    typeDraft('two screenshots');
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    });
+    const input = submit.mock.calls[0]![0] as {
+      attachments: Array<{ blob: Blob; filename: string }>;
+    };
+    expect(input.attachments).toHaveLength(2);
+    expect(input.attachments[0]!.filename).toBe('screenshot-1.png');
+    expect(input.attachments[1]!.filename).toBe('screenshot-2.webp');
+  });
+
+  it('disables the screenshot button once the combined attachment cap (5) is hit', async () => {
+    for (let i = 0; i < 5; i++) {
+      captureScreenshot.mockResolvedValueOnce(
+        new Blob([String(i)], { type: 'image/png' }),
+      );
+    }
+    mount();
+    openPanel();
+    for (let i = 0; i < 5; i++) await captureFullPage();
+
+    expect(
+      screen
+        .getAllByRole('button', { name: /remove screenshot/i })
+        .filter((n) => n.tagName === 'BUTTON'),
+    ).toHaveLength(5);
+    const screenshotBtn = screen.getByRole('button', {
+      name: /maximum 5 attachments reached/i,
+    });
+    expect(screenshotBtn).toBeDisabled();
+    expect(captureScreenshot).toHaveBeenCalledTimes(5);
+  });
+
+  it('shows a "Capturing screenshot…" indicator between region close and the chip render', async () => {
+    let release: (b: Blob) => void = () => undefined;
+    captureScreenshot.mockReturnValueOnce(
+      new Promise<Blob>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    // Capture is still pending — bubble + spinner should be visible.
+    expect(screen.getByText(/capturing screenshot/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove screenshot/i }),
+    ).toBeNull();
+
+    await act(async () => {
+      release(new Blob(['x'], { type: 'image/png' }));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /^remove screenshot$/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/capturing screenshot/i)).toBeNull();
+  });
+
+  it('disables the screenshot button while a capture is in flight', async () => {
+    let release: (b: Blob) => void = () => undefined;
+    captureScreenshot.mockReturnValueOnce(
+      new Promise<Blob>((resolve) => {
+        release = resolve;
+      }),
+    );
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    expect(
+      screen.getByRole('button', { name: /capturing screenshot/i }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      release(new Blob(['x'], { type: 'image/png' }));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /capture screenshot of this page/i,
+        }),
+      ).not.toBeDisabled(),
+    );
+  });
+
+  it('tapping a screenshot thumbnail opens a preview dialog with the captured image', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:mock-preview');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /preview screenshot/i }),
+    );
+    const preview = screen.getByTestId('brw-preview-dialog');
+    expect(preview).toBeInTheDocument();
+    const img = within(preview).getByRole('img', {
+      name: /captured screenshot/i,
+    });
+    expect(img).toHaveAttribute('src', 'blob:mock-preview');
+
+    fireEvent.click(
+      within(preview).getByRole('button', { name: /close preview/i }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId('brw-preview-dialog')).toBeNull(),
+    );
+    createObjectURL.mockRestore();
+  });
+
+  it('Esc dismisses the preview dialog without removing the screenshot', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /preview screenshot/i }),
+    );
+    const preview = screen.getByTestId('brw-preview-dialog');
+    fireEvent.keyDown(preview, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByTestId('brw-preview-dialog')).toBeNull(),
+    );
+    // Chip survives the Esc — Esc on the preview must not bubble up into
+    // the panel's own minimize handler. The chip's preview-button is the
+    // canonical "screenshot is still attached" probe.
+    expect(
+      screen.getByRole('button', { name: /preview screenshot/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('clicking the chip × does not open the preview dialog', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(blob);
+    mount();
+    openPanel();
+    await captureFullPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^remove screenshot$/i }),
+    );
+    expect(screen.queryByTestId('brw-preview-dialog')).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: /preview screenshot/i }),
+    ).toBeNull();
+  });
+
+  it('removing a screenshot while its preview is open closes the dialog', async () => {
+    const first = new Blob(['1'], { type: 'image/png' });
+    const second = new Blob(['2'], { type: 'image/png' });
+    captureScreenshot.mockResolvedValueOnce(first);
+    captureScreenshot.mockResolvedValueOnce(second);
+    mount();
+    openPanel();
+    await captureFullPage();
+    await captureFullPage();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /preview screenshot 2/i }),
+    );
+    expect(screen.getByTestId('brw-preview-dialog')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /^remove screenshot 2$/i }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId('brw-preview-dialog')).toBeNull(),
+    );
+  });
+});
+
 describe('<FeedbackButton> — Use AI toggle', () => {
   async function mountAndOpen(): Promise<void> {
     mount();

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -47,7 +47,7 @@ interface MessageAttachment {
 /**
  * One bubble in the conversation thread. The greeting and submitted-issue
  * receipt are `assistant` messages; submitted drafts become `user` messages.
- * `attachments` snapshots the screenshot + files that rode along with the
+ * `attachments` snapshots the screenshots + files that rode along with the
  * submit so a follow-up render can show what was sent (currently the bubble
  * itself just shows text, but the field is there for forward-compat).
  */
@@ -58,10 +58,19 @@ interface Message {
   sentAt?: number;
   issueSent?: boolean;
   attachments?: {
-    screenshot?: MessageAttachment;
+    screenshots?: readonly MessageAttachment[];
     files?: readonly MessageAttachment[];
   };
 }
+
+/**
+ * Combined screenshot + file cap, mirrored from the SDK's
+ * `MAX_ATTACHMENT_COUNT` in `packages/sdk/src/submit.ts`. Enforced in the
+ * UI by disabling the screenshot and file-attach buttons once the combined
+ * total reaches this ceiling — that way the user can't queue an attachment
+ * the SDK would reject downstream.
+ */
+const MAX_ATTACHMENTS = 5;
 
 const GREETING_MESSAGE: Message = {
   id: 'greeting',
@@ -138,6 +147,12 @@ function formatSize(bytes: number): string {
 }
 
 interface ScreenshotAttachment {
+  /**
+   * Monotonic id assigned at capture time. Same rationale as
+   * {@link FileAttachment.id}: keys based on `url` or array index would
+   * reconcile a removal-of-middle-item against the wrong slot.
+   */
+  readonly id: number;
   readonly blob: Blob;
   readonly url: string;
 }
@@ -281,10 +296,17 @@ export function FeedbackButton({
   const [expected, setExpected] = useState('');
   const [actual, setActual] = useState('');
   const [showExtras, setShowExtras] = useState(false);
-  const [screenshot, setScreenshot] = useState<ScreenshotAttachment | null>(
-    null,
-  );
+  const [screenshots, setScreenshots] = useState<
+    readonly ScreenshotAttachment[]
+  >([]);
   const [files, setFiles] = useState<readonly FileAttachment[]>([]);
+  const [capturing, setCapturing] = useState(false);
+  // Index into `screenshots` of the thumbnail the user tapped to preview;
+  // `null` keeps the preview dialog closed. Storing the id rather than the
+  // index would survive an out-of-band removal, but the chip × is also
+  // disabled while the preview is up so the index is stable for the dialog
+  // lifetime.
+  const [previewId, setPreviewId] = useState<number | null>(null);
   const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>(initialMessages);
@@ -294,7 +316,10 @@ export function FeedbackButton({
   // matrix below says the toggle should be visible.
   const [useAi, setUseAi] = useState(true);
   const mountedRef = useRef(true);
-  const screenshotUrlRef = useRef<string | null>(null);
+  // Mirrors `screenshots[*].url` for the unmount cleanup so we don't have to
+  // close over a stale `screenshots` value in the cleanup function.
+  const screenshotUrlsRef = useRef<readonly string[]>([]);
+  const screenshotIdRef = useRef(0);
   const fileIdRef = useRef(0);
   const messageIdRef = useRef(0);
 
@@ -315,22 +340,25 @@ export function FeedbackButton({
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      if (screenshotUrlRef.current) {
-        URL.revokeObjectURL(screenshotUrlRef.current);
-        screenshotUrlRef.current = null;
+      for (const url of screenshotUrlsRef.current) {
+        URL.revokeObjectURL(url);
       }
+      screenshotUrlsRef.current = [];
     };
   }, []);
 
   useEffect(() => {
-    screenshotUrlRef.current = screenshot?.url ?? null;
-  }, [screenshot]);
+    screenshotUrlsRef.current = screenshots.map((s) => s.url);
+  }, [screenshots]);
+
+  const attachmentCount = screenshots.length + files.length;
+  const attachmentsAtCap = attachmentCount >= MAX_ATTACHMENTS;
 
   const hasContent =
     draft.trim().length > 0 ||
     expected.length > 0 ||
     actual.length > 0 ||
-    screenshot !== null ||
+    screenshots.length > 0 ||
     files.length > 0;
 
   const resetAll = useCallback(() => {
@@ -338,11 +366,12 @@ export function FeedbackButton({
     setExpected('');
     setActual('');
     setShowExtras(false);
-    setScreenshot((prev) => {
-      if (prev) URL.revokeObjectURL(prev.url);
-      return null;
+    setScreenshots((prev) => {
+      for (const s of prev) URL.revokeObjectURL(s.url);
+      return [];
     });
     setFiles([]);
+    setPreviewId(null);
     setConfirmClose(false);
     setSubmitError(null);
     setMessages(initialMessages());
@@ -391,26 +420,49 @@ export function FeedbackButton({
   // `data-brevwick-skip` on every overlay node, which the SDK's capture
   // path honours before it snapshots. The React unmount lands before the
   // async rasterization / crop work completes and is defence-in-depth.
+  //
+  // `capturing` is the in-thread loading flag (issue #55). The region
+  // overlay closes the moment the user clicks Capture so the panel is
+  // already visible by the time `captureScreenshot()` resolves; the flag
+  // surfaces a "Capturing screenshot…" bubble in the thread to bridge that
+  // gap so the panel re-appearing without the chip is no longer mysterious.
   const performCapture = useCallback(
     async (region: Region | null) => {
       setSubmitError(null);
+      setCapturing(true);
       try {
         const blob = await captureScreenshot();
         if (!mountedRef.current) return;
         const finalBlob = region ? await cropToRegion(blob, region) : blob;
         if (!mountedRef.current) return;
-        setScreenshot((prev) => {
-          if (prev) URL.revokeObjectURL(prev.url);
-          return { blob: finalBlob, url: URL.createObjectURL(finalBlob) };
+        setScreenshots((prev) => {
+          // Defence-in-depth: the screenshot button is disabled at the cap,
+          // but a stale closure or a future race could still land here. Drop
+          // the new capture rather than silently exceed the SDK's combined
+          // attachment ceiling. (Object URL is created inside the branch
+          // that keeps the capture so a rejected one doesn't leak.)
+          if (prev.length + files.length >= MAX_ATTACHMENTS) {
+            return prev;
+          }
+          return [
+            ...prev,
+            {
+              id: ++screenshotIdRef.current,
+              blob: finalBlob,
+              url: URL.createObjectURL(finalBlob),
+            },
+          ];
         });
       } catch (err) {
         if (!mountedRef.current) return;
         const message =
           err instanceof Error ? err.message : 'Screenshot capture failed';
         setSubmitError(message);
+      } finally {
+        if (mountedRef.current) setCapturing(false);
       }
     },
-    [captureScreenshot],
+    [captureScreenshot, files.length],
   );
 
   const handleOpenRegionOverlay = useCallback(() => {
@@ -435,22 +487,43 @@ export function FeedbackButton({
     void performCapture(null);
   }, [performCapture]);
 
-  const handleFiles = useCallback((list: FileList | null) => {
-    if (!list || list.length === 0) return;
-    setFiles((prev) => {
-      const next = Array.from(list).map<FileAttachment>((file) => ({
-        id: ++fileIdRef.current,
-        file,
-      }));
-      return [...prev, ...next];
+  const handleFiles = useCallback(
+    (list: FileList | null) => {
+      if (!list || list.length === 0) return;
+      setFiles((prev) => {
+        // Cap the combined screenshot+file total at MAX_ATTACHMENTS so a
+        // bulk-add via <input multiple> can't exceed the SDK ceiling. Keep
+        // prefix-of-input semantics: drop the overflow tail rather than
+        // silently dropping arbitrary entries.
+        const remaining = MAX_ATTACHMENTS - (prev.length + screenshots.length);
+        if (remaining <= 0) return prev;
+        const next = Array.from(list)
+          .slice(0, remaining)
+          .map<FileAttachment>((file) => ({
+            id: ++fileIdRef.current,
+            file,
+          }));
+        return [...prev, ...next];
+      });
+    },
+    [screenshots.length],
+  );
+
+  const removeScreenshot = useCallback((id: number) => {
+    setScreenshots((prev) => {
+      const target = prev.find((s) => s.id === id);
+      if (target) URL.revokeObjectURL(target.url);
+      return prev.filter((s) => s.id !== id);
     });
+    setPreviewId((current) => (current === id ? null : current));
   }, []);
 
-  const removeScreenshot = useCallback(() => {
-    setScreenshot((prev) => {
-      if (prev) URL.revokeObjectURL(prev.url);
-      return null;
-    });
+  const handlePreviewScreenshot = useCallback((id: number) => {
+    setPreviewId(id);
+  }, []);
+
+  const handleClosePreview = useCallback(() => {
+    setPreviewId(null);
   }, []);
 
   const removeFile = useCallback((id: number) => {
@@ -466,13 +539,18 @@ export function FeedbackButton({
     setSubmitError(null);
 
     const attachments: Array<Blob | FeedbackAttachment> = [];
-    if (screenshot) {
-      const ext = screenshot.blob.type.split('/')[1]?.split('+')[0] || 'webp';
-      attachments.push({
-        blob: screenshot.blob,
-        filename: `screenshot.${ext}`,
-      });
-    }
+    // Single-screenshot filename stays `screenshot.<ext>` (matches pre-#56
+    // wire format and keeps existing tests / server-side identifiers
+    // stable). Multi-screenshot submissions disambiguate with `-1`, `-2`,
+    // … using the array order they were captured in.
+    screenshots.forEach((s, idx) => {
+      const ext = s.blob.type.split('/')[1]?.split('+')[0] || 'webp';
+      const filename =
+        screenshots.length === 1
+          ? `screenshot.${ext}`
+          : `screenshot-${idx + 1}.${ext}`;
+      attachments.push({ blob: s.blob, filename });
+    });
     for (const { file } of files)
       attachments.push({ blob: file, filename: file.name });
 
@@ -498,7 +576,7 @@ export function FeedbackButton({
     // (in which case React's setState below races with whatever they typed
     // after — the snapshot pins the version of the draft we're submitting).
     const submittedDraft = draft;
-    const submittedScreenshot = screenshot;
+    const submittedScreenshots = screenshots;
     const submittedFiles = files;
 
     try {
@@ -506,8 +584,10 @@ export function FeedbackButton({
       if (!mountedRef.current) return;
       onSubmit?.(result);
       if (result.ok) {
-        const screenshotSnapshot: MessageAttachment | undefined =
-          submittedScreenshot ? { blob: submittedScreenshot.blob } : undefined;
+        const screenshotsSnapshot: readonly MessageAttachment[] | undefined =
+          submittedScreenshots.length > 0
+            ? submittedScreenshots.map((s) => ({ blob: s.blob }))
+            : undefined;
         const filesSnapshot: readonly MessageAttachment[] | undefined =
           submittedFiles.length > 0
             ? submittedFiles.map(({ file }) => ({
@@ -520,10 +600,10 @@ export function FeedbackButton({
           role: 'user',
           text: submittedDraft,
           attachments:
-            screenshotSnapshot || filesSnapshot
+            screenshotsSnapshot || filesSnapshot
               ? {
-                  ...(screenshotSnapshot
-                    ? { screenshot: screenshotSnapshot }
+                  ...(screenshotsSnapshot
+                    ? { screenshots: screenshotsSnapshot }
                     : {}),
                   ...(filesSnapshot ? { files: filesSnapshot } : {}),
                 }
@@ -544,11 +624,12 @@ export function FeedbackButton({
         setExpected('');
         setActual('');
         setShowExtras(false);
-        setScreenshot((prev) => {
-          if (prev) URL.revokeObjectURL(prev.url);
-          return null;
+        setScreenshots((prev) => {
+          for (const s of prev) URL.revokeObjectURL(s.url);
+          return [];
         });
         setFiles([]);
+        setPreviewId(null);
         setSubmitError(null);
         // If the user minimized mid-submit, pop the panel back open so the
         // success confirmation is actually seen. A silent success while
@@ -575,7 +656,7 @@ export function FeedbackButton({
     expected,
     files,
     onSubmit,
-    screenshot,
+    screenshots,
     showAiToggle,
     status,
     submit,
@@ -624,8 +705,9 @@ export function FeedbackButton({
           />
           <Thread
             messages={messages}
-            screenshot={screenshot}
+            screenshots={screenshots}
             files={files}
+            capturing={capturing}
             showExtras={showExtras}
             expected={expected}
             actual={actual}
@@ -636,6 +718,7 @@ export function FeedbackButton({
             onExpectedChange={setExpected}
             onActualChange={setActual}
             onRemoveScreenshot={removeScreenshot}
+            onPreviewScreenshot={handlePreviewScreenshot}
             onRemoveFile={removeFile}
             onConfirmDiscard={handleFullClose}
             onCancelClose={() => setConfirmClose(false)}
@@ -643,6 +726,8 @@ export function FeedbackButton({
           <Composer
             draft={draft}
             submitting={status === 'submitting'}
+            capturing={capturing}
+            attachmentsAtCap={attachmentsAtCap}
             showAiToggle={showAiToggle}
             useAi={useAi}
             onDraftChange={setDraft}
@@ -660,6 +745,16 @@ export function FeedbackButton({
         onClose={handleCloseRegion}
         onConfirmRegion={handleConfirmRegion}
         onConfirmFull={handleConfirmFull}
+      />
+      <ScreenshotPreviewDialog
+        open={previewId !== null}
+        screenshot={
+          previewId !== null
+            ? (screenshots.find((s) => s.id === previewId) ?? null)
+            : null
+        }
+        theme={theme}
+        onClose={handleClosePreview}
       />
     </Dialog.Root>
   );
@@ -729,8 +824,9 @@ function PanelFooter(): ReactElement {
 
 interface ThreadProps {
   messages: readonly Message[];
-  screenshot: ScreenshotAttachment | null;
+  screenshots: readonly ScreenshotAttachment[];
   files: readonly FileAttachment[];
+  capturing: boolean;
   showExtras: boolean;
   expected: string;
   actual: string;
@@ -740,7 +836,8 @@ interface ThreadProps {
   onToggleExtras: () => void;
   onExpectedChange: (v: string) => void;
   onActualChange: (v: string) => void;
-  onRemoveScreenshot: () => void;
+  onRemoveScreenshot: (id: number) => void;
+  onPreviewScreenshot: (id: number) => void;
   onRemoveFile: (id: number) => void;
   onConfirmDiscard: () => void;
   onCancelClose: () => void;
@@ -748,8 +845,9 @@ interface ThreadProps {
 
 function Thread({
   messages,
-  screenshot,
+  screenshots,
   files,
+  capturing,
   showExtras,
   expected,
   actual,
@@ -760,6 +858,7 @@ function Thread({
   onExpectedChange,
   onActualChange,
   onRemoveScreenshot,
+  onPreviewScreenshot,
   onRemoveFile,
   onConfirmDiscard,
   onCancelClose,
@@ -784,14 +883,20 @@ function Thread({
           <UserBubble key={message.id}>{message.text}</UserBubble>
         ),
       )}
-      {screenshot && (
-        <AttachmentChip
-          name="screenshot"
-          size={screenshot.blob.size}
-          previewUrl={screenshot.url}
-          onRemove={onRemoveScreenshot}
-        />
-      )}
+      {screenshots.map((s, idx) => {
+        const label =
+          screenshots.length === 1 ? 'screenshot' : `screenshot ${idx + 1}`;
+        return (
+          <AttachmentChip
+            key={s.id}
+            name={label}
+            size={s.blob.size}
+            previewUrl={s.url}
+            onPreview={() => onPreviewScreenshot(s.id)}
+            onRemove={() => onRemoveScreenshot(s.id)}
+          />
+        );
+      })}
       {files.map(({ id, file }) => (
         <AttachmentChip
           key={id}
@@ -800,6 +905,16 @@ function Thread({
           onRemove={() => onRemoveFile(id)}
         />
       ))}
+      {/* In-thread loading indicator (issue #55). The region overlay closes
+          before `captureScreenshot()` resolves, so the panel is already
+          visible when this bubble shows up — it bridges the otherwise-silent
+          gap between the overlay closing and the thumbnail appearing. */}
+      {capturing && (
+        <AssistantBubble>
+          <span className="brw-spinner" aria-hidden="true" /> Capturing
+          screenshot…
+        </AssistantBubble>
+      )}
       <DisclosureExpectedActual
         open={showExtras}
         expected={expected}
@@ -917,6 +1032,10 @@ interface AttachmentChipProps {
   name: string;
   size: number;
   previewUrl?: string;
+  /** When provided alongside `previewUrl`, the thumbnail becomes a button
+   *  that opens the screenshot preview dialog. File chips (no `previewUrl`)
+   *  never receive this — they are not previewable. */
+  onPreview?: () => void;
   onRemove: () => void;
 }
 
@@ -924,11 +1043,30 @@ function AttachmentChip({
   name,
   size,
   previewUrl,
+  onPreview,
   onRemove,
 }: AttachmentChipProps): ReactElement {
+  // Render the thumbnail as a button only when there's something to preview
+  // and a handler to call. The keyboard activation comes free with `<button>`,
+  // so screen-reader users can hit Enter / Space to open the preview the
+  // same way pointer users can click. The remove × is a sibling — clicks on
+  // it don't propagate into the thumbnail's open-preview path because they
+  // are different elements.
   return (
     <div className="brw-chip">
-      {previewUrl && <img src={previewUrl} alt="" />}
+      {previewUrl &&
+        (onPreview ? (
+          <button
+            type="button"
+            className="brw-chip-preview-btn"
+            aria-label={`Preview ${name}`}
+            onClick={onPreview}
+          >
+            <img src={previewUrl} alt="" />
+          </button>
+        ) : (
+          <img src={previewUrl} alt="" />
+        ))}
       <span className="brw-chip-name">{name}</span>
       <span className="brw-chip-size">{formatSize(size)}</span>
       <button
@@ -1003,6 +1141,14 @@ function DisclosureExpectedActual({
 interface ComposerProps {
   draft: string;
   submitting: boolean;
+  /** True while a screenshot is being rasterised/cropped (issue #55). The
+   *  composer disables the screenshot + file-attach buttons so the user
+   *  cannot stack a second capture on top of one already in flight. */
+  capturing: boolean;
+  /** True once `screenshots.length + files.length >= MAX_ATTACHMENTS` (#56).
+   *  Disables the screenshot + file-attach buttons with an explanatory
+   *  aria-label so the user can't queue an attachment the SDK would reject. */
+  attachmentsAtCap: boolean;
   showAiToggle: boolean;
   useAi: boolean;
   onDraftChange: (v: string) => void;
@@ -1017,6 +1163,8 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
     {
       draft,
       submitting,
+      capturing,
+      attachmentsAtCap,
       showAiToggle,
       useAi,
       onDraftChange,
@@ -1055,15 +1203,29 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
       }
     };
 
+    // Once a capture is in flight or the attachment cap is reached, the
+    // screenshot + file-attach controls are disabled. The aria-label on the
+    // screenshot button mutates so AT users hear *why* the control is
+    // unavailable instead of the generic "Capture screenshot of this page,
+    // dimmed" announcement.
+    const attachDisabled = submitting || capturing || attachmentsAtCap;
+    const screenshotLabel = attachmentsAtCap
+      ? `Maximum ${MAX_ATTACHMENTS} attachments reached`
+      : capturing
+        ? 'Capturing screenshot…'
+        : 'Capture screenshot of this page';
+    const fileLabel = attachmentsAtCap
+      ? `Maximum ${MAX_ATTACHMENTS} attachments reached`
+      : 'Attach file';
     return (
       <div className="brw-composer">
         <div className="brw-composer-shell">
           <button
             type="button"
             className="brw-icon-btn"
-            aria-label="Capture screenshot of this page"
+            aria-label={screenshotLabel}
             onClick={onAttachScreenshot}
-            disabled={submitting}
+            disabled={attachDisabled}
           >
             <ScreenshotIcon />
           </button>
@@ -1072,13 +1234,13 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
             <input
               type="file"
               multiple
-              aria-label="Attach file"
+              aria-label={fileLabel}
               className="brw-file-input"
               onChange={(e) => {
                 onAttachFiles(e.target.files);
                 e.target.value = '';
               }}
-              disabled={submitting}
+              disabled={attachDisabled}
             />
           </label>
           <textarea
@@ -1426,6 +1588,83 @@ function RegionCaptureOverlay({
               Capture
             </button>
           </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+interface ScreenshotPreviewDialogProps {
+  open: boolean;
+  /**
+   * The screenshot the dialog should preview. Lifted into a prop (rather
+   * than a `src` string) so the dialog can format its sr-only title from
+   * the same blob metadata the chip uses, keeping the preview-button
+   * `aria-label="Preview <name>"` and the dialog title in sync.
+   *
+   * `null` while the dialog is closed; the `open` prop is the source of
+   * truth for visibility, but Radix mounts the portal regardless so we
+   * defer rendering the `<img>` until a screenshot is actually selected.
+   */
+  screenshot: ScreenshotAttachment | null;
+  theme: BrevwickTheme;
+  onClose: () => void;
+}
+
+/**
+ * Modal dialog that shows the captured screenshot at viewport-fit size so
+ * the submitter can confirm they captured the right region before sending.
+ * Mounted as a sibling Dialog.Root to the panel — same pattern as
+ * `RegionCaptureOverlay` — so Radix owns Esc-to-dismiss, focus trap, and
+ * focus-restore back to the chip's preview button when the dialog closes.
+ *
+ * Carries `data-brevwick-skip=""` on every node so a re-capture initiated
+ * while the dialog is up doesn't snapshot the dialog chrome itself.
+ */
+function ScreenshotPreviewDialog({
+  open,
+  screenshot,
+  theme,
+  onClose,
+}: ScreenshotPreviewDialogProps): ReactElement {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="brw-preview-backdrop"
+          data-brevwick-skip=""
+        />
+        <Dialog.Content
+          className="brw-root brw-preview-layer"
+          data-brevwick-skip=""
+          data-brw-theme={theme}
+          data-testid="brw-preview-dialog"
+          aria-label="Screenshot preview"
+          aria-describedby={undefined}
+        >
+          <Dialog.Title className="brw-sr-only">
+            Screenshot preview
+          </Dialog.Title>
+          {screenshot && (
+            <img
+              className="brw-preview-image"
+              src={screenshot.url}
+              alt="Captured screenshot"
+            />
+          )}
+          <button
+            type="button"
+            className="brw-icon-btn brw-preview-close"
+            aria-label="Close preview"
+            onClick={onClose}
+          >
+            <CloseIcon />
+          </button>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -301,11 +301,13 @@ export function FeedbackButton({
   >([]);
   const [files, setFiles] = useState<readonly FileAttachment[]>([]);
   const [capturing, setCapturing] = useState(false);
-  // Index into `screenshots` of the thumbnail the user tapped to preview;
-  // `null` keeps the preview dialog closed. Storing the id rather than the
-  // index would survive an out-of-band removal, but the chip × is also
-  // disabled while the preview is up so the index is stable for the dialog
-  // lifetime.
+  // Stable screenshot id of the thumbnail the user tapped to preview;
+  // `null` keeps the preview dialog closed. Using the id (not the array
+  // index) means the dialog stays bound to the same attachment if the
+  // user removes a sibling screenshot mid-preview — the lookup
+  // `screenshots.find(s => s.id === previewId)` returns `null` only when
+  // the previewed screenshot itself was removed, which is the case
+  // `removeScreenshot()` handles by clearing `previewId`.
   const [previewId, setPreviewId] = useState<number | null>(null);
   const [confirmClose, setConfirmClose] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -319,6 +321,12 @@ export function FeedbackButton({
   // Mirrors `screenshots[*].url` for the unmount cleanup so we don't have to
   // close over a stale `screenshots` value in the cleanup function.
   const screenshotUrlsRef = useRef<readonly string[]>([]);
+  // Mirror of `files.length`. The cap check inside `performCapture`'s
+  // `setScreenshots` updater needs the **current** file count, not the
+  // closure-captured one — files attached *during* a long-running capture
+  // would otherwise be invisible to the defence-in-depth guard, letting
+  // the cap silently slip from 5 to 6.
+  const filesLengthRef = useRef(0);
   const screenshotIdRef = useRef(0);
   const fileIdRef = useRef(0);
   const messageIdRef = useRef(0);
@@ -350,6 +358,10 @@ export function FeedbackButton({
   useEffect(() => {
     screenshotUrlsRef.current = screenshots.map((s) => s.url);
   }, [screenshots]);
+
+  useEffect(() => {
+    filesLengthRef.current = files.length;
+  }, [files]);
 
   const attachmentCount = screenshots.length + files.length;
   const attachmentsAtCap = attachmentCount >= MAX_ATTACHMENTS;
@@ -435,13 +447,20 @@ export function FeedbackButton({
         if (!mountedRef.current) return;
         const finalBlob = region ? await cropToRegion(blob, region) : blob;
         if (!mountedRef.current) return;
+        let rejectedAtCap = false;
         setScreenshots((prev) => {
           // Defence-in-depth: the screenshot button is disabled at the cap,
-          // but a stale closure or a future race could still land here. Drop
-          // the new capture rather than silently exceed the SDK's combined
+          // but a long-running capture started before files were attached
+          // can still land after the combined total is at the ceiling.
+          // Read the file count from the ref (not the closure) so we see
+          // anything attached while the capture was in flight. Drop the
+          // new capture rather than silently exceed the SDK's combined
           // attachment ceiling. (Object URL is created inside the branch
-          // that keeps the capture so a rejected one doesn't leak.)
-          if (prev.length + files.length >= MAX_ATTACHMENTS) {
+          // that keeps the capture so a rejected one doesn't leak.) The
+          // user-visible message is set after the setState below so the
+          // updater stays pure.
+          if (prev.length + filesLengthRef.current >= MAX_ATTACHMENTS) {
+            rejectedAtCap = true;
             return prev;
           }
           return [
@@ -453,6 +472,9 @@ export function FeedbackButton({
             },
           ];
         });
+        if (rejectedAtCap) {
+          setSubmitError(`Maximum ${MAX_ATTACHMENTS} attachments reached`);
+        }
       } catch (err) {
         if (!mountedRef.current) return;
         const message =
@@ -462,7 +484,7 @@ export function FeedbackButton({
         if (mountedRef.current) setCapturing(false);
       }
     },
-    [captureScreenshot, files.length],
+    [captureScreenshot],
   );
 
   const handleOpenRegionOverlay = useCallback(() => {
@@ -532,6 +554,13 @@ export function FeedbackButton({
 
   const doSubmit = useCallback(async () => {
     if (status === 'submitting') return;
+    // Block submission while a capture is in flight. Without this, the user
+    // could press Enter in the composer between clicking Capture and the
+    // thumbnail rendering, sending the issue without the screenshot they
+    // intended to include. The Send button itself is disabled in this
+    // state, but the Enter-to-send shortcut bypasses the button so the
+    // guard belongs here on the submit path too.
+    if (capturing) return;
     if (!draft.trim()) {
       setSubmitError('Please describe what happened.');
       return;
@@ -652,6 +681,7 @@ export function FeedbackButton({
     }
   }, [
     actual,
+    capturing,
     draft,
     expected,
     files,
@@ -1264,7 +1294,7 @@ const Composer = forwardRef<HTMLTextAreaElement, ComposerProps>(
             type="button"
             className="brw-send-btn"
             aria-label="Send"
-            disabled={submitting || draft.trim().length === 0}
+            disabled={submitting || capturing || draft.trim().length === 0}
             onClick={onSubmit}
           >
             <SendIcon />

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -298,6 +298,25 @@ export const BREVWICK_CSS = `
   object-fit: cover;
   border-radius: 4px;
   flex-shrink: 0;
+  display: block;
+}
+/* Tap-to-preview button wrapping the chip thumbnail (issue #57). The button
+   is just a transparent affordance; its child img carries the visual.
+   inline-flex keeps the image vertically centred against the chip text,
+   and the focus ring lands on the button so keyboard users see the
+   activation target without an outline on the image itself. */
+.brw-chip-preview-btn {
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.brw-chip-preview-btn:focus-visible {
+  outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+  outline-offset: 2px;
 }
 .brw-chip-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
 .brw-chip-size { color: var(--brw-fg-muted, var(--brw-fg-muted-base)); }
@@ -586,6 +605,46 @@ export const BREVWICK_CSS = `
   0%, 100% { transform: translateX(0); }
   25% { transform: translateX(-4px); }
   75% { transform: translateX(4px); }
+}
+/* Screenshot preview dialog (issue #57). Sits above the panel and the
+   region overlay z-stack so the dialog is always on top when triggered
+   from a chip in the panel. The image is contain-bounded to 90vw / 80vh
+   so a tall full-page capture stays readable and a small region capture
+   isn't upscaled past its native pixels. */
+.brw-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 2147483006;
+}
+.brw-preview-layer {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2147483007;
+  outline: none;
+}
+.brw-preview-image {
+  max-width: 90vw;
+  max-height: 80vh;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: var(--brw-shadow, var(--brw-shadow-base));
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+}
+.brw-preview-close {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  box-shadow: var(--brw-shadow, var(--brw-shadow-base));
 }
 @media (prefers-reduced-motion: reduce) {
   .brw-region-shake { animation: none; }


### PR DESCRIPTION
## Summary

Three feedback-panel UX fixes in one PR; together they make the screenshot flow legible end-to-end.

- **#55 — In-flight capture indicator.** Adds a `capturing` state and surfaces a "Capturing screenshot…" bubble in the thread between the region-overlay closing and the thumbnail rendering. Composer's screenshot + file-attach controls are disabled while a capture is in flight so a second click can't stack on top of the first. The panel was already visible during this window (the overlay closes before `captureScreenshot()` resolves) — the bubble fills the silent gap that previously left users unsure whether anything was happening.
- **#56 — Multiple screenshots per submission.** Promotes the composer's `screenshot: ScreenshotAttachment | null` to `screenshots: readonly ScreenshotAttachment[]` with stable monotonic ids (mirrors the existing `FileAttachment` pattern). Cap is the SDK's `MAX_ATTACHMENT_COUNT = 5`, applied to the combined screenshot+file total — once reached, both attach buttons disable with an explanatory `aria-label`. Single-screenshot submissions keep the historical `screenshot.<ext>` wire filename; multi-screenshot submissions disambiguate as `screenshot-1.<ext>`, `screenshot-2.<ext>`, in capture order. File bulk-adds via `<input multiple>` truncate to the remaining slots instead of silently overflowing the SDK ceiling.
- **#57 — Tap thumbnail to preview.** Wraps the screenshot chip's `<img>` in a `<button>` (free keyboard activation on Enter/Space) that opens a Radix `Dialog` preview of the full-size image. Esc, the close button, and the backdrop dismiss; focus restores to the chip on close. The chip's × remove stays a sibling element so it never opens the preview, and removing the screenshot whose preview is up auto-closes the dialog.

Closes #55, #56, #57.

## Bundle impact

- `@tatlacas/brevwick-sdk` eager chunk: 2115 / 2200 B gzip ✓
- `@tatlacas/brevwick-react` bundle: 10681 / 25000 B gzip ✓

No new runtime dependencies — preview dialog uses the existing `@radix-ui/react-dialog` already in the bundle (same nested-Dialog pattern as `RegionCaptureOverlay`).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — both packages, both example apps build
- [x] `pnpm test` — 204 SDK + 121 React tests pass (8 new tests for the multi-screenshot / loading / preview behaviour)
- [x] Bundle-size guards (`bundle-size.test.ts`, `chunk-split.test.ts`) green against built `dist/`
- [ ] Smoke-test in the `examples/next` host: capture two screenshots, tap each thumbnail to preview, send, confirm both attachments arrive