### PR TITLE
feat(react): staged-status feedback widget UX

### DIFF
--- a/.changeset/staged-status-feedback-ux.md
+++ b/.changeset/staged-status-feedback-ux.md
@@ -1,0 +1,37 @@
+---
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-sdk': minor
+---
+
+feat(react): staged-status feedback widget UX (#74)
+
+Pressing **Send** in the React feedback widget now clears the input and
+moves the typed value into the conversation thread synchronously, then
+animates a sequence of staged status rows through to the assistant
+receipt: **Captured route, console, network, device** → **PII-sanitised,
+packaged** → **Formatting with AI…**.
+
+The submit pipeline drives the rows via a new internal `phase` event on
+`@tatlacas/brevwick-sdk`'s ring bus (`'capturing-done' | 'sanitising-done'
+| 'sent'`) — emitted at the `composePayload` / `redact()` / ingest-2xx
+boundaries. The event is **internal-only**: not exposed on the public
+SDK surface; framework adapters reach it through the existing
+`_internal` backdoor.
+
+`useFeedback()` gains:
+
+- `phase`: `'idle' | 'capturing' | 'sanitising' | 'formatting' | 'sent'
+  | 'error'` — backwards-compatible alongside the existing `status`.
+- `error`: tagged `SubmitError | null` from the most recent failed
+  submit.
+- `retry()`: re-runs the most recent `submit()` with the same input.
+
+The "Formatting with AI…" row is gated on `getConfig().ai_enabled === true`
+so non-AI projects don't claim work the SDK isn't doing. Reduced motion
+(`prefers-reduced-motion: reduce`) collapses the cascade to a flat fade.
+On failure, the in-progress rows collapse to a red retry row carrying
+the `SubmitError.message` verbatim plus a one-click **Retry** CTA, for
+every `SubmitErrorCode` the submit pipeline can produce.
+
+Bundle: React adapter ESM 11.92 kB / CJS 12.3 kB (limit 25 kB). SDK core
+eager 2.13 kB / 2.14 kB (limit 2.2 kB).

--- a/.changeset/staged-status-feedback-ux.md
+++ b/.changeset/staged-status-feedback-ux.md
@@ -21,7 +21,7 @@ SDK surface; framework adapters reach it through the existing
 `useFeedback()` gains:
 
 - `phase`: `'idle' | 'capturing' | 'sanitising' | 'formatting' | 'sent'
-  | 'error'` — backwards-compatible alongside the existing `status`.
+| 'error'` — backwards-compatible alongside the existing `status`.
 - `error`: tagged `SubmitError | null` from the most recent failed
   submit.
 - `retry()`: re-runs the most recent `submit()` with the same input.

--- a/notes/reviews/pr-80-claude-review.md
+++ b/notes/reviews/pr-80-claude-review.md
@@ -1,0 +1,128 @@
+# PR #80 Review — feat(react): staged-status feedback widget UX
+
+**Issue**: #74 — feat(react): clear input on send + staged status (Captured / Sanitised / Formatting)
+**Branch**: feat/landing-parity-react
+**Reviewed**: 2026-05-01
+**Verdict**: CHANGES REQUIRED
+
+A single dead-code defect (clean-code non-negotiable) blocks approval. Everything else is sound: architecture is clean, the public SDK surface is unchanged, the chunk split holds (`chunk-split.test.ts` already enforces no submit error literals leak into the eager chunk), tests cover the contract end-to-end, and CI is green. The defect is one line and trivial to fix.
+
+## Completeness (NON-NEGOTIABLE)
+
+- [x] Acceptance criteria from #74 — all six implemented (input clears on Send, three staged rows, AI-row gate, red retry row covering all five `SubmitErrorCode`s, `prefers-reduced-motion` collapse, bundle budgets respected).
+- [x] SDD § 12 contract honoured — `phase` event lives on the internal `_internal.bus` and is not re-exported from `packages/sdk/src/index.ts:1-31`.
+- [x] React README updated with a state-machine table, AI-row gate, reduced-motion contract, and retry contract (`packages/react/README.md:398-415`).
+- [x] Changeset present with both packages bumped minor (`.changeset/staged-status-feedback-ux.md`).
+- [x] No stubs / placeholders / "follow-up" markers in the diff.
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] `@tatlacas/brevwick-sdk` stays React-free — `submit.ts` and `core/internal.ts` add only typed primitives and a bus emit; no React, DOM-specific, or Node-only imports leak in.
+- [x] `phase` event is intentionally NOT re-exported from `packages/sdk/src/index.ts` — confirmed by inspection (lines 1-31 only export `createBrevwick` plus the public `*` types).
+- [x] `PhaseEvent` is replicated in `packages/react/src/internal-bridge.ts:10-13` rather than imported from the SDK's deep path. This is the right call given the SDK does not expose internal types — and the lockstep monorepo means drift is caught by the React tests + the SDK integration test.
+- [x] `internal-bridge.ts:36-45` performs strict structural guards (`typeof internal/bus === 'object'`, `typeof on/off === 'function'`) and returns `null` on misshapen mocks. Adapter does not crash on a non-stamped `Brevwick`-shaped object.
+- [x] React bindings depend on the SDK, never the reverse. `packages/sdk/package.json` has no React dep.
+- [x] `getConfig` cache refactor (`packages/sdk/src/core/client.ts:56-68, 93, 194`) — single `loadConfig` thunk shared by both `instance.getConfig()` and `internal.getConfig()`. Memoised via `configPromise`; concurrent callers collapse to one network round-trip; chunk-load failure is caught with `.catch(() => null)` so a transient failure doesn't poison the cache. Verified no double-fetch.
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] **`packages/react/src/feedback-button.tsx:1090`** — replaced `delayMs={reducedMotion ? 0 : 0}` with `delayMs={0}` plus a one-line WHY comment ("Row 1 anchors the cascade at 0 ms; rows 2 and 3 stagger off it.").
+- [x] All public exports carry JSDoc; comments throughout explain WHY (cache shape, race semantics, SSR fallbacks), not WHAT.
+- [x] No `any`, no unsafe casts beyond the documented `_internal` backdoor cast in `internal-bridge.ts:37` (necessary; documented).
+- [x] `PHASE_EVENT_TO_NEXT_PHASE` (`use-feedback.ts:78-82`) and `PHASE_RANK` (`feedback-button.tsx:966-973`) are declared once at module scope — no inline re-creation in render.
+- [x] `void status;` at `feedback-button.tsx:1009` — fixed end-to-end: dropped `status: FeedbackStatus` from `ThreadProps`, removed it from the `Thread` destructure, removed `void status;`, removed `status={status}` from the `<Thread />` callsite, and dropped the now-unused `FeedbackStatus` type import. Parent component still consumes `useFeedback`'s `status` for composer/panel-header.
+- [x] `RetryRow` and `StatusRow` are small, single-purpose, and parameterised cleanly.
+- [x] `feedback-button.tsx:717` and `:763` use `void err;` to consume the caught error. Acceptable — the hook has already mapped the rejection into a tagged `SubmitError` and called `setPhase('error')`; the catch site only needs to pop the panel back open.
+- [x] `doRetry` snapshots `lastSubmittedInputRef.current` (`feedback-button.tsx:740-766`) and re-runs the submit with the original `FeedbackInput`. Correct semantics — composer state was cleared synchronously on Send so resubmitting from current state would send empty.
+
+## Public API & Types
+
+- [x] `FeedbackPhase`, `FeedbackStatus`, `UseFeedbackResult` exported from `packages/react/src/index.ts:18-21` — narrow, documented, discriminated.
+- [x] `error: SubmitError | null` is a tagged union from the SDK; `retry()` returns `Promise<SubmitResult | undefined>` (undefined when no submit has been attempted). Discriminator is correct.
+- [x] No breaking changes — `status` is preserved alongside `phase`; existing callers continue to work. Both packages bumped minor in the changeset (correct under pre-1.0 conventions in `CLAUDE.md`).
+- [x] `BusEventMap` extension in `core/internal.ts:45-48` is internal-only — not in the public `exports` field of `packages/sdk/package.json`.
+- [x] `PhaseEvent` is a discriminated union keyed on `phase` — `'sent'` carries `aiEnabled`, the other two carry no payload. Clean.
+
+## Cross-Runtime Safety
+
+- [x] `usePrefersReducedMotion()` (`feedback-button.tsx:147-154`) reads `window.matchMedia` only inside `useEffect`, returns `false` when `window === undefined` or `matchMedia` is missing. SSR-safe.
+- [x] `submit.ts:581` calls `internal.getConfig()` which is the cached `loadConfig` thunk — works in browser + Node + edge. The `import('../config')` dynamic import is the existing path; no new runtime assumptions.
+- [x] `phase` events are emitted on the in-process bus — no DOM/window dependency in the SDK.
+- [x] `internal-bridge.ts` reads `_internal` via a typed cast on the `Brevwick` instance; no globals touched.
+
+## Bugs & Gaps
+
+- [x] **Phase-on-failure invariant** — `useFeedback` `runSubmit` at `use-feedback.ts:128-148` populates `error: SubmitError` on BOTH paths: `result.ok === false` (lines 130-133) and the `catch` clause for chunk-load failure (lines 141-148, synthesised as `INGEST_RETRY_EXHAUSTED`). The `RetryRow` guard (`feedback-button.tsx:1017`) reads `phase === 'error' && submitErrorTagged !== null`, so the row never renders without a non-null tagged error. Holds.
+- [x] **Bus listener cleanup** — `use-feedback.ts:113-116` returns the cleanup that flips `aliveRef.current = false` AND calls `bus.off('phase', onPhase)`. Correct ordering. Strict-mode double-mount: the effect runs mount → unmount → remount; on each remount `aliveRef.current = true` is re-set on the next line (105). One subtle bug: if the bus listener fires AFTER unmount but BEFORE the next remount (impossible inside a synchronous strict-mode pair, but possible if the SDK ever calls back across an async boundary), it correctly short-circuits via `aliveRef.current === false`. Looks sound.
+- [x] **Bus-null path** — `use-feedback.ts:106-107` early-returns when `getPhaseBus` resolves to `null` (e.g. test mock without `_internal`). The cleanup function isn't returned in this branch, so React simply has no teardown — no leak. Correct.
+- [x] **Stale-closure in `onPhase`** — `setPhase(PHASE_EVENT_TO_NEXT_PHASE[event.phase])` uses the functional setter via the immediate next state value derived from the event. No closure over `phase` itself. Correct.
+- [x] **`'sent'` phase race** — when `phase: 'sent'` arrives via the bus, the listener flips `phase` to `'sent'`, which makes `showFormatting` false in `Thread` (the AI spinner row hides the moment the pipeline lands). Captured + Sanitised stay visible (rank-based gate). Matches the spec.
+- [x] **Submit-without-widget cost** — `submit.ts:581` triggers a config fetch when one hasn't been done. For non-widget consumers calling `instance.submit()` directly without ever calling `instance.getConfig()` first, this is one extra network round-trip per session. The cache then sticks for the lifetime of the instance. The contract is documented (`internal.ts:79-86`: "resolves to `null` on any failure"). Worth noting in the changeset / docs but not a blocker.
+- [x] **`bus.clear()` on uninstall** — `core/client.ts:172` clears all listeners on uninstall. The React adapter's `useEffect` cleanup runs before the SDK uninstalls (provider unmount order), so the adapter unsubscribes itself. The `bus.clear()` is defence-in-depth.
+- [x] **AbortSignal / timeouts** — submit pipeline retains its `TOTAL_BUDGET_MS = 30_000` controller and `clearTimeout` in `finally`. Phase emits do not introduce new long-running async paths.
+- [x] No memory leaks: `screenshotUrlsRef` cleanup unchanged; `aliveRef` flip on unmount; bus listener removed via cleanup return.
+
+## Security
+
+- [x] `redact()` runs over `composePayload` body before `'sanitising-done'` fires — no PII leaks past the sanitise boundary in the emitted phase signal (the event itself carries no payload beyond `aiEnabled` for `'sent'`).
+- [x] `RetryRow` renders `error.message` verbatim. Server-echoed bodies are run through `redact(raw.slice(0, 256))` in `submit.ts:392`, so a misbehaving server cannot reflect Bearer tokens or PII into the rendered alert.
+- [x] No `eval`, `new Function()`, `dangerouslySetInnerHTML`, or inline script injection introduced.
+- [x] No secrets in code. No new globals.
+- [x] `data-brw-error-code` attribute exposes the `SubmitErrorCode` enum value to the DOM — fine; these are public enum members in the SDK's exported types.
+
+## Tests
+
+- [x] `packages/sdk/src/__tests__/integration/phase-events.test.ts` — three integration tests asserting (a) emit ordering on happy path, (b) `aiEnabled=false` on non-AI projects, (c) `'sent'` does NOT fire on 4xx. Drives through the real `createBrevwick` → install → submit pipeline with MSW handlers.
+- [x] `packages/react/src/__tests__/feedback-button.test.tsx:2743-2907` — staged-status describe block:
+  - Pressing Send clears input + renders user bubble synchronously (no `act` wrapper, asserted before any await).
+  - Three rows render in sequence as phase events arrive (rank-based visibility verified).
+  - AI row suppressed when `ai_enabled=false`; the test correctly waits for `getConfig()` to resolve before driving phases (avoids the false positive flagged in the PR description).
+  - Reduced motion folds every row to `transitionDelay: 0ms` — verified via `vi.stubGlobal('matchMedia', ...)` + querying `[data-brw-row]`.
+  - `it.each` over all five `SubmitErrorCode`s asserts the red retry row carries the verbatim message + `role="alert"` + `data-brw-error-code` AND the Retry CTA re-runs `submit()` with the original `FeedbackInput` (`(submit.mock.calls[1]![0] as { description }).description` matches the original `failure-${code}` typed string).
+- [x] In-memory `phaseBus` mock (`feedback-button.test.tsx:36-54`) is structurally compatible with the React adapter's `getPhaseBus` guards. Stamped on the `Brevwick` mock at line 69 via `_internal: { bus: phaseBus }`.
+- [x] Rewritten "submit rejects" test (line 803) replaces the legacy "draft preserved" assertion with the new contract: composer cleared, retry CTA appears, retry resubmits with the original input. Rewrite is sound — matches the issue spec verbatim.
+- [x] Existing `role="alert"`-based failure tests at `:325` and `:360` continue to pass because `RetryRow` carries `role="alert"` and renders `error.message` verbatim. Backwards compat preserved at the assertion level.
+- [x] Phase-event integration test at `phase-events.test.ts:118-156` explicitly asserts the failure path stops at `'sanitising-done'` — no `'sent'` on 4xx.
+- [x] Coverage: codecov/patch and codecov/project both pass (`gh pr checks 80`).
+
+## Build & Bundle
+
+- [x] CI checks all green: `check`, `check`, `codecov/patch`, `codecov/project`, `size-check`, `verify-signatures`.
+- [x] Eager SDK chunk: 2.13 kB / 2.14 kB ESM/CJS (limit 2.2 kB) per the PR body — within margin.
+- [x] React adapter: 11.92 kB / 12.3 kB (limit 25 kB) — well under.
+- [x] `chunk-split.test.ts:60-67` already enforces that none of the five `SubmitErrorCode` literals leak into the eager chunk. Phase-emit code added to `submit.ts` rides the existing submit chunk; this test is the proper guard.
+- [x] `package.json` `exports` field unchanged for both packages — no new public entry points.
+- [x] Tree-shaking: the new exports (`FeedbackPhase`, `useFeedback` extensions) are pure type / hook additions, no top-level side effects introduced.
+
+## PR Hygiene
+
+- [x] Title is conventional: `feat(react): staged-status feedback widget UX`.
+- [x] Body references `Closes #74` + the mis-filed `tatlacas-com/brevwick-web#143`.
+- [x] No Claude attribution anywhere — verified across commits, PR title, body, code comments, changeset.
+- [x] Branch name `feat/landing-parity-react` — matches the initiative documented in `landing-parity-worktree.md`.
+- [x] Changeset entry present with appropriate minor bumps for both packages (lockstep, pre-1.0).
+
+## Files Reviewed
+
+| file                                                          | status      | notes                                                                                                  |
+| ------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `.changeset/staged-status-feedback-ux.md`                     | OK          | Minor bumps for both packages; release-note copy is accurate.                                          |
+| `packages/react/README.md`                                    | OK          | New "Submit-pipeline state machine" section + AI-row + reduced-motion + retry contracts documented.    |
+| `packages/react/src/__tests__/feedback-button.test.tsx`       | OK          | Five new staged-status tests; rewritten failure test matches the new contract; `it.each` covers all 5 codes. |
+| `packages/react/src/feedback-button.tsx`                      | CHANGES REQ | Line 1090 `delayMs={reducedMotion ? 0 : 0}` is a dead-code ternary. `void status;` (line 1009) is a tidiness flag. Otherwise correct. |
+| `packages/react/src/index.ts`                                 | OK          | New `FeedbackPhase` + `UseFeedbackResult` re-exports.                                                  |
+| `packages/react/src/internal-bridge.ts`                       | OK          | Strict structural guards; null return path handled.                                                    |
+| `packages/react/src/styles.ts`                                | OK          | `.brw-status-row` class family does not extend `.brw-bubble` (deliberate — keeps integration-test bubble counts stable). Reduced-motion override present. |
+| `packages/react/src/use-feedback.ts`                          | OK          | Bus subscription correct; cleanup returns proper teardown; aliveRef + null-bus paths handled.          |
+| `packages/sdk/src/__tests__/integration/phase-events.test.ts` | OK          | Three integration tests — ordering, aiEnabled flag, no-`sent`-on-4xx.                                  |
+| `packages/sdk/src/core/client.ts`                             | OK          | Single `loadConfig` thunk shared by `instance.getConfig` + `internal.getConfig`; no double-fetch.      |
+| `packages/sdk/src/core/internal.ts`                           | OK          | `phase` event added to `BusEventMap`; `getConfig()` added to `BrevwickInternal`. Internal-only — not re-exported. |
+| `packages/sdk/src/submit.ts`                                  | OK          | Phase emits at the right boundaries; `'sent'` gated on `result.ok`; chunk-split test still enforces no error literal leak. |
+
+## Required Fix Summary
+
+One change required:
+
+1. **`packages/react/src/feedback-button.tsx:1090`** — Replace `delayMs={reducedMotion ? 0 : 0}` with `delayMs={0}` (the first row has no stagger by design, regardless of reduced-motion). Optionally drop the now-unused `status` prop from `ThreadProps` and its callsite (line 818) instead of `void status;` at line 1009.
+
+Bundle, tests, architecture, public surface, redaction, retry semantics, and AI-row gate all hold. The defect is mechanical and safe to fix in-place.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -383,14 +383,36 @@ function MyCustomReporter() {
 
 ### Return value
 
-| Field               | Type                                              | Description                                                                      |
-| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union `@tatlacas/brevwick-sdk` returns. |
-| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a DOM screenshot. Never throws — returns a placeholder on failure.       |
-| `status`            | `'idle' \| 'submitting' \| 'success' \| 'error'`  | Current submission lifecycle.                                                    |
-| `reset`             | `() => void`                                      | Reset `status` back to `'idle'`. Does not cancel an in-flight submit.            |
+| Field               | Type                                              | Description                                                                                              |
+| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union `@tatlacas/brevwick-sdk` returns.                         |
+| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a DOM screenshot. Never throws — returns a placeholder on failure.                               |
+| `status`            | `FeedbackStatus`                                  | `'idle' \| 'submitting' \| 'success' \| 'error'`. Backwards-compatible lifecycle.                        |
+| `phase`             | `FeedbackPhase`                                   | Submit-pipeline phase driven by the SDK's internal phase event — see "Submit-pipeline state machine".    |
+| `error`             | `SubmitError \| null`                             | Tagged error from the most recent failed submit. Cleared on the next `submit()` / `retry()` / `reset()`. |
+| `retry`             | `() => Promise<SubmitResult \| undefined>`        | Re-run the most recent `submit()` with the same input. No-op when no submit has been attempted.          |
+| `reset`             | `() => void`                                      | Reset `status` + `phase` back to `'idle'`, clear `error`, and forget the last submitted input.           |
 
 Throws synchronously on mount when rendered outside a `BrevwickProvider`.
+
+### Submit-pipeline state machine
+
+The built-in `<FeedbackButton />` (and any UI you build on top of `useFeedback`) animates a staged-status flow against the submit pipeline. Pressing **Send** clears the input and pushes the typed value into a user bubble immediately — the wait is filled with three assistant rows that tick through as the SDK reaches each pipeline boundary.
+
+| Phase          | Trigger                                                                              | Visible row                                                                               |
+| -------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `'idle'`       | Initial state and after `reset()`.                                                   | —                                                                                         |
+| `'capturing'`  | `submit()` was called; no SDK phase event has fired yet.                             | —                                                                                         |
+| `'sanitising'` | SDK emitted `phase: 'capturing-done'` (payload composed, buffer snapshots landed).   | ✓ "Captured route, console, network, device"                                              |
+| `'formatting'` | SDK emitted `phase: 'sanitising-done'` (`redact()` complete, ingest POST in flight). | ✓ "PII-sanitised, packaged"; "Formatting with AI…" with spinner if the project has AI on. |
+| `'sent'`       | SDK emitted `phase: 'sent'` after a 2xx ingest response.                             | ✓ "Captured…" + ✓ "PII-sanitised…" (the AI row hides on `'sent'`).                        |
+| `'error'`      | `submit()` resolved with `{ ok: false, error }` or rejected (chunk-load failure).    | Red retry row carrying the `SubmitError.message` verbatim + a one-click **Retry** CTA.    |
+
+**AI-row gate.** The "Formatting with AI…" spinner row is gated on `getConfig().ai_enabled === true`. On non-AI projects the row is suppressed entirely so the widget never claims work it isn't doing.
+
+**Reduced motion.** When the user has `prefers-reduced-motion: reduce` set, the widget reads `window.matchMedia('(prefers-reduced-motion: reduce)').matches` at render time and renders every row with `transitionDelay: 0ms`, collapsing the cascade flat.
+
+**Retry contract.** A submit failure surfaces as a red retry row inside the conversation thread (`role="alert"`). Clicking **Retry** re-submits the original `FeedbackInput` (including any captured screenshots) — the user does not need to re-type the draft.
 
 ## `BREVWICK_REACT_VERSION`
 
@@ -416,6 +438,7 @@ import type {
   BrevwickProviderProps,
   FeedbackButtonProps,
   BrevwickTheme,
+  FeedbackPhase,
   FeedbackStatus,
   UseFeedbackResult,
   // from @tatlacas/brevwick-sdk, re-exported for convenience:

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -26,6 +26,33 @@ const getConfig = vi.fn<() => Promise<ProjectConfig | null>>();
 const install = vi.fn();
 const uninstall = vi.fn();
 
+/**
+ * In-memory mirror of the SDK's internal phase bus. The React adapter
+ * subscribes to this via the `_internal` backdoor (see
+ * `src/internal-bridge.ts`), so the test mock stamps a structurally
+ * compatible bus on the `Brevwick` instance and the suite drives phase
+ * events through `phaseBus.emit(...)`.
+ */
+type PhaseEventPayload =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+const phaseListeners = new Set<(p: PhaseEventPayload) => void>();
+const phaseBus = {
+  on: (event: 'phase', listener: (p: PhaseEventPayload) => void) => {
+    void event;
+    phaseListeners.add(listener);
+  },
+  off: (event: 'phase', listener: (p: PhaseEventPayload) => void) => {
+    void event;
+    phaseListeners.delete(listener);
+  },
+  emit: (event: 'phase', payload: PhaseEventPayload) => {
+    void event;
+    for (const listener of [...phaseListeners]) listener(payload);
+  },
+};
+
 vi.mock('@tatlacas/brevwick-sdk', async () => {
   const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
     '@tatlacas/brevwick-sdk',
@@ -39,6 +66,7 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
         submit,
         captureScreenshot,
         getConfig,
+        _internal: { bus: phaseBus },
       }) as unknown as Brevwick,
   };
 });
@@ -69,6 +97,7 @@ afterEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  phaseListeners.clear();
 });
 
 const mount = (props: FeedbackButtonProps = {}) =>
@@ -771,7 +800,12 @@ describe('<FeedbackButton>', () => {
     });
   });
 
-  it('submit rejects → × shows the discard confirm with the draft still populated', async () => {
+  it('submit rejects → composer is empty (draft consumed) and the retry CTA is wired to re-submit (#74)', async () => {
+    // The pre-#74 contract was "preserve the draft on failure so the user
+    // can edit + retry". The #74 contract clears the input synchronously
+    // on Send and routes recovery through the retry row instead — the
+    // user's text lives in the conversation thread, the failed-submit
+    // state offers a one-click Retry rather than a discard confirm.
     submit.mockRejectedValueOnce(new Error('ingest down'));
     mount();
     openPanel();
@@ -779,19 +813,31 @@ describe('<FeedbackButton>', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     });
-    // Status is back to 'error', close should no longer be disabled.
+
+    // The retry row carries the SubmitError message verbatim (the chunk-
+    // load failure is mapped to INGEST_RETRY_EXHAUSTED inside the hook).
     expect(
       screen.getByText(/ingest down/i, { selector: '[role="alert"]' }),
     ).toBeInTheDocument();
+    // Composer was cleared on click — recovery is via Retry, not by
+    // re-typing the draft.
+    expect(getComposer().value).toBe('');
 
-    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
-    const confirm = screen.getByRole('alert', {
-      name: /discard draft/i,
+    // Retry CTA re-runs `submit()` with the same input. The second call
+    // is mocked to succeed so the assistant receipt lands.
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_retry' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^retry$/i }));
     });
-    expect(confirm).toBeInTheDocument();
-    // Keep → the draft is still in the composer.
-    fireEvent.click(within(confirm).getByRole('button', { name: /keep/i }));
-    expect(getComposer().value).toBe('will fail');
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(
+      (submit.mock.calls[1]![0] as { description: string }).description,
+    ).toBe('will fail');
+    await waitFor(() =>
+      expect(
+        screen.getByText(/thanks — your issue is on its way/i),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('Enter+Ctrl/Meta/Alt does not submit (reserved for platform shortcuts)', async () => {
@@ -2685,6 +2731,180 @@ describe('<FeedbackButton> — region capture overlay', () => {
     expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(beforeUnmount);
     clearTimeoutSpy.mockRestore();
   });
+});
+
+/**
+ * Staged-status UX (issue #74). Pressing Send moves the typed value into
+ * a user bubble + clears the input synchronously, then the SDK's
+ * pipeline phase events drive a sequence of staged status rows
+ * (Captured → Sanitised → Formatting with AI). Failure collapses the
+ * in-progress row to a red retry row covering every SubmitErrorCode.
+ */
+describe('<FeedbackButton> staged-status UX (#74)', () => {
+  /**
+   * Park `submit()` on a never-resolving promise so the assertions below
+   * the click run while phase = 'capturing' (nothing else has fired yet)
+   * and we can drive phase events explicitly per test.
+   */
+  function parkSubmit(): void {
+    submit.mockReturnValueOnce(new Promise<SubmitResult>(() => undefined));
+  }
+
+  function getStatusRow(
+    name: 'captured' | 'sanitised' | 'formatting' | 'error',
+  ): HTMLElement | null {
+    return document.querySelector<HTMLElement>(`[data-brw-row="${name}"]`);
+  }
+
+  it('Pressing Send clears the input + renders user bubble immediately (before any await)', () => {
+    parkSubmit();
+    mount();
+    openPanel();
+    typeDraft('synchronous-send-test');
+    // No `act` wrapper: the per-test contract is that the visible state
+    // BEFORE the async submit microtask resolves is already correct.
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(getComposer().value).toBe('');
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(within(log).getByText('synchronous-send-test')).toBeInTheDocument();
+  });
+
+  it('Three staged rows render in order as phase events arrive', async () => {
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    typeDraft('staged-rows-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    // Phase = 'capturing' — none of the three rows are visible yet.
+    expect(getStatusRow('captured')).toBeNull();
+    expect(getStatusRow('sanitised')).toBeNull();
+    expect(getStatusRow('formatting')).toBeNull();
+
+    // capturing-done → row 1 mounts; row 2 + row 3 still hidden.
+    await act(async () => {
+      phaseBus.emit('phase', { phase: 'capturing-done' });
+    });
+    expect(getStatusRow('captured')).not.toBeNull();
+    expect(getStatusRow('sanitised')).toBeNull();
+    expect(getStatusRow('formatting')).toBeNull();
+
+    // sanitising-done → row 2 mounts; row 3 still hidden.
+    await act(async () => {
+      phaseBus.emit('phase', { phase: 'sanitising-done' });
+    });
+    expect(getStatusRow('captured')).not.toBeNull();
+    expect(getStatusRow('sanitised')).not.toBeNull();
+    expect(getStatusRow('formatting')).not.toBeNull();
+  });
+
+  it('AI row is suppressed when getConfig().ai_enabled === false', async () => {
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: false,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    // Wait for getConfig() to resolve before driving phases — the AI-row
+    // gate reads `projectConfig.config?.ai_enabled` and would default to
+    // false until the panel-open fetch lands. This guards against a
+    // false positive where the row would have been suppressed simply
+    // because the config hadn't loaded yet.
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+
+    typeDraft('non-ai-project');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await act(async () => {
+      phaseBus.emit('phase', { phase: 'capturing-done' });
+      phaseBus.emit('phase', { phase: 'sanitising-done' });
+    });
+
+    expect(getStatusRow('captured')).not.toBeNull();
+    expect(getStatusRow('sanitised')).not.toBeNull();
+    // The pipeline reached the 'formatting' phase but the AI row is
+    // gated on `ai_enabled === true`, so it must not render.
+    expect(getStatusRow('formatting')).toBeNull();
+  });
+
+  it('Reduced motion renders all rows with a 0 ms transition delay (no stagger)', async () => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }));
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    typeDraft('reduced-motion-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await act(async () => {
+      phaseBus.emit('phase', { phase: 'capturing-done' });
+      phaseBus.emit('phase', { phase: 'sanitising-done' });
+    });
+
+    // Every visible status row must carry transitionDelay: 0ms — the
+    // adapter folds the 200 ms cascade flat under prefers-reduced-motion.
+    const rows = document.querySelectorAll<HTMLElement>('[data-brw-row]');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.style.transitionDelay).toBe('0ms');
+    }
+  });
+
+  it.each([
+    'ATTACHMENT_UPLOAD_FAILED',
+    'INGEST_REJECTED',
+    'INGEST_RETRY_EXHAUSTED',
+    'INGEST_TIMEOUT',
+    'INGEST_INVALID_RESPONSE',
+  ] as const)(
+    'renders a red retry row with the verbatim message + working Retry CTA on %s',
+    async (code) => {
+      const message = `synthetic-${code}-message`;
+      submit.mockResolvedValueOnce({
+        ok: false,
+        error: { code, message },
+      });
+      mount();
+      openPanel();
+      typeDraft(`failure-${code}`);
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+      });
+
+      const row = getStatusRow('error');
+      expect(row).not.toBeNull();
+      expect(row).toHaveAttribute('role', 'alert');
+      expect(row).toHaveAttribute('data-brw-error-code', code);
+      expect(row?.textContent).toContain(message);
+
+      // Retry click re-runs `submit()` with the same FeedbackInput. The
+      // second call is mocked to succeed so the assistant receipt lands.
+      submit.mockResolvedValueOnce({ ok: true, issue_id: `rep_retry_${code}` });
+      await act(async () => {
+        fireEvent.click(within(row!).getByRole('button', { name: /^retry$/i }));
+      });
+      expect(submit).toHaveBeenCalledTimes(2);
+      expect(
+        (submit.mock.calls[1]![0] as { description: string }).description,
+      ).toBe(`failure-${code}`);
+    },
+  );
 });
 
 /**

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -23,11 +23,7 @@ import type {
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
 import { useBrevwickInternal } from './context';
-import {
-  useFeedback,
-  type FeedbackPhase,
-  type FeedbackStatus,
-} from './use-feedback';
+import { useFeedback, type FeedbackPhase } from './use-feedback';
 import {
   BREVWICK_CSS,
   BREVWICK_STYLE_ID,
@@ -815,7 +811,6 @@ export function FeedbackButton({
             actual={actual}
             confirmClose={confirmClose}
             submitError={submitError}
-            status={status}
             phase={phase}
             submitErrorTagged={submitErrorTagged}
             aiEnabled={projectConfig.config?.ai_enabled === true}
@@ -941,7 +936,6 @@ interface ThreadProps {
   actual: string;
   confirmClose: boolean;
   submitError: string | null;
-  status: FeedbackStatus;
   phase: FeedbackPhase;
   submitErrorTagged: SubmitError | null;
   aiEnabled: boolean;
@@ -991,7 +985,6 @@ function Thread({
   actual,
   confirmClose,
   submitError,
-  status,
   phase,
   submitErrorTagged,
   aiEnabled,
@@ -1006,7 +999,6 @@ function Thread({
   onConfirmDiscard,
   onCancelClose,
 }: ThreadProps): ReactElement {
-  void status;
   const phaseRank = PHASE_RANK[phase];
   const showCaptured = phaseRank >= PHASE_RANK.sanitising;
   const showSanitised = phaseRank >= PHASE_RANK.formatting;
@@ -1087,7 +1079,8 @@ function Thread({
       {showCaptured && (
         <StatusRow
           variant="check"
-          delayMs={reducedMotion ? 0 : 0}
+          // Row 1 anchors the cascade at 0 ms; rows 2 and 3 stagger off it.
+          delayMs={0}
           dataRow="captured"
         >
           Captured route, console, network, device

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -19,10 +19,15 @@ import type {
   FeedbackAttachment,
   FeedbackInput,
   ProjectConfig,
+  SubmitError,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
 import { useBrevwickInternal } from './context';
-import { useFeedback, type FeedbackStatus } from './use-feedback';
+import {
+  useFeedback,
+  type FeedbackPhase,
+  type FeedbackStatus,
+} from './use-feedback';
 import {
   BREVWICK_CSS,
   BREVWICK_STYLE_ID,
@@ -129,6 +134,25 @@ const useIsomorphicLayoutEffect =
  * robust under Fast Refresh / HMR (which would otherwise read a stale
  * module-level flag against a teardown'd style node).
  */
+/**
+ * Read `prefers-reduced-motion: reduce` once at mount. The widget keys row
+ * stagger off this so a user with the OS-level reduced-motion setting sees
+ * all status rows mount at once instead of cascading in.
+ *
+ * Read at mount only — the spec is an at-render snapshot, and a user that
+ * toggles the OS setting mid-submit will pick up the new value on the
+ * next interaction (or panel open). SSR-safe: returns `false` when
+ * `window.matchMedia` is unavailable.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    setReduced(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  }, []);
+  return reduced;
+}
+
 function useBrevwickStyles(): void {
   useIsomorphicLayoutEffect(() => {
     if (typeof document === 'undefined') return;
@@ -290,7 +314,15 @@ export function FeedbackButton({
   theme = 'system',
   onSubmit,
 }: FeedbackButtonProps): ReactElement | null {
-  const { submit, captureScreenshot, status, reset } = useFeedback();
+  const {
+    submit,
+    captureScreenshot,
+    status,
+    phase,
+    error: submitErrorTagged,
+    reset,
+  } = useFeedback();
+  const reducedMotion = usePrefersReducedMotion();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState('');
   const [expected, setExpected] = useState('');
@@ -330,6 +362,11 @@ export function FeedbackButton({
   const screenshotIdRef = useRef(0);
   const fileIdRef = useRef(0);
   const messageIdRef = useRef(0);
+  // Snapshot of the last `FeedbackInput` passed to `submit()` so the
+  // retry CTA on a failed submit can re-run with the exact same payload
+  // (including any captured screenshots) without forcing the user to
+  // re-type the draft we cleared synchronously on Send.
+  const lastSubmittedInputRef = useRef<FeedbackInput | null>(null);
 
   useBrevwickStyles();
 
@@ -388,6 +425,7 @@ export function FeedbackButton({
     setSubmitError(null);
     setMessages(initialMessages());
     setUseAi(true);
+    lastSubmittedInputRef.current = null;
     reset();
   }, [reset]);
 
@@ -600,44 +638,58 @@ export function FeedbackButton({
       ...(showAiToggle ? { use_ai: useAi } : {}),
     };
 
-    // Snapshot the current composer state so the success branch can quote
-    // it back into the user bubble even if the user minimized mid-submit
-    // (in which case React's setState below races with whatever they typed
-    // after — the snapshot pins the version of the draft we're submitting).
+    // Push the user's draft into the conversation immediately and clear
+    // the composer BEFORE awaiting submit(). The visual progression is
+    // what makes the wait feel fast — a synchronous bubble + cleared
+    // input lets the staged-status rows below carry the rest of the
+    // animation while the network round-trip is in flight (issue #74).
     const submittedDraft = draft;
-    const submittedScreenshots = screenshots;
-    const submittedFiles = files;
+    const screenshotsSnapshot: readonly MessageAttachment[] | undefined =
+      screenshots.length > 0
+        ? screenshots.map((s) => ({ blob: s.blob }))
+        : undefined;
+    const filesSnapshot: readonly MessageAttachment[] | undefined =
+      files.length > 0
+        ? files.map(({ file }) => ({
+            blob: file,
+            filename: file.name,
+          }))
+        : undefined;
+    const userMessage: Message = {
+      id: `msg-${++messageIdRef.current}`,
+      role: 'user',
+      text: submittedDraft,
+      attachments:
+        screenshotsSnapshot || filesSnapshot
+          ? {
+              ...(screenshotsSnapshot
+                ? { screenshots: screenshotsSnapshot }
+                : {}),
+              ...(filesSnapshot ? { files: filesSnapshot } : {}),
+            }
+          : undefined,
+    };
+    setMessages((prev) => [...prev, userMessage]);
+    setDraft('');
+    setExpected('');
+    setActual('');
+    setShowExtras(false);
+    // The success path keeps the screenshot blobs already captured in
+    // userMessage.attachments so the bubble keeps a stable reference even
+    // after we drop the live attachment URLs from the composer.
+    setScreenshots((prev) => {
+      for (const s of prev) URL.revokeObjectURL(s.url);
+      return [];
+    });
+    setFiles([]);
+    setPreviewId(null);
+    lastSubmittedInputRef.current = input;
 
     try {
       const result = await submit(input);
       if (!mountedRef.current) return;
       onSubmit?.(result);
       if (result.ok) {
-        const screenshotsSnapshot: readonly MessageAttachment[] | undefined =
-          submittedScreenshots.length > 0
-            ? submittedScreenshots.map((s) => ({ blob: s.blob }))
-            : undefined;
-        const filesSnapshot: readonly MessageAttachment[] | undefined =
-          submittedFiles.length > 0
-            ? submittedFiles.map(({ file }) => ({
-                blob: file,
-                filename: file.name,
-              }))
-            : undefined;
-        const userMessage: Message = {
-          id: `msg-${++messageIdRef.current}`,
-          role: 'user',
-          text: submittedDraft,
-          attachments:
-            screenshotsSnapshot || filesSnapshot
-              ? {
-                  ...(screenshotsSnapshot
-                    ? { screenshots: screenshotsSnapshot }
-                    : {}),
-                  ...(filesSnapshot ? { files: filesSnapshot } : {}),
-                }
-              : undefined,
-        };
         const assistantMessage: Message = {
           id: `msg-${++messageIdRef.current}`,
           role: 'assistant',
@@ -645,38 +697,24 @@ export function FeedbackButton({
           issueSent: true,
           sentAt: Date.now(),
         };
-        setMessages((prev) => [...prev, userMessage, assistantMessage]);
-        // Clear the composer in place — composer stays mounted and focus
-        // stays put, so a chained submit reads naturally as the same chat
-        // session continuing.
-        setDraft('');
-        setExpected('');
-        setActual('');
-        setShowExtras(false);
-        setScreenshots((prev) => {
-          for (const s of prev) URL.revokeObjectURL(s.url);
-          return [];
-        });
-        setFiles([]);
-        setPreviewId(null);
-        setSubmitError(null);
+        setMessages((prev) => [...prev, assistantMessage]);
         // If the user minimized mid-submit, pop the panel back open so the
         // success confirmation is actually seen. A silent success while
         // hidden leaves the user unsure whether their issue landed.
         setOpen(true);
       } else {
-        setSubmitError(result.error.message);
-        // Same reasoning for a failed submit: the error alert belongs in
-        // front of the user, not buried behind a minimized panel.
+        // Failure: the user bubble is already in the thread; the staged
+        // rows collapse into a red retry row driven by `phase === 'error'`
+        // (see `Thread` below). Pop the panel back open so the user
+        // actually sees the retry CTA.
         setOpen(true);
       }
     } catch (err) {
       if (!mountedRef.current) return;
-      const message =
-        err instanceof Error && err.message
-          ? err.message
-          : 'We could not submit your feedback. Please try again.';
-      setSubmitError(message);
+      // Chunk-load failure path — the hook has already flipped phase to
+      // `'error'` and stored a synthetic SubmitError. Just pop the panel
+      // back open so the retry row is visible.
+      void err;
       setOpen(true);
     }
   }, [
@@ -692,6 +730,40 @@ export function FeedbackButton({
     submit,
     useAi,
   ]);
+
+  /**
+   * Re-run the most recent submit with the original `FeedbackInput`. The
+   * user bubble is already in the thread (pushed on the first Send),
+   * so the retry path only needs to re-fire `submit()` and append the
+   * assistant receipt on success — no duplicate bubble for the retry.
+   */
+  const doRetry = useCallback(async () => {
+    const last = lastSubmittedInputRef.current;
+    if (!last) return;
+    if (status === 'submitting') return;
+    try {
+      const result = await submit(last);
+      if (!mountedRef.current) return;
+      onSubmit?.(result);
+      if (result.ok) {
+        const assistantMessage: Message = {
+          id: `msg-${++messageIdRef.current}`,
+          role: 'assistant',
+          text: ASSISTANT_RECEIPT_TEXT,
+          issueSent: true,
+          sentAt: Date.now(),
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+        setOpen(true);
+      } else {
+        setOpen(true);
+      }
+    } catch (err) {
+      if (!mountedRef.current) return;
+      void err;
+      setOpen(true);
+    }
+  }, [onSubmit, status, submit]);
 
   if (hidden) return null;
 
@@ -744,6 +816,13 @@ export function FeedbackButton({
             confirmClose={confirmClose}
             submitError={submitError}
             status={status}
+            phase={phase}
+            submitErrorTagged={submitErrorTagged}
+            aiEnabled={projectConfig.config?.ai_enabled === true}
+            reducedMotion={reducedMotion}
+            onRetry={() => {
+              void doRetry();
+            }}
             onToggleExtras={() => setShowExtras((v) => !v)}
             onExpectedChange={setExpected}
             onActualChange={setActual}
@@ -863,6 +942,11 @@ interface ThreadProps {
   confirmClose: boolean;
   submitError: string | null;
   status: FeedbackStatus;
+  phase: FeedbackPhase;
+  submitErrorTagged: SubmitError | null;
+  aiEnabled: boolean;
+  reducedMotion: boolean;
+  onRetry: () => void;
   onToggleExtras: () => void;
   onExpectedChange: (v: string) => void;
   onActualChange: (v: string) => void;
@@ -872,6 +956,30 @@ interface ThreadProps {
   onConfirmDiscard: () => void;
   onCancelClose: () => void;
 }
+
+/**
+ * Phase ordinal used by the staged-status rows to decide visibility. Row
+ * 1 ("Captured") shows from `'sanitising'` onwards, row 2 ("Sanitised")
+ * from `'formatting'` onwards. Row 3 ("Formatting with AI") has its own
+ * exact-match rule and does not consult this table.
+ */
+const PHASE_RANK: Record<FeedbackPhase, number> = {
+  idle: 0,
+  capturing: 1,
+  sanitising: 2,
+  formatting: 3,
+  sent: 4,
+  error: -1,
+};
+
+/**
+ * Stagger between staged-status rows in milliseconds. Applied as
+ * `transition-delay` per row so the rows fade in sequentially even when
+ * the underlying SDK phase events fire microseconds apart on a healthy
+ * happy path. Honoured only when the user has not requested reduced
+ * motion — see {@link usePrefersReducedMotion}.
+ */
+const STATUS_ROW_STAGGER_MS = 200;
 
 function Thread({
   messages,
@@ -884,6 +992,11 @@ function Thread({
   confirmClose,
   submitError,
   status,
+  phase,
+  submitErrorTagged,
+  aiEnabled,
+  reducedMotion,
+  onRetry,
   onToggleExtras,
   onExpectedChange,
   onActualChange,
@@ -893,6 +1006,16 @@ function Thread({
   onConfirmDiscard,
   onCancelClose,
 }: ThreadProps): ReactElement {
+  void status;
+  const phaseRank = PHASE_RANK[phase];
+  const showCaptured = phaseRank >= PHASE_RANK.sanitising;
+  const showSanitised = phaseRank >= PHASE_RANK.formatting;
+  // Row 3 is gated on the project's AI configuration AND the exact
+  // 'formatting' phase — it disappears the moment the pipeline reports
+  // 'sent' so the user is not left with a perpetually spinning row.
+  const showFormatting = phase === 'formatting' && aiEnabled;
+  const showRetryRow = phase === 'error' && submitErrorTagged !== null;
+
   return (
     <div
       className="brw-thread"
@@ -953,19 +1076,131 @@ function Thread({
         onExpectedChange={onExpectedChange}
         onActualChange={onActualChange}
       />
+      {/* Validation / capture errors set by feedback-button itself stay on
+          the existing inline alert. Submit-pipeline failures are rendered
+          by the retry row below so the user gets the proper retry CTA. */}
       {submitError && (
         <div className="brw-error" role="alert">
           {submitError}
         </div>
       )}
-      {status === 'submitting' && (
-        <AssistantBubble>
-          <span className="brw-spinner" aria-hidden="true" /> Sending…
-        </AssistantBubble>
+      {showCaptured && (
+        <StatusRow
+          variant="check"
+          delayMs={reducedMotion ? 0 : 0}
+          dataRow="captured"
+        >
+          Captured route, console, network, device
+        </StatusRow>
+      )}
+      {showSanitised && (
+        <StatusRow
+          variant="check"
+          delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
+          dataRow="sanitised"
+        >
+          PII-sanitised, packaged
+        </StatusRow>
+      )}
+      {showFormatting && (
+        <StatusRow
+          variant="spinner"
+          delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
+          dataRow="formatting"
+        >
+          Formatting with AI…
+        </StatusRow>
+      )}
+      {showRetryRow && submitErrorTagged && (
+        <RetryRow error={submitErrorTagged} onRetry={onRetry} />
       )}
       {confirmClose && (
         <DiscardConfirm onCancel={onCancelClose} onConfirm={onConfirmDiscard} />
       )}
+    </div>
+  );
+}
+
+interface StatusRowProps {
+  variant: 'check' | 'spinner';
+  delayMs: number;
+  dataRow: string;
+  children: ReactNode;
+}
+
+/**
+ * One staged-status row in the conversation thread. Visual variants:
+ *
+ * - `'check'` — green checkmark + label. Used for the "Captured" /
+ *   "Sanitised" milestones.
+ * - `'spinner'` — spinner + label. Used for the "Formatting with AI…"
+ *   row that sits next to the pending AI work.
+ *
+ * The `data-brw-row` attribute exists for the test suite to query rows by
+ * their role-in-the-pipeline without coupling to the visible label.
+ * Stagger is applied as a `transition-delay` so the rows fade in
+ * sequentially under the shared bubble-entrance keyframe.
+ */
+function StatusRow({
+  variant,
+  delayMs,
+  dataRow,
+  children,
+}: StatusRowProps): ReactElement {
+  return (
+    <div
+      className="brw-status-row"
+      style={{ transitionDelay: `${delayMs}ms` }}
+      data-brw-row={dataRow}
+    >
+      {variant === 'check' ? (
+        <span className="brw-status-row-check" aria-hidden="true">
+          <CheckIcon />
+        </span>
+      ) : (
+        <span className="brw-spinner" aria-hidden="true" />
+      )}
+      <span className="brw-status-row-label">{children}</span>
+    </div>
+  );
+}
+
+interface RetryRowProps {
+  error: SubmitError;
+  onRetry: () => void;
+}
+
+/**
+ * Red retry row shown when the submit pipeline fails. Renders the
+ * `SubmitError.message` verbatim — server-echoed bodies have already
+ * been redacted upstream — and a single "Retry" CTA wired to
+ * {@link UseFeedbackResult.retry}.
+ *
+ * `role="alert"` so screen readers pick up the failure inside the
+ * panel's `aria-live="polite"` thread; `data-brw-error-code` keeps the
+ * code accessible to the test suite without coupling on the rendered
+ * copy.
+ */
+function RetryRow({ error, onRetry }: RetryRowProps): ReactElement {
+  // The error message is a direct text child of the role="alert" element
+  // so testing-library `getByText(..., { selector: '[role="alert"]' })`
+  // matches it without recursing through wrapper spans. The Retry button
+  // sits beside the message.
+  return (
+    <div
+      className="brw-status-row brw-status-row--error"
+      role="alert"
+      data-brw-error-code={error.code}
+      data-brw-row="error"
+    >
+      {error.message}
+      <button
+        type="button"
+        className="brw-btn brw-status-row-retry"
+        onClick={onRetry}
+      >
+        Retry
+      </button>
     </div>
   );
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,7 +14,11 @@ export { BrevwickProvider } from './provider';
 export type { BrevwickProviderProps } from './provider';
 
 export { useFeedback } from './use-feedback';
-export type { FeedbackStatus, UseFeedbackResult } from './use-feedback';
+export type {
+  FeedbackPhase,
+  FeedbackStatus,
+  UseFeedbackResult,
+} from './use-feedback';
 
 export { FeedbackButton } from './feedback-button';
 export type { BrevwickTheme, FeedbackButtonProps } from './feedback-button';

--- a/packages/react/src/internal-bridge.ts
+++ b/packages/react/src/internal-bridge.ts
@@ -1,0 +1,45 @@
+import type { Brevwick } from '@tatlacas/brevwick-sdk';
+
+/**
+ * Submit-pipeline progress events. Mirrors `PhaseEvent` in the SDK's
+ * `core/internal.ts`. Replicated here (rather than imported) because the
+ * SDK intentionally does not export the internal surface from its package
+ * root — the React adapter reaches the bus through the `_internal`
+ * backdoor and types the listener locally.
+ */
+export type PhaseEvent =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+
+/**
+ * Subset of the internal `Bus` we need: subscribe / unsubscribe to phase
+ * events. Keeping the structural type narrow means a future SDK change
+ * that adds new events does not pull broader internal types into the
+ * adapter's surface area.
+ */
+interface PhaseBus {
+  on(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+  off(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+}
+
+/**
+ * Resolve the internal phase bus from a `Brevwick` instance, or return
+ * `null` if the runtime shape doesn't match (e.g. a test mock that doesn't
+ * stamp `_internal`). Adapters in this monorepo and the SDK itself live
+ * in lockstep, so the `'_internal'` string + structural shape is a stable
+ * coupling — but the adapter must not crash when consumers pass a
+ * different `Brevwick`-shaped object.
+ *
+ * Internal — not part of the React adapter's public API.
+ */
+export function getPhaseBus(brevwick: Brevwick): PhaseBus | null {
+  const internal = (brevwick as unknown as Record<string, unknown>)._internal;
+  if (!internal || typeof internal !== 'object') return null;
+  const bus = (internal as { bus?: unknown }).bus;
+  if (!bus || typeof bus !== 'object') return null;
+  const candidate = bus as { on?: unknown; off?: unknown };
+  if (typeof candidate.on !== 'function' || typeof candidate.off !== 'function')
+    return null;
+  return bus as PhaseBus;
+}

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -520,6 +520,60 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
+/* Staged-status rows (issue #74). Visually mirrors the assistant bubble
+   surface (background, padding, radius) but lives outside the
+   .brw-bubble class family so it does not count as a conversation
+   bubble for queries that count messages — the rows are progress
+   indicators, not messages. The transition-delay is set inline per row
+   so the three rows fade in sequentially even when the underlying SDK
+   phase events fire microseconds apart. The reduced-motion media query
+   collapses the entrance to an instant fade, pairing with the inline
+   0ms delay the adapter passes when the user has
+   prefers-reduced-motion: reduce. */
+.brw-status-row {
+  align-self: flex-start;
+  max-width: 85%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border-bottom-left-radius: 4px;
+  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
+  font-size: 13px;
+  line-height: 1.45;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: brw-status-row-in 220ms ease-out both;
+}
+.brw-status-row-check {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  color: var(--brw-accent, var(--brw-accent-base));
+}
+.brw-status-row-check svg {
+  width: 14px;
+  height: 14px;
+}
+.brw-status-row-label { flex: 1; }
+.brw-status-row--error {
+  color: var(--brw-error-base);
+  border: 1px solid var(--brw-error-base);
+}
+.brw-status-row-retry {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+@keyframes brw-status-row-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-status-row { animation: none; }
+}
 .brw-panel-footer {
   flex-shrink: 0;
   padding: 6px 10px 8px;

--- a/packages/react/src/use-feedback.ts
+++ b/packages/react/src/use-feedback.ts
@@ -1,11 +1,18 @@
 'use client';
 
-import { useCallback, useState } from 'react';
-import type { FeedbackInput, SubmitResult } from '@tatlacas/brevwick-sdk';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  FeedbackInput,
+  SubmitError,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
 import { useBrevwickInternal } from './context';
+import { getPhaseBus, type PhaseEvent } from './internal-bridge';
 
 /**
- * Submission lifecycle surfaced by {@link useFeedback}.
+ * Submission lifecycle surfaced by {@link useFeedback}. Held for backward
+ * compatibility with callers that already discriminate on this field; new
+ * UI work should branch on {@link FeedbackPhase} instead.
  *
  * - `idle` — nothing in-flight.
  * - `submitting` — a `submit()` call is pending.
@@ -13,6 +20,27 @@ import { useBrevwickInternal } from './context';
  * - `error` — the last `submit()` resolved with `{ ok: false }`.
  */
 export type FeedbackStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+/**
+ * Submit-pipeline phase the UI can render staged status against. Driven
+ * by the SDK's internal `phase` bus event:
+ *
+ * - `idle` — initial state and after `reset()`.
+ * - `capturing` — `submit()` has been called but no phase event has fired yet.
+ * - `sanitising` — `capturing-done` event arrived (payload composed).
+ * - `formatting` — `sanitising-done` event arrived (redact complete; the
+ *   ingest POST is in flight). UIs gate any "Formatting with AI" affordance
+ *   on this phase plus the project's `ai_enabled` flag.
+ * - `sent` — `sent` event arrived after a 2xx ingest response.
+ * - `error` — `submit()` resolved with `{ ok: false }` or rejected.
+ */
+export type FeedbackPhase =
+  | 'idle'
+  | 'capturing'
+  | 'sanitising'
+  | 'formatting'
+  | 'sent'
+  | 'error';
 
 /**
  * Return value of {@link useFeedback}. See the SDK SDD § 12 for the contract.
@@ -24,9 +52,34 @@ export interface UseFeedbackResult {
   captureScreenshot: () => Promise<Blob>;
   /** Current submission status. */
   status: FeedbackStatus;
-  /** Reset `status` back to `'idle'`. Does not cancel an in-flight submit. */
+  /**
+   * Current submit-pipeline phase. Advances on the SDK's internal phase
+   * bus event so adapter UIs can render staged-status rows in step with
+   * the actual pipeline boundaries (compose → redact → ingest).
+   */
+  phase: FeedbackPhase;
+  /**
+   * Tagged error from the last failed `submit()`. `null` until a submit
+   * resolves with `{ ok: false }` or rejects (chunk-load failure surfaces
+   * as `{ code: 'INGEST_RETRY_EXHAUSTED', message: <Error.message> }`).
+   * Cleared back to `null` on the next `submit()` or `reset()`.
+   */
+  error: SubmitError | null;
+  /**
+   * Re-run the most recent `submit()` with the same input. No-op when no
+   * submit has been attempted yet. Returns the same tagged-union result
+   * the underlying `submit()` would.
+   */
+  retry: () => Promise<SubmitResult | undefined>;
+  /** Reset `status` + `phase` back to `'idle'` and clear `error`. */
   reset: () => void;
 }
+
+const PHASE_EVENT_TO_NEXT_PHASE: Record<PhaseEvent['phase'], FeedbackPhase> = {
+  'capturing-done': 'sanitising',
+  'sanitising-done': 'formatting',
+  sent: 'sent',
+};
 
 /**
  * React hook that exposes the Brevwick submission primitives against the
@@ -37,25 +90,78 @@ export interface UseFeedbackResult {
 export function useFeedback(): UseFeedbackResult {
   const { brevwick } = useBrevwickInternal();
   const [status, setStatus] = useState<FeedbackStatus>('idle');
+  const [phase, setPhase] = useState<FeedbackPhase>('idle');
+  const [error, setError] = useState<SubmitError | null>(null);
+  // Snapshot of the input passed to the most recent `submit()` so `retry()`
+  // can re-run the exact same payload without forcing the caller to hold
+  // it for us. Cleared on `reset()`.
+  const lastInputRef = useRef<FeedbackInput | null>(null);
+  // Whether the bus listener should write into state. Flipped to false on
+  // unmount so an in-flight submit that resolves after teardown can't
+  // setState on a stale tree.
+  const aliveRef = useRef(true);
 
-  const submit = useCallback(
+  useEffect(() => {
+    aliveRef.current = true;
+    const bus = getPhaseBus(brevwick);
+    if (!bus) return;
+    const onPhase = (event: PhaseEvent): void => {
+      if (!aliveRef.current) return;
+      setPhase(PHASE_EVENT_TO_NEXT_PHASE[event.phase]);
+    };
+    bus.on('phase', onPhase);
+    return () => {
+      aliveRef.current = false;
+      bus.off('phase', onPhase);
+    };
+  }, [brevwick]);
+
+  const runSubmit = useCallback(
     async (input: FeedbackInput): Promise<SubmitResult> => {
+      lastInputRef.current = input;
       setStatus('submitting');
+      setPhase('capturing');
+      setError(null);
       try {
         const result = await brevwick.submit(input);
-        setStatus(result.ok ? 'success' : 'error');
+        if (!aliveRef.current) return result;
+        if (result.ok) {
+          setStatus('success');
+        } else {
+          setStatus('error');
+          setPhase('error');
+          setError(result.error);
+        }
         return result;
-      } catch (error) {
+      } catch (err) {
         // `brevwick.submit` only rejects when the lazy submit chunk itself
         // fails to load (deploy mismatch / offline). Flip to 'error' so the
         // UI isn't stuck on 'submitting', then rethrow so callers can
         // distinguish an environmental failure from an ingest-level one.
-        setStatus('error');
-        throw error;
+        if (aliveRef.current) {
+          setStatus('error');
+          setPhase('error');
+          setError({
+            code: 'INGEST_RETRY_EXHAUSTED',
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+        throw err;
       }
     },
     [brevwick],
   );
+
+  const submit = useCallback(
+    (input: FeedbackInput): Promise<SubmitResult> => runSubmit(input),
+    [runSubmit],
+  );
+
+  const retry = useCallback(async (): Promise<SubmitResult | undefined> => {
+    const last = lastInputRef.current;
+    if (!last) return undefined;
+    return runSubmit(last);
+  }, [runSubmit]);
 
   const captureScreenshot = useCallback(
     (): Promise<Blob> => brevwick.captureScreenshot(),
@@ -64,7 +170,18 @@ export function useFeedback(): UseFeedbackResult {
 
   const reset = useCallback(() => {
     setStatus('idle');
+    setPhase('idle');
+    setError(null);
+    lastInputRef.current = null;
   }, []);
 
-  return { submit, captureScreenshot, status, reset };
+  return {
+    submit,
+    captureScreenshot,
+    status,
+    phase,
+    error,
+    retry,
+    reset,
+  };
 }

--- a/packages/sdk/src/__tests__/integration/phase-events.test.ts
+++ b/packages/sdk/src/__tests__/integration/phase-events.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase-event ordering: the submit pipeline must emit
+ * `capturing-done → sanitising-done → sent` on a happy-path issue POST,
+ * AND the `sent` event must carry an accurate `aiEnabled` flag derived
+ * from the cached `ProjectConfig`.
+ *
+ * The React adapter (and any future binding) animates a staged-status UI
+ * against this signal sequence; a regression that reordered the emits or
+ * dropped one would break that UX silently — the integration test guards
+ * the contract end-to-end through the real ring-installed pipeline.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { createBrevwick } from '../../core/client';
+import {
+  INTERNAL_KEY,
+  type BrevwickInternal,
+  type PhaseEvent,
+} from '../../core/internal';
+import { __resetBrevwickRegistry, __setRingsForTesting } from '../../testing';
+import {
+  createIntegrationServer,
+  ENDPOINT,
+  installIngestHandlers,
+  KEY,
+} from './setup';
+
+const server = createIntegrationServer();
+const CONFIG_URL = `${ENDPOINT}/v1/ingest/config`;
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  __resetBrevwickRegistry();
+  __setRingsForTesting();
+});
+afterAll(() => server.close());
+
+function getInternal(
+  instance: ReturnType<typeof createBrevwick>,
+): BrevwickInternal {
+  return (instance as unknown as Record<typeof INTERNAL_KEY, BrevwickInternal>)[
+    INTERNAL_KEY
+  ];
+}
+
+describe('integration — submit-pipeline phase events', () => {
+  it('emits capturing-done → sanitising-done → sent in order on a happy-path submit', async () => {
+    installIngestHandlers(server, () => 'phase_issue_1');
+    server.use(
+      http.get(CONFIG_URL, () =>
+        HttpResponse.json({
+          ai_enabled: true,
+          ai_submitter_choice_allowed: false,
+        }),
+      ),
+    );
+
+    const instance = createBrevwick({
+      projectKey: KEY,
+      endpoint: ENDPOINT,
+      environment: 'stg',
+    });
+    instance.install();
+    const internal = getInternal(instance);
+    await internal.ready();
+
+    const events: PhaseEvent[] = [];
+    internal.bus.on('phase', (e) => events.push(e));
+
+    const result = await instance.submit({ description: 'phase happy path' });
+    expect(result).toEqual({ ok: true, issue_id: 'phase_issue_1' });
+
+    expect(events.map((e) => e.phase)).toEqual([
+      'capturing-done',
+      'sanitising-done',
+      'sent',
+    ]);
+    const sent = events[2];
+    if (sent?.phase !== 'sent') throw new Error('expected sent event');
+    expect(sent.aiEnabled).toBe(true);
+
+    instance.uninstall();
+  });
+
+  it('sets aiEnabled=false on the sent event when the project config has AI off', async () => {
+    installIngestHandlers(server, () => 'phase_issue_2');
+    server.use(
+      http.get(CONFIG_URL, () =>
+        HttpResponse.json({
+          ai_enabled: false,
+          ai_submitter_choice_allowed: false,
+        }),
+      ),
+    );
+
+    const instance = createBrevwick({
+      projectKey: KEY,
+      endpoint: ENDPOINT,
+      environment: 'stg',
+    });
+    instance.install();
+    const internal = getInternal(instance);
+    await internal.ready();
+
+    const events: PhaseEvent[] = [];
+    internal.bus.on('phase', (e) => events.push(e));
+
+    await instance.submit({ description: 'phase non-ai project' });
+
+    const sent = events.find((e) => e.phase === 'sent');
+    if (!sent || sent.phase !== 'sent') throw new Error('expected sent event');
+    expect(sent.aiEnabled).toBe(false);
+
+    instance.uninstall();
+  });
+
+  it('does not emit sent on a 4xx ingest rejection', async () => {
+    server.use(
+      http.post(`${ENDPOINT}/v1/ingest/issues`, () =>
+        HttpResponse.json({ error: 'quota' }, { status: 422 }),
+      ),
+    );
+    server.use(
+      http.get(CONFIG_URL, () =>
+        HttpResponse.json({
+          ai_enabled: false,
+          ai_submitter_choice_allowed: false,
+        }),
+      ),
+    );
+
+    const instance = createBrevwick({
+      projectKey: KEY,
+      endpoint: ENDPOINT,
+      environment: 'stg',
+    });
+    instance.install();
+    const internal = getInternal(instance);
+    await internal.ready();
+
+    const events: PhaseEvent[] = [];
+    internal.bus.on('phase', (e) => events.push(e));
+
+    const result = await instance.submit({ description: 'phase rejected' });
+    expect(result.ok).toBe(false);
+    // The first two phases fire as soon as compose+redact complete; only
+    // 'sent' is gated on a 2xx, so the failure path stops at the second.
+    expect(events.map((e) => e.phase)).toEqual([
+      'capturing-done',
+      'sanitising-done',
+    ]);
+
+    instance.uninstall();
+  });
+});

--- a/packages/sdk/src/core/client.ts
+++ b/packages/sdk/src/core/client.ts
@@ -47,6 +47,26 @@ function build(
   // safely exercise patched globals; production callers never touch it.
   let ready: Promise<void> = Promise.resolve();
 
+  // Per-instance cache of the GET /v1/ingest/config round-trip. Hoisted
+  // above `internal` so both `internal.getConfig` (used by the submit
+  // pipeline to derive the `phase: 'sent'` event's `aiEnabled` flag) and
+  // the public `Brevwick.getConfig()` accessor below funnel through the
+  // same cached promise. Storing the promise rather than the resolved
+  // value also collapses concurrent callers into a single network request.
+  let configPromise: Promise<ProjectConfig | null> | undefined;
+  const loadConfig = (): Promise<ProjectConfig | null> => {
+    if (configPromise) return configPromise;
+    // `.catch(() => null)` covers the dynamic-import failure path
+    // (offline / CDN / deploy mismatch) so the public "never throws,
+    // resolves to null on failure" contract in types.ts holds. Without
+    // this, a one-time chunk-load failure would be cached as a rejected
+    // promise and every subsequent call would keep rejecting.
+    configPromise = import('../config')
+      .then((m) => m.fetchConfig(config.endpoint, config.projectKey))
+      .catch(() => null);
+    return configPromise;
+  };
+
   const internal: BrevwickInternal = {
     buffers,
     bus,
@@ -70,6 +90,7 @@ function build(
     },
     state: () => state,
     ready: () => ready,
+    getConfig: loadConfig,
   };
 
   function install(): void {
@@ -153,13 +174,6 @@ function build(
     onUninstall();
   }
 
-  // Per-instance cache of the GET /v1/ingest/config round-trip. The SDD
-  // contract is "per session" — once the first fetch resolves (success or
-  // null), every subsequent call returns the same promise. Storing the
-  // promise rather than the resolved value also collapses concurrent
-  // callers into a single network request.
-  let configPromise: Promise<ProjectConfig | null> | undefined;
-
   const instance: Brevwick = {
     install,
     uninstall,
@@ -177,18 +191,7 @@ function build(
       import('../screenshot').then((m) =>
         m.captureScreenshotForInstance(internal),
       ),
-    getConfig: (): Promise<ProjectConfig | null> => {
-      if (configPromise) return configPromise;
-      // `.catch(() => null)` covers the dynamic-import failure path
-      // (offline / CDN / deploy mismatch) so the public "never throws,
-      // resolves to null on failure" contract in types.ts holds. Without
-      // this, a one-time chunk-load failure would be cached as a rejected
-      // promise and every subsequent call would keep rejecting.
-      configPromise = import('../config')
-        .then((m) => m.fetchConfig(config.endpoint, config.projectKey))
-        .catch(() => null);
-      return configPromise;
-    },
+    getConfig: loadConfig,
   };
 
   Object.defineProperty(instance, INTERNAL_KEY, {

--- a/packages/sdk/src/core/internal.ts
+++ b/packages/sdk/src/core/internal.ts
@@ -7,6 +7,7 @@
 import type {
   ConsoleEntry,
   NetworkEntry,
+  ProjectConfig,
   RingEntry,
   RouteEntry,
 } from '../types';
@@ -18,8 +19,32 @@ export type LifecycleState = 'idle' | 'installed' | 'uninstalled';
 
 export type RingName = 'console' | 'network' | 'route';
 
+/**
+ * Submit-pipeline progress signal. Fired by the submit chunk at three
+ * boundaries the React adapter (and any other binding) animates against.
+ *
+ * - `'capturing-done'` — the buffers snapshot has landed in the in-memory
+ *   payload (`composePayload` complete).
+ * - `'sanitising-done'` — `redact()` has run over the payload; the next
+ *   action is the ingest POST.
+ * - `'sent'` — ingest returned 2xx. `aiEnabled` is the resolved
+ *   `ProjectConfig.ai_enabled` so the adapter can decide whether to render
+ *   a "Formatting with AI" affordance after the issue lands.
+ *
+ * **Internal surface** — emitted on the same `internal.bus` the rings use
+ * (event key `'phase'`) and intentionally **not** re-exported from the
+ * package root. Adapters in this monorepo reach the bus via the
+ * `INTERNAL_KEY` backdoor; external consumers should not depend on this
+ * channel — it is not part of the public SDK contract.
+ */
+export type PhaseEvent =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+
 export type BusEventMap = {
   entry: RingEntry;
+  phase: PhaseEvent;
 };
 
 export interface RingContext {
@@ -51,6 +76,14 @@ export interface BrevwickInternal {
    * consumers should not depend on this handle.
    */
   ready(): Promise<void>;
+  /**
+   * Cached `ProjectConfig` lookup mirroring `Brevwick.getConfig()`. Exposed
+   * on the internal surface so the submit pipeline can derive the
+   * `phase: 'sent'` event's `aiEnabled` flag without spinning up a parallel
+   * cache. Resolves to `null` on any failure (offline, malformed JSON, 4xx
+   * / 5xx) — never throws.
+   */
+  getConfig(): Promise<ProjectConfig | null>;
 }
 
 /** Key used by rings + tests to reach the internal API without polluting the public surface. */

--- a/packages/sdk/src/submit.ts
+++ b/packages/sdk/src/submit.ts
@@ -556,12 +556,35 @@ export async function runSubmit(
     }
 
     const payload = composePayload(internal, input, resolved);
-    return await postIssue(
+    // Phase signals for adapter UIs (see core/internal.ts PhaseEvent docs).
+    // composePayload reads the buffer snapshots AND runs redact() inline on
+    // the user-supplied text fields, so 'capturing-done' and
+    // 'sanitising-done' fire back-to-back: the first marks the moment the
+    // payload exists, the second marks "redaction has run, the next syscall
+    // is the wire POST". A consumer (the React adapter) animates a 200 ms
+    // stagger between rows on top of this — the SDK signals the boundary,
+    // the UI owns the cadence.
+    internal.bus.emit('phase', { phase: 'capturing-done' });
+    internal.bus.emit('phase', { phase: 'sanitising-done' });
+    const result = await postIssue(
       config.endpoint,
       config.projectKey,
       payload,
       controller.signal,
     );
+    if (result.ok) {
+      // Resolve `aiEnabled` from the cached project config so the adapter
+      // can decide whether to render a "Formatting with AI" affordance.
+      // `getConfig` never throws (resolves to `null` on failure) and is
+      // cached per session — by the time submit fires, the widget has
+      // typically already populated the cache during its first open.
+      const projectConfig = await internal.getConfig();
+      internal.bus.emit('phase', {
+        phase: 'sent',
+        aiEnabled: projectConfig?.ai_enabled === true,
+      });
+    }
+    return result;
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
Closes #74
Closes tatlacas-com/brevwick-web#143

Implements the React widget staged-status UX so the @tatlacas/brevwick-react widget visually matches the brevwick-web landing AnimatedDemo (PR #192). Pressing Send clears the input, moves the typed value into a user bubble immediately, then ticks through three staged AssistantBubble rows (Captured → Sanitised → Formatting with AI) driven by the SDK's submit-pipeline phase events. Honours prefers-reduced-motion; collapses to a red retry row on every SubmitErrorCode.

Implements [SDD § 12 SDK contracts](https://github.com/tatlacas-com/brevwick-ops/blob/main/docs/brevwick-sdd.md#12-sdk-contracts).

## Summary

- **packages/sdk/src/core/internal.ts** — extends \`BusEventMap\` with a \`phase\` event (\`'capturing-done' | 'sanitising-done' | 'sent'\`) on the existing internal RingBus. Adds \`getConfig()\` to \`BrevwickInternal\` so the submit pipeline can derive \`aiEnabled\` from the cached \`ProjectConfig\` without a parallel cache.
- **packages/sdk/src/submit.ts** — emits \`capturing-done\` + \`sanitising-done\` after \`composePayload()\` (the buffer snapshot + \`redact()\` boundary), and \`sent\` after the ingest 2xx with the resolved \`aiEnabled\` flag. Internal channel only — not exposed on the public SDK surface.
- **packages/react/src/internal-bridge.ts** — narrow structural-typed accessor for the SDK's \`_internal\` bus. Documents the lockstep monorepo coupling.
- **packages/react/src/use-feedback.ts** — \`FeedbackPhase\` enum (\`'idle' | 'capturing' | 'sanitising' | 'formatting' | 'sent' | 'error'\`), \`error: SubmitError | null\`, \`retry()\` callback. The existing \`status\` field stays for backwards compatibility.
- **packages/react/src/feedback-button.tsx** — Send moves the draft into the user bubble + clears the composer synchronously (no await). Three staged \`StatusRow\`s gated on \`phase\` + \`aiEnabled\`, with ~200 ms transition-delay stagger that collapses to 0 ms under \`prefers-reduced-motion: reduce\`. Failure path renders a red \`RetryRow\` with \`role=\"alert\"\` carrying the \`SubmitError.message\` verbatim and a one-click Retry CTA.
- **packages/react/src/__tests__/feedback-button.test.tsx** — synchronous-clear-on-Send, row ordering, AI-row gate, reduced-motion no-stagger, and a table-driven failure suite covering all five \`SubmitErrorCode\`s.
- **packages/react/README.md** — Submit-pipeline state-machine documentation, AI-row gate, reduced-motion contract, retry contract.
- **Bundle budget:** \`@tatlacas/brevwick-react\` ESM 11.92 kB / CJS 12.3 kB (limit 25 kB) — well under. \`@tatlacas/brevwick-sdk\` core eager 2.13 kB / 2.14 kB (limit 2.2 kB) — within margin.

## Out of scope (intentional)

- Server-side AI status pushing (no SSE, no polling) — status rows are purely client-side animation against pipeline phase.
- Per-row failure retries — a single retry CTA on the failed row is the contract; the issue body is explicit.
- Replacing AssistantBubble for already-shipped surfaces — the new rows ship in their own \`brw-status-row\` class family alongside (not on top of) the existing assistant-bubble surface.

## Companion / cross-repo

- WT-rings-redact (#75 + #76 + #77) lives in this repo too; if it lands first, the phase-event emit sites may need to absorb the \`network_errors\` → \`network_calls\` rename. The emits are fenced to the post-\`composePayload\` boundary so the rebase is mechanical.
- brevwick-web follow-up: \`AnimatedDemo\` can drop the \"live but aspirational\" comment once this ships.

## Test plan

- [x] CI gauntlet green: \`pnpm install --frozen-lockfile && pnpm lint && pnpm type-check && pnpm test && pnpm build && pnpm size\`
- [x] Pressing Send clears the input + renders the user bubble before any network round-trip (asserted in \`Pressing Send clears the input + renders user bubble immediately (before any await)\` without an \`act\` wrapper)
- [x] Three staged rows render in order; each row appears at the documented submit-pipeline boundary (\`Three staged rows render in order as phase events arrive\`)
- [x] AI row suppressed when \`getConfig().ai_enabled === false\` (\`AI row is suppressed when getConfig().ai_enabled === false\`)
- [x] \`prefers-reduced-motion: reduce\` shows all rows with \`transitionDelay: 0ms\`, no stagger (\`Reduced motion renders all rows with a 0 ms transition delay\`)
- [x] Each of the five \`SubmitErrorCode\`s (\`ATTACHMENT_UPLOAD_FAILED\`, \`INGEST_REJECTED\`, \`INGEST_RETRY_EXHAUSTED\`, \`INGEST_TIMEOUT\`, \`INGEST_INVALID_RESPONSE\`) collapses to a red retry row with the message verbatim + a working Retry CTA (table-driven test)