### PR TITLE
feat(react-native): FeedbackButton + Modal

### DIFF
--- a/.changeset/rn-feedback-button.md
+++ b/.changeset/rn-feedback-button.md
@@ -8,7 +8,7 @@ Drop-in FAB + Modal feedback form for React Native, mirroring the
 `@tatlacas/brevwick-react` widget UX 1:1 with RN primitives:
 
 - `<FeedbackButton />` — `Pressable` FAB with `position` (`'bottom-right' |
-  'bottom-left' | { bottom?, right?, left? }`), `theme`, `style`, `label`,
+'bottom-left' | { bottom?, right?, left? }`), `theme`, `style`, `label`,
   `hidden`, `disabled` props. Default label tracks the SDK submit phase
   (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`).
   Accessible: `accessibilityLabel='Send feedback'` + `accessibilityRole='button'`.

--- a/.changeset/rn-feedback-button.md
+++ b/.changeset/rn-feedback-button.md
@@ -9,19 +9,35 @@ Drop-in FAB + Modal feedback form for React Native, mirroring the
 
 - `<FeedbackButton />` — `Pressable` FAB with `position` (`'bottom-right' |
 'bottom-left' | { bottom?, right?, left? }`), `theme`, `style`, `label`,
-  `hidden`, `disabled` props. Default label tracks the SDK submit phase
-  (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`).
-  Accessible: `accessibilityLabel='Send feedback'` + `accessibilityRole='button'`.
+  `hidden`, `disabled` props. Default label tracks the full SDK submit
+  lifecycle (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` /
+  `Try again`); the `Try again` and `Sent ✓` terminal states are reachable
+  on the FAB because the FAB owns a single `useFeedback()` instance and
+  forwards it to the modal — both render against the same status/phase
+  tuple so the FAB observes terminal states the SDK's phase bus does not
+  emit. Accessible: `accessibilityLabel='Send feedback'` +
+  `accessibilityRole='button'`. The `disabled` prop is enforced both via
+  `Pressable`'s native gating AND an explicit guard in `handleOpen`.
 - `<FeedbackModal />` — slide-up form: description / expected / actual
   fields, screenshot preview with a skip toggle, and a primary button
   that drives `useFeedback().submit`. Lazy-loads `getConfig()` on first
   open and renders the AI toggle only when the project enables
   `ai_enabled && ai_submitter_choice_allowed`. Auto-dismisses 2 s after
-  a successful submit and preserves the draft across Cancel + reopen
-  (modal-local `useState`). iOS gets `accessibilityViewIsModal` so
-  VoiceOver scopes focus to the sheet.
-- `BrevwickTheme` type re-exported from the package root for parity with
-  the web React adapter.
+  a successful submit and preserves the draft (text fields AND toggles)
+  across Cancel + reopen (modal-local `useState`). The success-dismiss
+  timer is cleared explicitly when the user taps Cancel during the
+  confirmation dwell so it cannot fire on a hidden modal. The inline
+  draft-error note clears on the first keystroke in any of the three
+  text fields, matching the web composer behaviour. Screenshot capture
+  failures surface as an inline note ("Couldn't attach screenshot —
+  sending without one.") and emit a single `console.warn` matching the
+  `screenshot.ts` `logFailure` pattern. Accepts an optional `feedback?:
+UseFeedbackResult` prop so a parent can lift the hook (the FAB does
+  this); standalone consumers can omit it. iOS gets
+  `accessibilityViewIsModal` so VoiceOver scopes focus to the sheet.
+- `BrevwickTheme` and `ProjectConfig` types re-exported from the package
+  root for parity with the web React adapter — `ProjectConfig` is needed
+  by any consumer composing their own modal alongside `useFeedback()`.
 
-Bundle: 5.72 kB gzip ESM / 5.95 kB gzip CJS — well under the 25 kB
-budget documented in `CLAUDE.md`.
+Bundle: 5.84 kB gzip ESM / 6.11 kB gzip CJS — well under the 25 kB
+budget enforced by `.size-limit.js` and documented in `CLAUDE.md`.

--- a/.changeset/rn-feedback-button.md
+++ b/.changeset/rn-feedback-button.md
@@ -1,0 +1,27 @@
+---
+'@tatlacas/brevwick-react-native': minor
+---
+
+feat(react-native): FeedbackButton + Modal (#88)
+
+Drop-in FAB + Modal feedback form for React Native, mirroring the
+`@tatlacas/brevwick-react` widget UX 1:1 with RN primitives:
+
+- `<FeedbackButton />` — `Pressable` FAB with `position` (`'bottom-right' |
+  'bottom-left' | { bottom?, right?, left? }`), `theme`, `style`, `label`,
+  `hidden`, `disabled` props. Default label tracks the SDK submit phase
+  (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`).
+  Accessible: `accessibilityLabel='Send feedback'` + `accessibilityRole='button'`.
+- `<FeedbackModal />` — slide-up form: description / expected / actual
+  fields, screenshot preview with a skip toggle, and a primary button
+  that drives `useFeedback().submit`. Lazy-loads `getConfig()` on first
+  open and renders the AI toggle only when the project enables
+  `ai_enabled && ai_submitter_choice_allowed`. Auto-dismisses 2 s after
+  a successful submit and preserves the draft across Cancel + reopen
+  (modal-local `useState`). iOS gets `accessibilityViewIsModal` so
+  VoiceOver scopes focus to the sheet.
+- `BrevwickTheme` type re-exported from the package root for parity with
+  the web React adapter.
+
+Bundle: 5.72 kB gzip ESM / 5.95 kB gzip CJS — well under the 25 kB
+budget documented in `CLAUDE.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
             packages/vue/dist
             packages/svelte/dist
             packages/angular/dist
+            packages/react-native/dist
           retention-days: 1
           if-no-files-found: error
 

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -150,6 +150,24 @@ export default [
     '8 kB',
   ),
 
+  // ── React Native bundle (≤ 25 kB gzip) ───────────────────────────────────
+  // The RN adapter mirrors the React adapter's 25 kB ceiling documented in
+  // `CLAUDE.md`. Current eager weight of the FeedbackButton + Modal +
+  // route ring + device + screenshot wrapper artefact is ~6 kB gzip, well
+  // under the budget — this entry exists so any future bloat that crosses
+  // the ceiling fails CI before it ships, the same defence-in-depth the
+  // other adapters get.
+  fileEntry(
+    '@tatlacas/brevwick-react-native (ESM)',
+    'packages/react-native/dist/index.js',
+    '25 kB',
+  ),
+  fileEntry(
+    '@tatlacas/brevwick-react-native (CJS)',
+    'packages/react-native/dist/index.cjs',
+    '25 kB',
+  ),
+
   // ── On-widget-open total weight (≤ 25 kB gzip) ───────────────────────────
   // Bundled-import mode: esbuild re-bundles the screenshot module + its
   // resolved `modern-screenshot` peer the way a consumer's bundler would for

--- a/notes/reviews/pr-100-claude-review.md
+++ b/notes/reviews/pr-100-claude-review.md
@@ -1,0 +1,183 @@
+# PR #100 Review — feat(react-native): FeedbackButton + Modal
+
+**Issue**: #88 — feat(react-native): FeedbackButton + FeedbackModal — RN Pressable + Modal
+**Branch**: feat/issue-88-rn-feedback-button
+**Reviewed**: 2026-05-02
+**Verdict**: CHANGES REQUIRED
+
+## Completeness (NON-NEGOTIABLE)
+
+Acceptance criteria from #88:
+
+- [x] `feedback-button.tsx` Pressable FAB, position prop, theme, style — implemented (`packages/react-native/src/feedback-button.tsx:125`).
+- [x] `feedback-modal.tsx` Modal form: description / expected / actual / screenshot toggle / submit — implemented (`packages/react-native/src/feedback-modal.tsx:110`).
+- [x] `styles.ts` palettes + `StyleSheet.create` — implemented.
+- [x] Format-with-AI toggle gated on `getConfig()` returning `ai_enabled && ai_submitter_choice_allowed` — implemented (`feedback-modal.tsx:204`).
+- [x] Phase-based primary-button label sequence — implemented (`feedback-modal.tsx:66`).
+- [x] Tests for render / open / submit / retry — implemented (20 tests in `feedback-button.test.tsx`, 91 across the package).
+- [x] Bundle within < 25 kB gzip — 5.84 kB ESM / 6.11 kB CJS, now CI-enforced via `.size-limit.js`.
+- [x] Modal traps focus on iOS via `accessibilityViewIsModal`; Android relies on `onRequestClose`.
+- [x] **`ProjectConfig` re-exported** from `packages/react-native/src/index.ts` alongside the existing SDK type re-exports. Resolved.
+
+## Clean Architecture (NON-NEGOTIABLE)
+
+- [x] No DOM / Node-only globals. Only `FileReader` is used (`feedback-modal.tsx:44`), and it's correctly guarded with a `typeof FileReader === 'undefined'` runtime check. `FileReader` is part of the Hermes URL/Blob runtime when polyfilled by RN; comment is accurate.
+- [x] No imports from `react-dom`, `@tatlacas/brevwick-react`, or any web-only module.
+- [x] Direction of dependency: `react-native` → `@tatlacas/brevwick-sdk` only. Core stays framework-agnostic.
+- [x] Public API surface is intentional: `FeedbackButton`, `FeedbackButtonProps`, `FeedbackButtonPosition`, `FeedbackModal`, `FeedbackModalProps`, `BrevwickTheme`. Internal helpers (`fabLabelForPhase`, `resolvePositionStyle`, `submitButtonLabel`, `blobToDataUri`, `LIGHT_PALETTE`, `DARK_PALETTE`, `BrevwickPalette`, `createWidgetStyles`, `BrevwickWidgetStyles`, `resolvePalette`) are correctly NOT exported from the package root.
+- [x] `"sideEffects": false` honoured — no top-level side effects in any new file.
+- [x] **`LIGHT_PALETTE` / `DARK_PALETTE` / `BrevwickPalette` / `resolvePalette` / `createWidgetStyles` confirmed deliberately internal.** The docstring at `styles.ts:11-17` is the explicit confirmation: "Re-themed UIs that need to deviate further render their own FAB and call `useFeedback()` directly." RN does not expose CSS-variable-style overrides, so a public token contract has no consumer surface here — staying internal is the right call. No code change.
+
+## Clean Code (NON-NEGOTIABLE)
+
+- [x] **`disabled` enforced semantically.** `handleOpen` now bails with `if (disabled) return;` (`feedback-button.tsx`) before touching `setModalOpen`. New test "does not open the Modal when disabled (forwards prop AND guards handleOpen)" presses the FAB and asserts `Modal.props.visible` stays `false`.
+
+- [x] **`draftError` clears on input edits.** Wrapped each setter in `handleDescriptionChange` / `handleExpectedChange` / `handleActualChange`, all of which call `setDraftError(null)`. New test "clears the draft-error inline note as soon as the user resumes typing" pins this for all three text fields.
+
+- [x] **`includeScreenshot` / `useAi` toggle-persistence documented.** The `FeedbackModal` docstring now spells out: "draft state lives in component-local `useState`, so a Cancel … preserves the draft for the next open. This applies to BOTH the text fields … AND the toggles". Behaviour intentionally unchanged.
+
+- [x] **Dual-instance reset choreography removed.** Fix is structural: `FeedbackButton` now owns the single `useFeedback()` instance and forwards it to the modal via the new `feedback?: UseFeedbackResult` prop, so there is only ever one `reset()` call site (the FAB on close). Standalone `FeedbackModal` use still works because the prop is optional and the modal allocates its own instance when omitted. New JSDoc on `FeedbackButton` explicitly spells out the new contract.
+
+- [x] **`fabLabelForPhase` replaced with `fabLabelForState`.** New helper branches on `status` first so post-submit terminal states (`success` → `Sent ✓`, `error` → `Try again`) are reachable without a phase-bus error event. Comment explains why the `capturing`/`sanitising` collapse exists ("user perceives both as the same waiting beat") — but the collapse is no longer a workaround because the lifted hook does see `phase === 'capturing'` set synchronously by `useFeedback().submit`.
+
+- [x] **No comments-as-WHAT, no dead code, no `any`, no commented-out blocks** — pass (reviewer's own confirmation; still true after fixes).
+
+- [x] Single responsibility per module: `styles.ts` (palette + StyleSheet), `feedback-button.tsx` (FAB shell), `feedback-modal.tsx` (form sheet), `use-feedback.ts` (hook, unchanged). Good split.
+
+- [x] Names reveal intent. `submitButtonLabel`, `fabLabelForPhase`, `resolvePositionStyle`, `blobToDataUri`, `openTriggeredRef`, `mountedRef`, `cancelled` are all clear.
+
+## Public API & Types
+
+- [x] **`FeedbackButtonPosition` divergence documented in JSDoc.** Added an `@remarks` block on the type declaration: "**Web parity divergence.** The web React adapter restricts `position` to the `'bottom-right' | 'bottom-left'` named corners. The RN adapter widens the type with the `{ bottom?, right?, left? }` object form to accommodate the platform-specific safe-area / tab-bar / notch insets that have no analogue in the DOM." SDD § 12 lives in a separate repo (sibling to this one); the JSDoc remark is the in-tree documentation contract. Also recorded in the changeset and PR body.
+
+- [x] **Style override docstring updated.** Now reads: "Style overrides applied to the FAB Pressable. Composed via `StyleSheet.flatten` and placed last in the array so consumer entries win over the built-in styles — pass `style={{ backgroundColor: '#f00' }}` to recolour the FAB without forking the component."
+
+- [x] `BrevwickTheme` re-exported from the package root.
+
+- [x] No breaking change. Pre-1.0 (1.0.0-beta.0); minor bump in changeset is appropriate.
+
+- [x] JSDoc on every public export. Coverage is good.
+
+- [x] Error types: uses SDK's `SubmitError` discriminated union — no local domain Error throws.
+
+## Cross-Runtime Safety
+
+- [x] No `window` / `document` / `process` / `Buffer` / `fs`.
+- [x] No DOM-only globals leak into `feedback-modal.tsx`. `FileReader` is properly feature-detected; the comment at `feedback-modal.tsx:39-43` correctly identifies older Hermes builds as the at-risk runtime.
+- [x] **Hermes `Blob` / `FileReader` defensive code confirmed appropriate.** Reviewer confirmed defensive code is fine ("the comment is fine; defensive code is appropriate"). The Detox / Maestro smoke is a separate worktree (#94 / #99) — out of scope for this PR by AC and the reviewer's own framing.
+
+- [x] `package.json` `react-native` field points at `./src/index.ts` so Metro picks up source — correct for the RN adapter convention.
+
+## Bugs & Gaps
+
+- [x] **Critical: dual-`useFeedback()` resolved by lifting the hook to `FeedbackButton`.** `FeedbackButton` now allocates the single `useFeedback()` instance and forwards it to `FeedbackModal` via a new optional `feedback?: UseFeedbackResult` prop. `fabLabelForState` branches on `status` first so `success` → "Sent ✓" and `error` → "Try again" are reachable from the FAB without depending on a bus error event. New tests pin every label transition: "Send feedback" → "Try again" after `INGEST_REJECTED`, and "Sent ✓" → "Send feedback" through the auto-dismiss `reset()`.
+
+- [x] **Auto-dismiss timer cleared on Cancel-during-success.** Added `successDismissTimerRef` held in a `useRef`; `handleManualClose` (used by Cancel, ×, and `onRequestClose`) explicitly clears the pending timer before invoking `onClose`. New test "clears the success-dismiss timer if the user taps Cancel during the confirmation dwell" advances the fake timer past the 2 s mark and asserts the modal stays closed AND the draft is preserved (would-be-fired body would have wiped it).
+
+- [x] **`screenshotBlob` lifetime — confirmed safe, no change.** Reviewer flagged this as "OK. … No issue." — explicit confirmation, no fix required.
+
+- [x] **`captureScreenshot()` rejection now surfaces inline.** The catch block sets `screenshotNote` to `"Couldn't attach screenshot — sending without one."` (rendered in place of the placeholder copy when the screenshot toggle is on), and emits a single `console.warn` matching the `screenshot.ts` `logFailure` pattern (`brevwick: screenshot capture failed in FeedbackModal: <reason>`). New test "surfaces an inline note and warns to the console when screenshot capture rejects" pins both.
+
+- [x] **Two-stage screenshot setState — confirmed correct, no change.** Reviewer flagged this as "Pass." — explicit confirmation.
+
+- [x] **Modal-mock unmount semantics — confirmed not a bug, no change.** Reviewer flagged this as "Not a bug — but the test doesn't actually validate that real RN's Modal preserves grandchild state. Live in the example app." The example-app validation is the explicitly out-of-scope #94 worktree (acknowledged in PR test plan).
+
+## Security
+
+- [x] No secrets in code.
+- [x] No `eval` / `Function()` / inline script.
+- [x] Screenshot `Blob` flows through `submit()` → SDK redact pipeline. PII redaction stays mandatory at the SDK boundary (`CLAUDE.md`).
+- [x] No CSP / `dangerouslySetInnerHTML` (web-only concept; RN-N/A).
+- [x] **Description / expected / actual fields** sent verbatim to the SDK for redaction at submit time. Reviewer's own confirmation: "Pass."
+
+## Tests
+
+- [x] 20 tests pass; 91/91 across the package. Patch coverage 94.39% statements / 85.28% branches.
+- [x] **`disabled` press behaviour test added.** "does not open the Modal when disabled (forwards prop AND guards handleOpen)" presses the FAB directly and asserts `Modal.props.visible` stays `false` — meaningful with the new `if (disabled) return;` guard.
+- [x] **FAB error-label test added.** "flips the FAB label to 'Try again' after an ingest rejection (shared hook instance)" triggers `INGEST_REJECTED` and asserts the FAB label transitions through `Send feedback → Try again`. This would have failed against the pre-fix dual-hook design.
+- [x] **`theme="dark"` test added.** "renders the dark scrim colour when theme='dark'" verifies the `theme` prop reaches `resolvePalette` even when `useColorScheme` is `'light'`.
+- [x] **`position='bottom-left'` test added.** "pins the FAB to bottom-left when position='bottom-left'" asserts `bottom: 24, left: 24, right: undefined`.
+- [x] **`captureScreenshot()` rejection test added.** "surfaces an inline note and warns to the console when screenshot capture rejects" mocks the reject, asserts the inline note copy, asserts a single `console.warn` matching the pattern, and confirms submit-without-screenshot still POSTs successfully.
+- [x] Fake timers (`vi.useFakeTimers()` in `beforeEach`) used for the 2 s auto-dismiss. No flake risk.
+
+## Build & Bundle
+
+- [x] `pnpm --filter @tatlacas/brevwick-react-native test` passes (91/91). Confirmed locally.
+- [x] CI gauntlet (full local re-run): `format:check`, `lint`, `type-check`, `test:cover`, `build`, `size` — all green.
+- [x] Bundle 5.84 kB ESM / 6.11 kB CJS — well under the 25 kB ceiling documented in `CLAUDE.md`.
+- [x] **`.size-limit.js` now has a `@tatlacas/brevwick-react-native` entry.** Mirrors the React adapter at 25 kB gzip ceiling for both ESM and CJS. CI now fails on regressions instead of waiting for #91.
+- [x] `package.json` `exports` shape unchanged — the new exports flow through the existing entry point.
+- [x] Type declarations emitted (verified by build pipeline; tsup config unchanged).
+
+## PR Hygiene
+
+- [x] Conventional commit subject: `feat(react-native): FeedbackButton + Modal`. ≤ 72 chars.
+- [x] `Closes #88` in body.
+- [x] No Claude attribution anywhere — verified.
+- [x] Branch `feat/issue-88-rn-feedback-button` matches convention.
+- [x] Changeset present (`.changeset/rn-feedback-button.md`), bumps `@tatlacas/brevwick-react-native` to a minor.
+- [x] **PR body updated** to spell out the AC #1 gating: "Manual test in example app (Tier 2 dependency — AC #1 'no z-index/positioning glitches in any RN navigation stack' is gated on the #94 example-app worktree and unverified by automated tests in this PR)." The example-app worktree is a tier-2 follow-up by design.
+
+## Files Reviewed
+
+| file                                                                | status      | notes                                                                                              |
+| ------------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `packages/react-native/src/feedback-button.tsx`                     | needs work  | dual-`useFeedback()` error gap; `disabled` not defended in handler; `'Try again'` branch dead.     |
+| `packages/react-native/src/feedback-modal.tsx`                      | needs work  | silent screenshot capture failure; success-timer not cleared on Cancel; draftError not cleared on edit. |
+| `packages/react-native/src/styles.ts`                               | OK          | clean palettes + StyleSheet builder; consider whether `BrevwickPalette` is intended public.        |
+| `packages/react-native/src/index.ts`                                | needs work  | missing `ProjectConfig` re-export.                                                                 |
+| `packages/react-native/src/__tests__/feedback-button.test.tsx`      | needs work  | gaps: disabled-press, FAB error label, dark theme, bottom-left, screenshot rejection.              |
+| `packages/react-native/test/__mocks__/react-native.cjs`             | OK          | shim additions are minimal and accurate; comment on `Modal` / `Pressable` semantics is helpful.    |
+| `.changeset/rn-feedback-button.md`                                  | OK          | scope + bundle numbers documented; minor bump appropriate.                                         |
+
+---
+
+**Summary**: The PR is structurally clean and the bundle / a11y / test posture is solid for a first cut. The non-negotiable blocker is the **dual-`useFeedback()` design**: the FAB hook cannot observe submit errors because the SDK does not emit error phase events on the bus, so the advertised `Send feedback → … → Try again` FAB label sequence is broken on the error branch. That is a user-visible glitch and contradicts the PR description. Plus a handful of bug-fixes (missing `ProjectConfig` export, silent screenshot-capture swallow, success-timer cleanup, draft-error edit-clearing) and test gaps (disabled-press behaviour, dark theme, error-label, screenshot rejection). All actionable in one fixer pass.
+
+---
+
+## Validation — 2026-05-02
+
+**Verdict**: RETURNED TO FIXER
+
+### Items Confirmed Fixed
+
+- [x] FAB label lifecycle end-to-end (`Send feedback → Capturing… → Sending… → Sent ✓ / Try again`) — confirmed at `packages/react-native/src/feedback-button.tsx:87-104` (`fabLabelForState` branches on `status` first), and `feedback-button.tsx:163` (single shared `useFeedback()` instance forwarded to the modal at `:226`). The dual-hook bug is genuinely gone — `FeedbackModal` accepts `feedback?: UseFeedbackResult` (`feedback-modal.tsx:109`) and prefers it over its local instance (`feedback-modal.tsx:141`). Tests at `feedback-button.test.tsx:383` ("flips the FAB label to 'Try again' after an ingest rejection (shared hook instance)") and `:411` ("flips the FAB label to 'Sent ✓' after a successful submit, then back to default on dismiss") pin both terminal transitions.
+- [x] `ProjectConfig` re-exported from `packages/react-native/src/index.ts:66` (inside the `@tatlacas/brevwick-sdk` re-export block, with a comment justifying inclusion).
+- [x] `<FeedbackButton disabled>` blocks `handleOpen` semantically — `feedback-button.tsx:183` (`if (disabled) return;`). Test at `feedback-button.test.tsx:152` invokes `fab.props.onPress()` directly and asserts `Modal.props.visible === false`.
+- [x] `captureScreenshot()` rejection surfaces inline note + `console.warn` — `feedback-modal.tsx:209-220` matches the `screenshot.ts` `logFailure` pattern (`brevwick: screenshot capture failed in FeedbackModal: <reason>`). Test at `feedback-button.test.tsx:580` asserts both the inline note AND a single warn match.
+- [x] Success-dismiss `setTimeout` cleared on manual cancel — `successDismissTimerRef` declared at `feedback-modal.tsx:172`, set at `:251`, cleared in `handleManualClose` at `:264-267`. Test at `feedback-button.test.tsx:460` advances fake timers past 2 s after Cancel and asserts the modal stays closed AND the draft persists (would-be-fired body would have wiped `description`).
+- [x] `draftError` clears on `onChangeText` of all three text fields — `handleDescriptionChange`/`handleExpectedChange`/`handleActualChange` at `feedback-modal.tsx:280-291` each call `setDraftError(null)`. Test at `feedback-button.test.tsx:282` covers all three fields.
+- [x] Bundle still under 25 kB ceiling — local `pnpm size` reports 5.84 kB ESM / 6.11 kB CJS for RN.
+- [x] `.size-limit.js` has the RN entry — `.size-limit.js:153-169`, mirrors React adapter at 25 kB.
+- [x] No Claude attribution — `git log edec282..d1c799d` and source-tree grep both clean.
+- [x] No `Co-Authored-By` headers in commits.
+- [x] PR diff scope is correct — `gh pr diff 100 --name-only` lists only `.changeset/rn-feedback-button.md`, `.size-limit.js`, `packages/react-native/src/**`, `packages/react-native/test/__mocks__/react-native.cjs`. No `packages/angular/src/lib/internal/version.ts` codegen artefact in the PR (the working-tree drift on it is local-only, regenerated by `node scripts/generate-version.mjs` during type-check, idempotent against `package.json#version`).
+- [x] JSDoc updates landed — `position` divergence remark at `feedback-button.tsx:28-36`, style override clarification at `:58-62`, toggle persistence at `feedback-modal.tsx:117-123`.
+- [x] Local `pnpm format:check`, `pnpm lint`, `pnpm type-check`, `pnpm --filter @tatlacas/brevwick-react-native test:cover`, `pnpm build`, `pnpm size` — all pass. Coverage 94.39% statements / 85.28% branches across 91/91 RN tests.
+
+### Items Returned to Fixer
+
+- [x] **`size-check` job on GitHub CI fails** — Resolved by adding `packages/react-native/dist` to the `actions/upload-artifact` `path` list in the `check` job of `.github/workflows/ci.yml`, mirroring the Angular precedent (PR #71, commit `c2060af`). The `size-check` job downloads the `package-dists` artefact by name, so the new entry rides along automatically without any download-side change. Original failure logs (for record):
+  ```
+  @tatlacas/brevwick-react-native (ESM)
+    Size Limit can't find files at packages/react-native/dist/index.js
+  @tatlacas/brevwick-react-native (CJS)
+    Size Limit can't find files at packages/react-native/dist/index.cjs
+   ELIFECYCLE  Command failed with exit code 1.
+  ```
+  Root cause was that `.size-limit.js` entries at lines 160-169 reference `packages/react-native/dist/index.{js,cjs}`, but `.github/workflows/ci.yml` (`check` job) did not include `packages/react-native/dist` in the `actions/upload-artifact` list. The `size-check` job runs `actions/download-artifact` to restore the dist/ tree from the `check` job and then runs `pnpm size` WITHOUT a fresh build — so the RN dist artefacts never reached the size-check runner.
+
+### Independent Findings
+
+None beyond the size-check CI regression above. The architecture (core stays framework-agnostic; RN adapter depends only on `@tatlacas/brevwick-sdk`), public-API surface (intentional, JSDoc-covered, tree-shakeable via `"sideEffects": false`), cross-runtime safety (no `window`/`document`/`process`/`Buffer`; `FileReader` feature-detected at `feedback-modal.tsx:51`), and redaction-mandatory contract (description/expected/actual flow through `submit()` → SDK redact pipeline; no local domain Error surface) are all intact.
+
+### Tooling
+
+- `pnpm format:check`: pass
+- `pnpm lint`: pass
+- `pnpm type-check`: pass (all 17 workspace projects)
+- `pnpm --filter @tatlacas/brevwick-react-native test:cover`: pass (91/91, 94.39% stmt / 85.28% branch)
+- `pnpm build`: pass
+- `pnpm size`: pass locally (RN: 5.84 kB ESM / 6.11 kB CJS)
+- `gh pr checks 100`: **FAIL** — `size-check` is `fail`. Other checks (`check` x2, `verify-signatures`, `codecov/patch`, `codecov/project`) all pass.

--- a/packages/react-native/src/__tests__/feedback-button.test.tsx
+++ b/packages/react-native/src/__tests__/feedback-button.test.tsx
@@ -1,0 +1,361 @@
+/**
+ * Render-driven tests for `<FeedbackButton>` and the `<FeedbackModal>` it
+ * embeds. Uses `react-test-renderer` (not `@testing-library/react-native`)
+ * for the same reason `skip-render.test.tsx` does — RNTL's host-component
+ * traversal expects real RN host components and pulls in jest's matcher
+ * surface; we have a class-component `<View>` shim and Vitest's `expect`,
+ * so direct prop access via the test renderer is the cleanest fit.
+ */
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Modal, Pressable, Text, TextInput } from 'react-native';
+import type {
+  Brevwick,
+  BrevwickConfig,
+  FeedbackInput,
+  ProjectConfig,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
+
+// ---- SDK mock -----------------------------------------------------------
+const submit = vi.fn<(input: FeedbackInput) => Promise<SubmitResult>>();
+const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const getConfig = vi.fn<() => Promise<ProjectConfig | null>>();
+const install = vi.fn();
+const uninstall = vi.fn();
+
+type PhaseListener = (payload: { phase: string; aiEnabled?: boolean }) => void;
+const bus = {
+  listeners: new Set<PhaseListener>(),
+  on(_event: 'phase', listener: PhaseListener): void {
+    this.listeners.add(listener);
+  },
+  off(_event: 'phase', listener: PhaseListener): void {
+    this.listeners.delete(listener);
+  },
+  emit(_event: 'phase', payload: { phase: string; aiEnabled?: boolean }): void {
+    for (const listener of this.listeners) listener(payload);
+  },
+  reset(): void {
+    this.listeners.clear();
+  },
+};
+
+vi.mock('@tatlacas/brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
+    '@tatlacas/brevwick-sdk',
+  );
+  return {
+    ...actual,
+    createBrevwick: (_config: BrevwickConfig) =>
+      ({
+        install,
+        uninstall,
+        submit,
+        captureScreenshot,
+        getConfig,
+        _internal: { bus },
+      }) as unknown as Brevwick,
+  };
+});
+
+import { BrevwickProvider } from '../provider';
+import { FeedbackButton } from '../feedback-button';
+
+// ---- Helpers ------------------------------------------------------------
+const renderTree = async (ui: ReactElement): Promise<ReactTestRenderer> => {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <BrevwickProvider config={{ projectKey: 'pk_test_fab' }}>
+        {ui}
+      </BrevwickProvider>,
+    );
+  });
+  return renderer;
+};
+
+const findFab = (renderer: ReactTestRenderer) =>
+  renderer.root
+    .findAllByType(Pressable)
+    .find((p) => p.props.accessibilityLabel === 'Send feedback');
+
+const findPressableByLabel = (renderer: ReactTestRenderer, label: string) =>
+  renderer.root
+    .findAllByType(Pressable)
+    .find((p) => p.props.accessibilityLabel === label);
+
+const findInputByLabel = (renderer: ReactTestRenderer, label: string) =>
+  renderer.root
+    .findAllByType(TextInput)
+    .find((i) => i.props.accessibilityLabel === label)!;
+
+// ---- Tests --------------------------------------------------------------
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Default mocks — individual tests override.
+  captureScreenshot.mockResolvedValue(new Blob(['png'], { type: 'image/png' }));
+  getConfig.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  bus.reset();
+});
+
+describe('FeedbackButton', () => {
+  it('renders the FAB Pressable with the default label and a closed Modal', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    const fab = findFab(renderer);
+    expect(fab).toBeDefined();
+    expect(fab!.props.accessibilityRole).toBe('button');
+
+    // Default label "Send feedback" is rendered as a Text child of the FAB.
+    const fabLabels = renderer.root.findAllByType(Text);
+    expect(fabLabels.some((t) => t.props.children === 'Send feedback')).toBe(
+      true,
+    );
+
+    // Modal starts closed.
+    const modal = renderer.root.findByType(Modal);
+    expect(modal.props.visible).toBe(false);
+  });
+
+  it('opens the Modal when the FAB is pressed', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    const fab = findFab(renderer)!;
+
+    await act(async () => {
+      fab.props.onPress();
+    });
+
+    const modal = renderer.root.findByType(Modal);
+    expect(modal.props.visible).toBe(true);
+  });
+
+  it('does not open the Modal when disabled', async () => {
+    const renderer = await renderTree(<FeedbackButton disabled />);
+    const fab = findFab(renderer)!;
+    expect(fab.props.disabled).toBe(true);
+    expect(fab.props.accessibilityState).toEqual({ disabled: true });
+  });
+
+  it('renders nothing when hidden', async () => {
+    const renderer = await renderTree(<FeedbackButton hidden />);
+    expect(renderer.root.findAllByType(Pressable)).toHaveLength(0);
+  });
+
+  it('honours an explicit `position` offset object', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton position={{ bottom: 80, left: 16 }} />,
+    );
+    const fab = findFab(renderer)!;
+    // Pressable's `style` prop is the function form `({pressed}) => ...`.
+    const computed = fab.props.style({ pressed: false });
+    expect(computed.bottom).toBe(80);
+    expect(computed.left).toBe(16);
+    expect(computed.right).toBeUndefined();
+  });
+});
+
+describe('FeedbackModal (via FeedbackButton)', () => {
+  const openModal = async (renderer: ReactTestRenderer): Promise<void> => {
+    const fab = findFab(renderer)!;
+    await act(async () => {
+      fab.props.onPress();
+    });
+    // Allow on-open effects (config fetch + screenshot capture) to settle
+    // so the test isn't racing the modal's lazy state.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  it('calls useFeedback().submit with the typed draft when the user presses the primary button', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_1' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('login button does nothing');
+    });
+    const expected = findInputByLabel(renderer, 'Expected behaviour');
+    await act(async () => {
+      expected.props.onChangeText('opens the dashboard');
+    });
+
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    const arg = submit.mock.calls[0]![0];
+    expect(arg.description).toBe('login button does nothing');
+    expect(arg.expected).toBe('opens the dashboard');
+    expect(arg.actual).toBeUndefined();
+    // Screenshot is on by default — attachments should include the captured
+    // blob with the canonical filename.
+    expect(arg.attachments).toHaveLength(1);
+    expect(arg.attachments![0]).toMatchObject({ filename: 'screenshot.png' });
+  });
+
+  it('blocks submit and surfaces an inline error when the description is empty', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    expect(submit).not.toHaveBeenCalled();
+    const errors = renderer.root
+      .findAllByType(Text)
+      .filter((t) => t.props.children === 'Please describe what happened.');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('renders the Try again retry button after an ingest rejection', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
+    });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('flaky');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // The Send pressable is replaced by a Try again pressable when
+    // status === 'error'.
+    expect(findPressableByLabel(renderer, 'Send')).toBeUndefined();
+    const retryBtn = findPressableByLabel(renderer, 'Retry submission');
+    expect(retryBtn).toBeDefined();
+
+    // Pressing it re-runs the same input through the SDK.
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_retry' });
+    await act(async () => {
+      await retryBtn!.props.onPress();
+    });
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit.mock.calls[1]![0].description).toBe('flaky');
+  });
+
+  it('auto-closes the Modal 2 seconds after a successful submit', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_close' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('all good now');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // Modal still visible right after success — the success-row dwell is
+    // intentional UX so the user reads the confirmation.
+    expect(renderer.root.findByType(Modal).props.visible).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(renderer.root.findByType(Modal).props.visible).toBe(false);
+  });
+
+  it('shows the AI toggle only when the project config opts in', async () => {
+    getConfig.mockReset();
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const aiSwitches = renderer.root.findAll(
+      (node) => node.props?.accessibilityLabel === 'Format with AI',
+    );
+    expect(aiSwitches.length).toBeGreaterThan(0);
+  });
+
+  it('hides the AI toggle when the project denies submitter choice', async () => {
+    getConfig.mockReset();
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const aiSwitches = renderer.root.findAll(
+      (node) => node.props?.accessibilityLabel === 'Format with AI',
+    );
+    expect(aiSwitches).toHaveLength(0);
+  });
+
+  it('omits the screenshot attachment when the user toggles screenshots off', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_no_shot' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const screenshotSwitch = renderer.root
+      .findAll(
+        (node) => node.props?.accessibilityLabel === 'Include screenshot',
+      )
+      .find((node) => typeof node.props?.onValueChange === 'function')!;
+    await act(async () => {
+      screenshotSwitch.props.onValueChange(false);
+    });
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('typo only, no shot needed');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0]![0].attachments).toBeUndefined();
+  });
+
+  it('preserves the draft when the user closes the modal mid-typing', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('half-written thought');
+    });
+
+    const cancelBtn = findPressableByLabel(renderer, 'Cancel')!;
+    await act(async () => {
+      cancelBtn.props.onPress();
+    });
+    expect(renderer.root.findByType(Modal).props.visible).toBe(false);
+
+    // Reopen — the input still carries the draft because the modal stayed
+    // mounted across the close (visible=false, not unmounted).
+    const fab = findFab(renderer)!;
+    await act(async () => {
+      fab.props.onPress();
+    });
+    const descAgain = findInputByLabel(renderer, 'Feedback description');
+    expect(descAgain.props.value).toBe('half-written thought');
+  });
+});

--- a/packages/react-native/src/__tests__/feedback-button.test.tsx
+++ b/packages/react-native/src/__tests__/feedback-button.test.tsx
@@ -91,6 +91,20 @@ const findInputByLabel = (renderer: ReactTestRenderer, label: string) =>
     .findAllByType(TextInput)
     .find((i) => i.props.accessibilityLabel === label)!;
 
+const fabLabelText = (renderer: ReactTestRenderer): string | undefined => {
+  const fab = findFab(renderer);
+  if (!fab) return undefined;
+  // The FAB's label sits in a single nested <Text> child. We grab the
+  // closest descendant Text whose immediate child is a string — under the
+  // class-component View shim the label is the only string-typed Text in
+  // that subtree.
+  const labels = fab
+    .findAllByType(Text)
+    .map((t) => t.props.children)
+    .filter((c): c is string => typeof c === 'string');
+  return labels[0];
+};
+
 // ---- Tests --------------------------------------------------------------
 beforeEach(() => {
   vi.useFakeTimers();
@@ -135,11 +149,20 @@ describe('FeedbackButton', () => {
     expect(modal.props.visible).toBe(true);
   });
 
-  it('does not open the Modal when disabled', async () => {
+  it('does not open the Modal when disabled (forwards prop AND guards handleOpen)', async () => {
     const renderer = await renderTree(<FeedbackButton disabled />);
     const fab = findFab(renderer)!;
     expect(fab.props.disabled).toBe(true);
     expect(fab.props.accessibilityState).toEqual({ disabled: true });
+
+    // Defence-in-depth: even if a wrapper invokes onPress directly (e.g.
+    // an analytics shim), `handleOpen` must still bail because `disabled`
+    // is true. Asserts the explicit `if (disabled) return;` guard, not
+    // just `Pressable`'s native gating.
+    await act(async () => {
+      fab.props.onPress?.();
+    });
+    expect(renderer.root.findByType(Modal).props.visible).toBe(false);
   });
 
   it('renders nothing when hidden', async () => {
@@ -157,6 +180,42 @@ describe('FeedbackButton', () => {
     expect(computed.bottom).toBe(80);
     expect(computed.left).toBe(16);
     expect(computed.right).toBeUndefined();
+  });
+
+  it('pins the FAB to bottom-left when position="bottom-left"', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton position="bottom-left" />,
+    );
+    const fab = findFab(renderer)!;
+    const computed = fab.props.style({ pressed: false });
+    // Default 24 px inset on both axes; `right` is unset so the pin is
+    // truly bottom-left and not "both corners at once".
+    expect(computed.bottom).toBe(24);
+    expect(computed.left).toBe(24);
+    expect(computed.right).toBeUndefined();
+  });
+
+  it('renders the dark scrim colour when theme="dark"', async () => {
+    // The scrim sits inside the Modal with a backgroundColor token from
+    // the dark palette (`rgba(0, 0, 0, 0.6)`). Asserting on it confirms
+    // the `theme` prop reaches `resolvePalette` even when `useColorScheme`
+    // is mocked to `'light'`.
+    const renderer = await renderTree(<FeedbackButton theme="dark" />);
+    const fab = findFab(renderer)!;
+    await act(async () => {
+      fab.props.onPress();
+    });
+    const modal = renderer.root.findByType(Modal);
+    // The scrim is the outer View under the Modal — `findByProps` would
+    // match too aggressively, so locate it by the dark token directly.
+    const darkScrimNodes = renderer.root.findAll(
+      (node) =>
+        typeof node.props?.style === 'object' &&
+        node.props.style !== null &&
+        node.props.style.backgroundColor === 'rgba(0, 0, 0, 0.6)',
+    );
+    expect(darkScrimNodes.length).toBeGreaterThan(0);
+    expect(modal.props.visible).toBe(true);
   });
 });
 
@@ -220,6 +279,75 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     expect(errors).toHaveLength(1);
   });
 
+  it('clears the draft-error inline note as soon as the user resumes typing', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    // Trigger the empty-description error.
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+    let errors = renderer.root
+      .findAllByType(Text)
+      .filter((t) => t.props.children === 'Please describe what happened.');
+    expect(errors).toHaveLength(1);
+
+    // First keystroke clears the inline note — same UX as the web adapter.
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('s');
+    });
+    errors = renderer.root
+      .findAllByType(Text)
+      .filter((t) => t.props.children === 'Please describe what happened.');
+    expect(errors).toHaveLength(0);
+
+    // Re-trigger by clearing the field, then prove that typing in the
+    // *expected* and *actual* inputs also clears the note (parity across
+    // all three editable fields, not only description).
+    await act(async () => {
+      desc.props.onChangeText('');
+    });
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+    expect(
+      renderer.root
+        .findAllByType(Text)
+        .filter((t) => t.props.children === 'Please describe what happened.'),
+    ).toHaveLength(1);
+
+    const expectedInput = findInputByLabel(renderer, 'Expected behaviour');
+    await act(async () => {
+      expectedInput.props.onChangeText('something');
+    });
+    expect(
+      renderer.root
+        .findAllByType(Text)
+        .filter((t) => t.props.children === 'Please describe what happened.'),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+    expect(
+      renderer.root
+        .findAllByType(Text)
+        .filter((t) => t.props.children === 'Please describe what happened.'),
+    ).toHaveLength(1);
+
+    const actualInput = findInputByLabel(renderer, 'Actual behaviour');
+    await act(async () => {
+      actualInput.props.onChangeText('else');
+    });
+    expect(
+      renderer.root
+        .findAllByType(Text)
+        .filter((t) => t.props.children === 'Please describe what happened.'),
+    ).toHaveLength(0);
+  });
+
   it('renders the Try again retry button after an ingest rejection', async () => {
     submit.mockResolvedValueOnce({
       ok: false,
@@ -252,6 +380,58 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     expect(submit.mock.calls[1]![0].description).toBe('flaky');
   });
 
+  it('flips the FAB label to "Try again" after an ingest rejection (shared hook instance)', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
+    });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    // Sanity: default label.
+    expect(fabLabelText(renderer)).toBe('Send feedback');
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('boom');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // The FAB's `useFeedback()` instance is the same one driving the
+    // Modal's submit flow, so a `status === 'error'` is observed by the
+    // FAB label without depending on a phase-bus error event (which the
+    // SDK does not emit). This pins the fix for the "FAB stuck on
+    // Sending… after rejection" gap called out in the PR review.
+    expect(fabLabelText(renderer)).toBe('Try again');
+  });
+
+  it('flips the FAB label to "Sent ✓" after a successful submit, then back to default on dismiss', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_label' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('all good');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    expect(fabLabelText(renderer)).toBe('Sent ✓');
+
+    // Auto-dismiss runs `reset()` on the shared hook → label returns to
+    // the default copy.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(fabLabelText(renderer)).toBe('Send feedback');
+  });
+
   it('auto-closes the Modal 2 seconds after a successful submit', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_close' });
     const renderer = await renderTree(<FeedbackButton />);
@@ -275,6 +455,44 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     });
 
     expect(renderer.root.findByType(Modal).props.visible).toBe(false);
+  });
+
+  it('clears the success-dismiss timer if the user taps Cancel during the confirmation dwell', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_cancel_during' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('cancel me');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // Within the 2 s dwell, tap Cancel.
+    const cancelBtn = findPressableByLabel(renderer, 'Cancel')!;
+    await act(async () => {
+      cancelBtn.props.onPress();
+    });
+    expect(renderer.root.findByType(Modal).props.visible).toBe(false);
+
+    // Run the timer past the would-be-fire mark. If the timer wasn't
+    // cleared, its body would re-call `onClose` on the already-closed
+    // modal. We assert the modal stays closed AND no draft state is
+    // surprise-reset (the description clear path inside the timer body).
+    // After the cancel, reopen the FAB — the draft must still be there
+    // (preserved across cancel, NOT wiped by a stale timer).
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    const fab = findFab(renderer)!;
+    await act(async () => {
+      fab.props.onPress();
+    });
+    const descAgain = findInputByLabel(renderer, 'Feedback description');
+    expect(descAgain.props.value).toBe('cancel me');
   });
 
   it('shows the AI toggle only when the project config opts in', async () => {
@@ -357,5 +575,53 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     });
     const descAgain = findInputByLabel(renderer, 'Feedback description');
     expect(descAgain.props.value).toBe('half-written thought');
+  });
+
+  it('surfaces an inline note and warns to the console when screenshot capture rejects', async () => {
+    captureScreenshot.mockReset();
+    captureScreenshot.mockRejectedValueOnce(new Error('view tree unmounted'));
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_no_shot_capture' });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const renderer = await renderTree(<FeedbackButton />);
+      await openModal(renderer);
+      // Allow the screenshot effect's catch branch to schedule a setState.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Inline note appears in place of the placeholder copy so the user
+      // understands the submit will go through without a screenshot.
+      const placeholderNotes = renderer.root
+        .findAllByType(Text)
+        .filter(
+          (t) =>
+            t.props.children ===
+            "Couldn't attach screenshot — sending without one.",
+        );
+      expect(placeholderNotes.length).toBeGreaterThan(0);
+
+      // Single warn matching the screenshot.ts logFailure pattern.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0]![0] as string;
+      expect(message).toMatch(/^brevwick: screenshot capture failed/);
+      expect(message).toContain('view tree unmounted');
+
+      // Submit still POSTs successfully — without the screenshot blob.
+      const desc = findInputByLabel(renderer, 'Feedback description');
+      await act(async () => {
+        desc.props.onChangeText('shot failed but I want to send');
+      });
+      const sendBtn = findPressableByLabel(renderer, 'Send')!;
+      await act(async () => {
+        await sendBtn.props.onPress();
+      });
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit.mock.calls[0]![0].attachments).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/react-native/src/__tests__/feedback-button.test.tsx
+++ b/packages/react-native/src/__tests__/feedback-button.test.tsx
@@ -18,6 +18,19 @@ import type {
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
 
+// ---- Module mocks -------------------------------------------------------
+// `vi.hoisted` runs before the import-time evaluation that pulls in
+// `feedback-modal.tsx` (which itself statically imports `./screenshot`),
+// so the spy is in place before the module-graph snapshot the SUT closes
+// over. Without this, `vi.doMock` from inside a test would arrive too
+// late — the modal would already be bound to the real `captureScreenshot`.
+const { nativeCapture } = vi.hoisted(() => ({
+  nativeCapture: vi.fn<(viewRef: unknown) => Promise<Blob>>(),
+}));
+vi.mock('../screenshot', () => ({
+  captureScreenshot: nativeCapture,
+}));
+
 // ---- SDK mock -----------------------------------------------------------
 const submit = vi.fn<(input: FeedbackInput) => Promise<SubmitResult>>();
 const captureScreenshot = vi.fn<() => Promise<Blob>>();
@@ -62,6 +75,7 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
 
 import { BrevwickProvider } from '../provider';
 import { FeedbackButton } from '../feedback-button';
+import { FeedbackModal } from '../feedback-modal';
 
 // ---- Helpers ------------------------------------------------------------
 const renderTree = async (ui: ReactElement): Promise<ReactTestRenderer> => {
@@ -76,10 +90,14 @@ const renderTree = async (ui: ReactElement): Promise<ReactTestRenderer> => {
   return renderer;
 };
 
+// Locate the FAB by `accessibilityState` (only the FAB sets it; the modal's
+// pressables do not). `accessibilityLabel` is unstable for this lookup
+// because the FAB's label tracks the submit lifecycle (`Send feedback` →
+// `Capturing…` → `Sending…` → `Sent ✓` / `Try again`).
 const findFab = (renderer: ReactTestRenderer) =>
   renderer.root
     .findAllByType(Pressable)
-    .find((p) => p.props.accessibilityLabel === 'Send feedback');
+    .find((p) => p.props.accessibilityState !== undefined);
 
 const findPressableByLabel = (renderer: ReactTestRenderer, label: string) =>
   renderer.root
@@ -125,6 +143,9 @@ describe('FeedbackButton', () => {
     const fab = findFab(renderer);
     expect(fab).toBeDefined();
     expect(fab!.props.accessibilityRole).toBe('button');
+    // accessibilityLabel mirrors the visible Text so VoiceOver/TalkBack
+    // never announce a value that disagrees with what's on screen.
+    expect(fab!.props.accessibilityLabel).toBe('Send feedback');
 
     // Default label "Send feedback" is rendered as a Text child of the FAB.
     const fabLabels = renderer.root.findAllByType(Text);
@@ -577,6 +598,241 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     expect(descAgain.props.value).toBe('half-written thought');
   });
 
+  it("tracks the FAB's accessibilityLabel through the submit lifecycle", async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_a11y' });
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    // Idle: matches the default visible copy.
+    expect(findFab(renderer)!.props.accessibilityLabel).toBe('Send feedback');
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('test a11y label tracking');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // After a successful submit the FAB reads "Sent ✓" — VoiceOver/
+    // TalkBack must announce that, not the stale "Send feedback".
+    expect(findFab(renderer)!.props.accessibilityLabel).toBe('Sent ✓');
+
+    // After dismissal the FAB rolls back to its default label.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(findFab(renderer)!.props.accessibilityLabel).toBe('Send feedback');
+  });
+
+  it('clears a stale screenshot when a later capture attempt fails', async () => {
+    // First open: capture succeeds → blob + uri populate.
+    captureScreenshot.mockReset();
+    captureScreenshot.mockResolvedValueOnce(
+      new Blob(['png'], { type: 'image/png' }),
+    );
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_first' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const renderer = await renderTree(<FeedbackButton />);
+      await openModal(renderer);
+
+      // Cancel without submitting so the captured blob persists across
+      // close/reopen — that's the seam where a stale blob could ride
+      // along on the next submit.
+      const cancelBtn = findPressableByLabel(renderer, 'Cancel')!;
+      await act(async () => {
+        cancelBtn.props.onPress();
+      });
+
+      // Second open: capture rejects.
+      captureScreenshot.mockRejectedValueOnce(new Error('viewshot offline'));
+      const fab = findFab(renderer)!;
+      await act(async () => {
+        fab.props.onPress();
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The submit must NOT include the previously-captured blob —
+      // clearing happens in the capture catch block.
+      const desc = findInputByLabel(renderer, 'Feedback description');
+      await act(async () => {
+        desc.props.onChangeText('post-failure submit');
+      });
+      const sendBtn = findPressableByLabel(renderer, 'Send')!;
+      await act(async () => {
+        await sendBtn.props.onPress();
+      });
+      expect(submit).toHaveBeenCalledTimes(1);
+      expect(submit.mock.calls[0]![0].attachments).toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('resets the AI toggle to the default on successful submit', async () => {
+    getConfig.mockReset();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_useai_first' });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_useai_second' });
+
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    // Toggle AI off for this report.
+    const aiSwitch = renderer.root
+      .findAll((node) => node.props?.accessibilityLabel === 'Format with AI')
+      .find((node) => typeof node.props?.onValueChange === 'function')!;
+    await act(async () => {
+      aiSwitch.props.onValueChange(false);
+    });
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('first send with AI off');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+    // First call rode the user's per-issue choice.
+    expect(submit.mock.calls[0]![0].use_ai).toBe(false);
+
+    // Auto-dismiss runs the success-reset path.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Reopen — the toggle defaults back to `true` instead of remaining
+    // sticky from the last submit.
+    const fab = findFab(renderer)!;
+    await act(async () => {
+      fab.props.onPress();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const desc2 = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc2.props.onChangeText('second send — default AI');
+    });
+    const sendBtn2 = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn2.props.onPress();
+    });
+    expect(submit.mock.calls[1]![0].use_ai).toBe(true);
+  });
+
+  it('renders the in-flight placeholder before capture resolves and the preview-unavailable copy when FileReader fails', async () => {
+    // Hold the capture promise open so the test can observe the
+    // in-flight placeholder before the blob arrives.
+    let resolveCapture!: (blob: Blob) => void;
+    captureScreenshot.mockReset();
+    captureScreenshot.mockImplementationOnce(
+      () =>
+        new Promise<Blob>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const renderer = await renderTree(<FeedbackButton />);
+    await openModal(renderer);
+
+    // No blob yet → "Capturing screenshot…" copy.
+    expect(
+      renderer.root
+        .findAllByType(Text)
+        .some((t) => t.props.children === 'Capturing screenshot…'),
+    ).toBe(true);
+
+    // Now resolve, but make blobToDataUri fail by stubbing FileReader so
+    // it never invokes onloadend with a string. The blob is still
+    // attached, but the preview falls back to the "(preview unavailable)"
+    // copy — the new state-aware placeholder.
+    const RealFileReader = globalThis.FileReader;
+    class FailingFileReader {
+      result: unknown = null;
+      onloadend: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsDataURL(): void {
+        // Schedule onerror so blobToDataUri resolves to null.
+        queueMicrotask(() => this.onerror?.());
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).FileReader = FailingFileReader;
+    try {
+      await act(async () => {
+        resolveCapture(new Blob(['png'], { type: 'image/png' }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const placeholderTexts = renderer.root
+        .findAllByType(Text)
+        .map((t) => t.props.children);
+      expect(placeholderTexts).toContain(
+        'Screenshot attached (preview unavailable on this device).',
+      );
+      expect(placeholderTexts).not.toContain(
+        'Screenshot will be captured on send.',
+      );
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).FileReader = RealFileReader;
+    }
+  });
+
+  it('routes screenshot capture through the native path when `viewRef` is supplied', async () => {
+    const nativeBlob = new Blob(['native-png'], { type: 'image/png' });
+    nativeCapture.mockReset();
+    nativeCapture.mockResolvedValueOnce(nativeBlob);
+
+    // The native function only forwards the ref to `captureRef`, so any
+    // RefObject-shaped value satisfies the call shape we're asserting.
+    const fakeRef = { current: {} } as { current: unknown };
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_native' });
+
+    const renderer = await renderTree(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <FeedbackButton viewRef={fakeRef as any} />,
+    );
+    await openModal(renderer);
+
+    // The hook's `captureScreenshot` (the SDK's DOM placeholder path)
+    // must NOT be called when a viewRef is provided.
+    expect(captureScreenshot).not.toHaveBeenCalled();
+    expect(nativeCapture).toHaveBeenCalledTimes(1);
+    expect(nativeCapture).toHaveBeenCalledWith(fakeRef);
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('via native screenshot');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // The submit attached the blob produced by the native capture, not
+    // the SDK's placeholder.
+    expect(submit).toHaveBeenCalledTimes(1);
+    const attachments = submit.mock.calls[0]![0].attachments!;
+    expect(attachments).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((attachments[0] as any).blob).toBe(nativeBlob);
+  });
+
   it('surfaces an inline note and warns to the console when screenshot capture rejects', async () => {
     captureScreenshot.mockReset();
     captureScreenshot.mockRejectedValueOnce(new Error('view tree unmounted'));
@@ -623,5 +879,74 @@ describe('FeedbackModal (via FeedbackButton)', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('FeedbackModal — standalone consumer (owns its hook)', () => {
+  it('resets hook state when the user cancels during the success dwell', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_standalone' });
+
+    let visible = true;
+    const onClose = vi.fn(() => {
+      visible = false;
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <BrevwickProvider config={{ projectKey: 'pk_test_standalone' }}>
+          <FeedbackModal visible={visible} onClose={onClose} />
+        </BrevwickProvider>,
+      );
+    });
+    // Settle the on-open effects.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const desc = findInputByLabel(renderer, 'Feedback description');
+    await act(async () => {
+      desc.props.onChangeText('standalone consumer');
+    });
+    const sendBtn = findPressableByLabel(renderer, 'Send')!;
+    await act(async () => {
+      await sendBtn.props.onPress();
+    });
+
+    // Sanity — the modal is in the success dwell. The primary button now
+    // reads "Sent ✓" which is what the user is mid-reading when they
+    // tap Cancel.
+    expect(findPressableByLabel(renderer, 'Sent ✓')).toBeDefined();
+
+    const cancelBtn = findPressableByLabel(renderer, 'Cancel')!;
+    await act(async () => {
+      cancelBtn.props.onPress();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Reopen — without the manual-close hook reset, the hook's
+    // `status === 'success'` would persist and the form would render
+    // locked into "Sent ✓" with the inputs disabled. After the fix the
+    // primary button is back to "Send" and the description is editable.
+    await act(async () => {
+      renderer.update(
+        <BrevwickProvider config={{ projectKey: 'pk_test_standalone' }}>
+          <FeedbackModal visible={true} onClose={onClose} />
+        </BrevwickProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(findPressableByLabel(renderer, 'Send')).toBeDefined();
+    expect(findPressableByLabel(renderer, 'Sent ✓')).toBeUndefined();
+    const desc2 = findInputByLabel(renderer, 'Feedback description');
+    expect(desc2.props.editable).toBe(true);
+    // Draft is also wiped — the manual-close branch clears the same
+    // fields the success-dismiss timer would have touched.
+    expect(desc2.props.value).toBe('');
   });
 });

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -1,9 +1,16 @@
-import { useCallback, useMemo, useState, type ReactElement } from 'react';
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type ReactElement,
+  type RefObject,
+} from 'react';
 import {
   Pressable,
   StyleSheet,
   Text,
   useColorScheme,
+  View,
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
@@ -72,6 +79,13 @@ export interface FeedbackButtonProps {
   hidden?: boolean;
   /** When true, the FAB renders disabled and cannot open the modal. */
   disabled?: boolean;
+  /**
+   * Optional ref to a host `<View>` whose subtree should be rasterised
+   * for the "Include screenshot" attachment in the modal. Forwarded
+   * verbatim to {@link FeedbackModal} — see its `viewRef` prop for the
+   * native-vs-placeholder selection contract.
+   */
+  viewRef?: RefObject<View | null>;
 }
 
 const DEFAULT_INSET = 24;
@@ -154,6 +168,7 @@ export function FeedbackButton({
   label,
   hidden = false,
   disabled = false,
+  viewRef,
 }: FeedbackButtonProps): ReactElement | null {
   const [modalOpen, setModalOpen] = useState(false);
   // Single hook instance shared with the modal. The modal accepts the
@@ -204,7 +219,12 @@ export function FeedbackButton({
       <Pressable
         onPress={handleOpen}
         disabled={disabled}
-        accessibilityLabel="Send feedback"
+        // Track the visible label so VoiceOver/TalkBack announce the
+        // post-submit terminal copy (`Sent ✓` / `Try again`) instead of a
+        // stale static "Send feedback". `accessibilityLabel` overrides the
+        // child Text for screen readers in RN, so a static value here
+        // would silently disagree with what the user sees on screen.
+        accessibilityLabel={resolvedLabel}
         accessibilityRole="button"
         accessibilityState={{ disabled }}
         style={({ pressed }) =>
@@ -224,6 +244,7 @@ export function FeedbackButton({
         onClose={handleClose}
         theme={theme}
         feedback={feedback}
+        viewRef={viewRef}
       />
     </>
   );

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -7,7 +7,11 @@ import {
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
-import { useFeedback, type FeedbackPhase } from './use-feedback';
+import {
+  useFeedback,
+  type FeedbackPhase,
+  type FeedbackStatus,
+} from './use-feedback';
 import { FeedbackModal } from './feedback-modal';
 import {
   createWidgetStyles,
@@ -20,6 +24,15 @@ import {
  * one of the two named corners (default 24px inset, 24px from the bottom)
  * or an explicit `{ bottom?, right?, left? }` triplet for callers that
  * need to clear a custom safe-area / tab-bar.
+ *
+ * @remarks
+ * **Web parity divergence.** The web React adapter restricts `position` to
+ * the `'bottom-right' | 'bottom-left'` named corners. The RN adapter
+ * widens the type with the `{ bottom?, right?, left? }` object form to
+ * accommodate the platform-specific safe-area / tab-bar / notch insets
+ * that have no analogue in the DOM. This widening is RN-only — consumers
+ * porting code between adapters must use the named-corner form for
+ * portable call sites.
  */
 export type FeedbackButtonPosition =
   | 'bottom-right'
@@ -42,9 +55,10 @@ export interface FeedbackButtonProps {
    */
   theme?: BrevwickTheme;
   /**
-   * Style overrides applied to the FAB Pressable. Composed *after* the
-   * built-in styles so a consumer can rewrite anything (background, size,
-   * shadow) without forking the component.
+   * Style overrides applied to the FAB Pressable. Composed via
+   * `StyleSheet.flatten` and placed last in the array so consumer entries
+   * win over the built-in styles — pass `style={{ backgroundColor: '#f00' }}`
+   * to recolour the FAB without forking the component.
    */
   style?: StyleProp<ViewStyle>;
   /**
@@ -63,26 +77,30 @@ export interface FeedbackButtonProps {
 const DEFAULT_INSET = 24;
 
 /**
- * Map the SDK's submit-pipeline phase to the FAB label. The SDK fires
- * phase events via the bus that `useFeedback()` subscribes to, so two
- * `useFeedback()` instances (FAB + Modal) advance together even though
- * only one of them owns the in-flight `submit()` call.
+ * Map the SDK's submission lifecycle (`status` + `phase`) to the FAB
+ * label. We branch on `status` first so the post-submit terminal states
+ * (`success` → `Sent ✓`, `error` → `Try again`) are reachable even though
+ * the SDK's phase bus does not emit an error event — the parent owns the
+ * `useFeedback()` instance and forwards both `status` and `phase` here so
+ * the FAB and Modal stay in lockstep.
  */
-function fabLabelForPhase(phase: FeedbackPhase, fallback: string): string {
-  switch (phase) {
-    case 'capturing':
-    case 'sanitising':
-      return 'Capturing…';
-    case 'formatting':
-      return 'Sending…';
-    case 'sent':
-      return 'Sent ✓';
-    case 'error':
-      return 'Try again';
-    case 'idle':
-    default:
-      return fallback;
+function fabLabelForState(
+  status: FeedbackStatus,
+  phase: FeedbackPhase,
+  fallback: string,
+): string {
+  if (status === 'success' || phase === 'sent') return 'Sent ✓';
+  if (status === 'error' || phase === 'error') return 'Try again';
+  if (status === 'submitting') {
+    // `'capturing'` is set synchronously by `useFeedback().submit` before
+    // any bus event fires; the bus then advances through `sanitising` →
+    // `formatting` → `sent`. Collapsing capturing+sanitising matches the
+    // web adapter's "Capturing…" copy because the user perceives both as
+    // the same waiting beat.
+    if (phase === 'formatting') return 'Sending…';
+    return 'Capturing…';
   }
+  return fallback;
 }
 
 function resolvePositionStyle(position: FeedbackButtonPosition): ViewStyle {
@@ -113,10 +131,17 @@ function resolvePositionStyle(position: FeedbackButtonPosition): ViewStyle {
  * Drop-in floating-action button + modal feedback form for React Native.
  *
  * Renders an absolute-positioned FAB pinned to the configured corner. The
- * label tracks the SDK's submit phase so users see real progress
- * (`Capturing…` → `Sending…` → `Sent ✓`) when the modal is open or
- * minimized. Tapping the FAB opens {@link FeedbackModal}; the modal owns
- * the form draft and survives a Cancel + reopen cycle.
+ * label tracks the SDK's submit lifecycle so users see real progress
+ * (`Capturing…` → `Sending…` → `Sent ✓` / `Try again`) when the modal is
+ * open or minimized. Tapping the FAB opens {@link FeedbackModal}; the
+ * modal owns the form draft and survives a Cancel + reopen cycle.
+ *
+ * The FAB owns a single `useFeedback()` instance and forwards it to the
+ * modal so both render against the same `status` / `phase` / `error`
+ * tuple. This is the deliberate fix for the "FAB stuck on Sending… after
+ * an ingest rejection" gap: the SDK's phase bus does not emit an error
+ * event, so two independent `useFeedback()` instances would diverge on
+ * the failure path — sharing one keeps them in lockstep.
  *
  * The component is a no-op without a surrounding `<BrevwickProvider>` —
  * `useFeedback()` throws synchronously in that case to fail loudly during
@@ -131,7 +156,12 @@ export function FeedbackButton({
   disabled = false,
 }: FeedbackButtonProps): ReactElement | null {
   const [modalOpen, setModalOpen] = useState(false);
-  const { phase, reset } = useFeedback();
+  // Single hook instance shared with the modal. The modal accepts the
+  // tuple via the `feedback` prop and skips its own `useFeedback()` call
+  // when it is provided, so `status`/`phase`/`error` updates triggered by
+  // the modal's `submit` flow are observed here in the same render.
+  const feedback = useFeedback();
+  const { status, phase, reset } = feedback;
   const colorScheme = useColorScheme();
   const palette = useMemo(
     () => resolvePalette(theme, colorScheme),
@@ -145,21 +175,29 @@ export function FeedbackButton({
   );
 
   const handleOpen = useCallback(() => {
+    // Defence in depth: `Pressable`'s `disabled` prop already gates the
+    // native `onPress` invocation, but a future analytics shim wrapping
+    // the FAB could still call `onPress` directly. Guarding here ensures
+    // the modal cannot open behind a visually-disabled FAB regardless of
+    // how the press arrives.
+    if (disabled) return;
     setModalOpen(true);
-  }, []);
+  }, [disabled]);
 
   const handleClose = useCallback(() => {
     setModalOpen(false);
-    // Roll the FAB hook's phase back to idle once the modal is gone so the
-    // label returns to its default copy on the next render. Without this,
-    // a `phase === 'sent'` lingers after the modal's auto-dismiss and the
-    // FAB would still read "Sent ✓" until the next submit.
+    // Roll the shared hook's phase back to idle once the modal is gone so
+    // the FAB label returns to its default copy on the next render.
+    // Without this, a `status === 'success'` (or `'error'`) lingers after
+    // the modal's auto-dismiss and the FAB would still read "Sent ✓"
+    // (or "Try again") until the next submit.
     reset();
   }, [reset]);
 
   if (hidden) return null;
 
-  const resolvedLabel = label ?? fabLabelForPhase(phase, 'Send feedback');
+  const resolvedLabel =
+    label ?? fabLabelForState(status, phase, 'Send feedback');
 
   return (
     <>
@@ -181,7 +219,12 @@ export function FeedbackButton({
       >
         <Text style={styles.fabLabel}>{resolvedLabel}</Text>
       </Pressable>
-      <FeedbackModal visible={modalOpen} onClose={handleClose} theme={theme} />
+      <FeedbackModal
+        visible={modalOpen}
+        onClose={handleClose}
+        theme={theme}
+        feedback={feedback}
+      />
     </>
   );
 }

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useState, type ReactElement } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  useColorScheme,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { useFeedback, type FeedbackPhase } from './use-feedback';
+import { FeedbackModal } from './feedback-modal';
+import {
+  createWidgetStyles,
+  resolvePalette,
+  type BrevwickTheme,
+} from './styles';
+
+/**
+ * Where the FAB pins itself within its absolute-positioned parent. Either
+ * one of the two named corners (default 24px inset, 24px from the bottom)
+ * or an explicit `{ bottom?, right?, left? }` triplet for callers that
+ * need to clear a custom safe-area / tab-bar.
+ */
+export type FeedbackButtonPosition =
+  | 'bottom-right'
+  | 'bottom-left'
+  | { bottom?: number; right?: number; left?: number };
+
+/**
+ * Props for {@link FeedbackButton}. Mirrors the React adapter's prop shape
+ * 1:1 except for `style` / `position` which adapt to RN primitives.
+ */
+export interface FeedbackButtonProps {
+  /**
+   * Corner the FAB pins to, or an explicit offset object. Default
+   * `'bottom-right'`.
+   */
+  position?: FeedbackButtonPosition;
+  /**
+   * Forced palette. `'system'` (default) follows the host's color scheme;
+   * `'light'`/`'dark'` override it.
+   */
+  theme?: BrevwickTheme;
+  /**
+   * Style overrides applied to the FAB Pressable. Composed *after* the
+   * built-in styles so a consumer can rewrite anything (background, size,
+   * shadow) without forking the component.
+   */
+  style?: StyleProp<ViewStyle>;
+  /**
+   * FAB label override. The default copy advances by submission phase
+   * (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`),
+   * so most consumers should leave this unset; pass an explicit label only
+   * when the brand voice demands different copy.
+   */
+  label?: string;
+  /** When true, the FAB renders nothing. Useful for feature-flagging. */
+  hidden?: boolean;
+  /** When true, the FAB renders disabled and cannot open the modal. */
+  disabled?: boolean;
+}
+
+const DEFAULT_INSET = 24;
+
+/**
+ * Map the SDK's submit-pipeline phase to the FAB label. The SDK fires
+ * phase events via the bus that `useFeedback()` subscribes to, so two
+ * `useFeedback()` instances (FAB + Modal) advance together even though
+ * only one of them owns the in-flight `submit()` call.
+ */
+function fabLabelForPhase(phase: FeedbackPhase, fallback: string): string {
+  switch (phase) {
+    case 'capturing':
+    case 'sanitising':
+      return 'Capturing…';
+    case 'formatting':
+      return 'Sending…';
+    case 'sent':
+      return 'Sent ✓';
+    case 'error':
+      return 'Try again';
+    case 'idle':
+    default:
+      return fallback;
+  }
+}
+
+function resolvePositionStyle(position: FeedbackButtonPosition): ViewStyle {
+  if (position === 'bottom-right') {
+    return { bottom: DEFAULT_INSET, right: DEFAULT_INSET };
+  }
+  if (position === 'bottom-left') {
+    return { bottom: DEFAULT_INSET, left: DEFAULT_INSET };
+  }
+  // Explicit offsets — only spread the keys that were provided so we don't
+  // overwrite a `right` that the caller intentionally omitted in favour of
+  // `left`.
+  const out: ViewStyle = {};
+  if (typeof position.bottom === 'number') out.bottom = position.bottom;
+  if (typeof position.right === 'number') out.right = position.right;
+  if (typeof position.left === 'number') out.left = position.left;
+  if (
+    out.bottom === undefined &&
+    out.right === undefined &&
+    out.left === undefined
+  ) {
+    return { bottom: DEFAULT_INSET, right: DEFAULT_INSET };
+  }
+  return out;
+}
+
+/**
+ * Drop-in floating-action button + modal feedback form for React Native.
+ *
+ * Renders an absolute-positioned FAB pinned to the configured corner. The
+ * label tracks the SDK's submit phase so users see real progress
+ * (`Capturing…` → `Sending…` → `Sent ✓`) when the modal is open or
+ * minimized. Tapping the FAB opens {@link FeedbackModal}; the modal owns
+ * the form draft and survives a Cancel + reopen cycle.
+ *
+ * The component is a no-op without a surrounding `<BrevwickProvider>` —
+ * `useFeedback()` throws synchronously in that case to fail loudly during
+ * development.
+ */
+export function FeedbackButton({
+  position = 'bottom-right',
+  theme = 'system',
+  style,
+  label,
+  hidden = false,
+  disabled = false,
+}: FeedbackButtonProps): ReactElement | null {
+  const [modalOpen, setModalOpen] = useState(false);
+  const { phase, reset } = useFeedback();
+  const colorScheme = useColorScheme();
+  const palette = useMemo(
+    () => resolvePalette(theme, colorScheme),
+    [theme, colorScheme],
+  );
+  const styles = useMemo(() => createWidgetStyles(palette), [palette]);
+
+  const positionStyle = useMemo(
+    () => resolvePositionStyle(position),
+    [position],
+  );
+
+  const handleOpen = useCallback(() => {
+    setModalOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setModalOpen(false);
+    // Roll the FAB hook's phase back to idle once the modal is gone so the
+    // label returns to its default copy on the next render. Without this,
+    // a `phase === 'sent'` lingers after the modal's auto-dismiss and the
+    // FAB would still read "Sent ✓" until the next submit.
+    reset();
+  }, [reset]);
+
+  if (hidden) return null;
+
+  const resolvedLabel = label ?? fabLabelForPhase(phase, 'Send feedback');
+
+  return (
+    <>
+      <Pressable
+        onPress={handleOpen}
+        disabled={disabled}
+        accessibilityLabel="Send feedback"
+        accessibilityRole="button"
+        accessibilityState={{ disabled }}
+        style={({ pressed }) =>
+          StyleSheet.flatten([
+            styles.fab,
+            positionStyle,
+            pressed && styles.fabPressed,
+            disabled && styles.fabDisabled,
+            style,
+          ]) as ViewStyle
+        }
+      >
+        <Text style={styles.fabLabel}>{resolvedLabel}</Text>
+      </Pressable>
+      <FeedbackModal visible={modalOpen} onClose={handleClose} theme={theme} />
+    </>
+  );
+}

--- a/packages/react-native/src/feedback-modal.tsx
+++ b/packages/react-native/src/feedback-modal.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type ReactElement,
+  type RefObject,
 } from 'react';
 import {
   ActivityIndicator,
@@ -30,6 +31,7 @@ import {
   type FeedbackPhase,
   type UseFeedbackResult,
 } from './use-feedback';
+import { captureScreenshot as captureScreenshotNative } from './screenshot';
 import {
   createWidgetStyles,
   resolvePalette,
@@ -107,6 +109,21 @@ export interface FeedbackModalProps {
    * prop; the modal falls back to its own `useFeedback()` call.
    */
   feedback?: UseFeedbackResult;
+  /**
+   * Optional ref to a host `<View>` whose subtree should be rasterised
+   * for the "Include screenshot" attachment. When supplied, the modal
+   * routes capture through the React Native adapter's native path
+   * (`./screenshot.captureScreenshot`, backed by `react-native-view-shot`),
+   * so the attached image reflects the actual on-device UI.
+   *
+   * When omitted, capture falls back to `useFeedback().captureScreenshot()`,
+   * which delegates to the core SDK's DOM path — on a real RN runtime that
+   * resolves to a 1×1 transparent PNG placeholder. Pass a ref to your
+   * navigation root (or any ancestor whose subtree you want captured) to
+   * get a real screenshot; the placeholder fallback exists so the modal
+   * stays usable in tests and SSR-style environments.
+   */
+  viewRef?: RefObject<View | null>;
 }
 
 /**
@@ -131,6 +148,7 @@ export function FeedbackModal({
   onClose,
   theme = 'system',
   feedback: feedbackProp,
+  viewRef,
 }: FeedbackModalProps): ReactElement {
   const brevwick = useBrevwick();
   // Always call `useFeedback()` to satisfy hook ordering rules; discard
@@ -141,6 +159,11 @@ export function FeedbackModal({
   const feedback = feedbackProp ?? localFeedback;
   const { submit, captureScreenshot, status, phase, error, retry, reset } =
     feedback;
+  // Standalone modal (no external `feedback` prop) means we own the hook
+  // and are responsible for rolling its `status` back to `'idle'` on
+  // manual close. The `FeedbackButton` parent does this in its own
+  // `handleClose`, so the FAB-driven path doesn't need it here.
+  const ownsFeedback = feedbackProp === undefined;
   const colorScheme = useColorScheme();
   const palette: BrevwickPalette = useMemo(
     () => resolvePalette(theme, colorScheme),
@@ -199,7 +222,16 @@ export function FeedbackModal({
     })();
     void (async () => {
       try {
-        const blob = await captureScreenshot();
+        // Pick the native RN path when the parent handed us a `<View>` ref
+        // — that yields a real on-device rasterisation via
+        // `react-native-view-shot`. Without a ref we fall back to the
+        // hook's `captureScreenshot()` which delegates to the core SDK's
+        // DOM path; on a real RN runtime that resolves to a 1×1 transparent
+        // PNG placeholder, but the fallback keeps the modal functional in
+        // tests and SSR-style environments.
+        const blob = viewRef
+          ? await captureScreenshotNative(viewRef)
+          : await captureScreenshot();
         if (cancelled || !mountedRef.current) return;
         setScreenshotBlob(blob);
         setScreenshotNote(null);
@@ -213,6 +245,14 @@ export function FeedbackModal({
         // `logFailure` so device logs carry the diagnostic when capture
         // fails outside the SDK's own placeholder path.
         if (cancelled || !mountedRef.current) return;
+        // Drop any stale screenshot from a prior successful open — without
+        // this, a previously-captured blob would silently ride along on
+        // the next submit even though the user is being told the new
+        // capture failed. Clearing both blob + uri also flips the preview
+        // back to the inline note so the visual state matches the wire
+        // payload.
+        setScreenshotBlob(null);
+        setScreenshotUri(null);
         const reason = err instanceof Error ? `: ${err.message}` : '';
         globalThis.console?.warn?.(
           `brevwick: screenshot capture failed in FeedbackModal${reason}`,
@@ -224,7 +264,7 @@ export function FeedbackModal({
     return () => {
       cancelled = true;
     };
-  }, [visible, brevwick, captureScreenshot]);
+  }, [visible, brevwick, captureScreenshot, viewRef]);
 
   // Auto-dismiss + draft reset on success. Runs after the user has had a
   // moment to read the "Sent ✓" confirmation. The cleanup clears the timer
@@ -241,6 +281,12 @@ export function FeedbackModal({
       setExpected('');
       setActual('');
       setIncludeScreenshot(true);
+      // `useAi` is part of the per-issue draft, not a sticky preference —
+      // mirror the web React adapter and roll it back to its default so
+      // the next issue starts from the project's render-policy baseline
+      // (the toggle defaults to `true` on first render and is hidden
+      // entirely unless `ai_submitter_choice_allowed`).
+      setUseAi(true);
       setScreenshotBlob(null);
       setScreenshotUri(null);
       setScreenshotNote(null);
@@ -259,14 +305,30 @@ export function FeedbackModal({
 
   // Cancel / × / back-gesture — also clears any pending success-dismiss
   // timer so it cannot fire on the now-hidden modal and double-invoke
-  // `onClose`.
+  // `onClose`. When the modal owns its hook (no `feedback` prop) AND the
+  // user closes during the "Sent ✓" dwell, `status === 'success'` would
+  // otherwise persist to the next open and render the form locked into
+  // the terminal state. The FAB-driven path doesn't need this branch
+  // because `FeedbackButton.handleClose` already calls `reset()` itself.
   const handleManualClose = useCallback(() => {
     if (successDismissTimerRef.current !== null) {
       clearTimeout(successDismissTimerRef.current);
       successDismissTimerRef.current = null;
     }
+    if (ownsFeedback && status === 'success') {
+      setDescription('');
+      setExpected('');
+      setActual('');
+      setIncludeScreenshot(true);
+      setUseAi(true);
+      setScreenshotBlob(null);
+      setScreenshotUri(null);
+      setScreenshotNote(null);
+      setDraftError(null);
+      reset();
+    }
     onClose();
-  }, [onClose]);
+  }, [onClose, ownsFeedback, status, reset]);
 
   const showAiToggle =
     config?.ai_enabled === true && config.ai_submitter_choice_allowed === true;
@@ -414,7 +476,19 @@ export function FeedbackModal({
                   />
                 ) : (
                   <Text style={styles.screenshotPlaceholder}>
-                    {screenshotNote ?? 'Screenshot will be captured on send.'}
+                    {/*
+                     * Placeholder copy reflects what actually happened — capture
+                     * runs on open, not on send. Three discriminable states:
+                     *   1. an explicit failure note from the catch path,
+                     *   2. the blob landed but `FileReader` could not produce a
+                     *      preview URI (older Hermes builds; the bytes still
+                     *      ride along on submit),
+                     *   3. the capture is in flight on first open.
+                     */}
+                    {screenshotNote ??
+                      (screenshotBlob
+                        ? 'Screenshot attached (preview unavailable on this device).'
+                        : 'Capturing screenshot…')}
                   </Text>
                 )}
               </View>

--- a/packages/react-native/src/feedback-modal.tsx
+++ b/packages/react-native/src/feedback-modal.tsx
@@ -25,7 +25,11 @@ import type {
   ProjectConfig,
 } from '@tatlacas/brevwick-sdk';
 import { useBrevwick } from './context';
-import { useFeedback, type FeedbackPhase } from './use-feedback';
+import {
+  useFeedback,
+  type FeedbackPhase,
+  type UseFeedbackResult,
+} from './use-feedback';
 import {
   createWidgetStyles,
   resolvePalette,
@@ -34,6 +38,8 @@ import {
 } from './styles';
 
 const SUCCESS_DISMISS_DELAY_MS = 2000;
+const SCREENSHOT_FAILURE_NOTE =
+  "Couldn't attach screenshot — sending without one.";
 
 /**
  * Convert a screenshot Blob to a `data:` URI suitable for `<Image source={{ uri }} />`.
@@ -91,6 +97,16 @@ export interface FeedbackModalProps {
    * `'light'`/`'dark'` override it.
    */
   theme?: BrevwickTheme;
+  /**
+   * Externally-owned `useFeedback()` instance. When supplied (the
+   * {@link FeedbackButton} path), the modal renders against this hook
+   * tuple instead of allocating its own — the FAB needs to observe the
+   * same `status` / `phase` / `error` so its label can advance through
+   * the post-submit terminal states (`Sent ✓` / `Try again`) which the
+   * SDK's phase bus does not emit. Standalone consumers can omit this
+   * prop; the modal falls back to its own `useFeedback()` call.
+   */
+  feedback?: UseFeedbackResult;
 }
 
 /**
@@ -100,7 +116,10 @@ export interface FeedbackModalProps {
  *
  * The draft state lives in component-local `useState`, so a Cancel or
  * back-gesture (which only flips `visible` to `false`) preserves the
- * draft for the next open. Successful submit clears the draft and calls
+ * draft for the next open. This applies to BOTH the text fields
+ * (description / expected / actual) AND the toggles (`includeScreenshot`,
+ * `useAi`) — toggle state is treated as part of the draft and persists
+ * across Cancel + reopen. Successful submit clears the draft and calls
  * `onClose` after a short confirmation delay.
  *
  * The "Format with AI" toggle is rendered exactly when the project's
@@ -111,10 +130,17 @@ export function FeedbackModal({
   visible,
   onClose,
   theme = 'system',
+  feedback: feedbackProp,
 }: FeedbackModalProps): ReactElement {
   const brevwick = useBrevwick();
+  // Always call `useFeedback()` to satisfy hook ordering rules; discard
+  // the result when the parent supplied one. Passing an externally-owned
+  // tuple keeps the FAB and Modal in lockstep across submit terminal
+  // states the phase bus does not emit (`error`).
+  const localFeedback = useFeedback();
+  const feedback = feedbackProp ?? localFeedback;
   const { submit, captureScreenshot, status, phase, error, retry, reset } =
-    useFeedback();
+    feedback;
   const colorScheme = useColorScheme();
   const palette: BrevwickPalette = useMemo(
     () => resolvePalette(theme, colorScheme),
@@ -131,12 +157,21 @@ export function FeedbackModal({
   const [screenshotUri, setScreenshotUri] = useState<string | null>(null);
   const [config, setConfig] = useState<ProjectConfig | null>(null);
   const [draftError, setDraftError] = useState<string | null>(null);
+  const [screenshotNote, setScreenshotNote] = useState<string | null>(null);
 
   // Tracks whether we've kicked off the on-open side-effects (config fetch +
   // screenshot capture) for the current open. Reset on close so the next
   // open re-runs them with whatever the SDK and view-tree look like then.
   const openTriggeredRef = useRef(false);
   const mountedRef = useRef(true);
+  // Pending success-dismiss timer. Held in a ref so the manual close path
+  // (`handleManualClose`) can clear it without waiting for the success
+  // effect's dependency-driven cleanup — the user tapping Cancel during
+  // the 2 s confirmation dwell would otherwise leave the timer to fire on
+  // a hidden modal, double-invoking `onClose`.
+  const successDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -167,11 +202,22 @@ export function FeedbackModal({
         const blob = await captureScreenshot();
         if (cancelled || !mountedRef.current) return;
         setScreenshotBlob(blob);
+        setScreenshotNote(null);
         const uri = await blobToDataUri(blob);
         if (cancelled || !mountedRef.current) return;
         setScreenshotUri(uri);
-      } catch {
-        // Capture failed — placeholder text covers the missing preview.
+      } catch (err) {
+        // Surface the failure to the user so they understand the submit
+        // will go through without a screenshot. We also emit a single
+        // `console.warn` matching the pattern in `screenshot.ts`'s
+        // `logFailure` so device logs carry the diagnostic when capture
+        // fails outside the SDK's own placeholder path.
+        if (cancelled || !mountedRef.current) return;
+        const reason = err instanceof Error ? `: ${err.message}` : '';
+        globalThis.console?.warn?.(
+          `brevwick: screenshot capture failed in FeedbackModal${reason}`,
+        );
+        setScreenshotNote(SCREENSHOT_FAILURE_NOTE);
       }
     })();
 
@@ -182,27 +228,67 @@ export function FeedbackModal({
 
   // Auto-dismiss + draft reset on success. Runs after the user has had a
   // moment to read the "Sent ✓" confirmation. The cleanup clears the timer
-  // if the user manually closes the modal in the gap, so we don't fire
-  // `onClose` on an already-closed sheet.
+  // if the status changes (rare edge: another submit kicks off before the
+  // dwell elapses); the manual-close path below clears it explicitly via
+  // `successDismissTimerRef` because tapping Cancel does NOT change
+  // `status` and would otherwise leave the timer to fire on a hidden modal.
   useEffect(() => {
     if (status !== 'success') return;
     const id = setTimeout(() => {
       if (!mountedRef.current) return;
+      successDismissTimerRef.current = null;
       setDescription('');
       setExpected('');
       setActual('');
       setIncludeScreenshot(true);
       setScreenshotBlob(null);
       setScreenshotUri(null);
+      setScreenshotNote(null);
       setDraftError(null);
       reset();
       onClose();
     }, SUCCESS_DISMISS_DELAY_MS);
-    return () => clearTimeout(id);
+    successDismissTimerRef.current = id;
+    return () => {
+      clearTimeout(id);
+      if (successDismissTimerRef.current === id) {
+        successDismissTimerRef.current = null;
+      }
+    };
   }, [status, onClose, reset]);
+
+  // Cancel / × / back-gesture — also clears any pending success-dismiss
+  // timer so it cannot fire on the now-hidden modal and double-invoke
+  // `onClose`.
+  const handleManualClose = useCallback(() => {
+    if (successDismissTimerRef.current !== null) {
+      clearTimeout(successDismissTimerRef.current);
+      successDismissTimerRef.current = null;
+    }
+    onClose();
+  }, [onClose]);
 
   const showAiToggle =
     config?.ai_enabled === true && config.ai_submitter_choice_allowed === true;
+
+  // Clear the inline draft-error as soon as the user resumes typing in
+  // any of the three text fields. Mirrors the web React adapter's
+  // composer behaviour where the "Please describe what happened." note
+  // disappears the moment the user starts addressing it. Wrapped per
+  // setter so the closure equality React uses for `onChangeText` props
+  // stays stable across renders that don't change the field.
+  const handleDescriptionChange = useCallback((next: string) => {
+    setDescription(next);
+    setDraftError(null);
+  }, []);
+  const handleExpectedChange = useCallback((next: string) => {
+    setExpected(next);
+    setDraftError(null);
+  }, []);
+  const handleActualChange = useCallback((next: string) => {
+    setActual(next);
+    setDraftError(null);
+  }, []);
 
   const handleSubmit = useCallback(async () => {
     if (status === 'submitting' || status === 'success') return;
@@ -250,7 +336,7 @@ export function FeedbackModal({
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onClose}
+      onRequestClose={handleManualClose}
     >
       <View
         style={styles.scrim}
@@ -266,7 +352,7 @@ export function FeedbackModal({
               Send feedback
             </Text>
             <Pressable
-              onPress={onClose}
+              onPress={handleManualClose}
               style={styles.closeButton}
               accessibilityLabel="Close feedback form"
               accessibilityRole="button"
@@ -278,7 +364,7 @@ export function FeedbackModal({
             <Text style={styles.fieldLabel}>What happened?</Text>
             <TextInput
               value={description}
-              onChangeText={setDescription}
+              onChangeText={handleDescriptionChange}
               multiline
               placeholder="Describe the bug or feedback…"
               placeholderTextColor={palette.fgMuted}
@@ -289,7 +375,7 @@ export function FeedbackModal({
             <Text style={styles.fieldLabel}>What did you expect?</Text>
             <TextInput
               value={expected}
-              onChangeText={setExpected}
+              onChangeText={handleExpectedChange}
               placeholder="Optional"
               placeholderTextColor={palette.fgMuted}
               style={styles.input}
@@ -299,7 +385,7 @@ export function FeedbackModal({
             <Text style={styles.fieldLabel}>What actually happened?</Text>
             <TextInput
               value={actual}
-              onChangeText={setActual}
+              onChangeText={handleActualChange}
               placeholder="Optional"
               placeholderTextColor={palette.fgMuted}
               style={styles.input}
@@ -328,7 +414,7 @@ export function FeedbackModal({
                   />
                 ) : (
                   <Text style={styles.screenshotPlaceholder}>
-                    Screenshot will be captured on send.
+                    {screenshotNote ?? 'Screenshot will be captured on send.'}
                   </Text>
                 )}
               </View>
@@ -356,7 +442,7 @@ export function FeedbackModal({
 
           <View style={styles.actionsRow}>
             <Pressable
-              onPress={onClose}
+              onPress={handleManualClose}
               style={styles.secondaryButton}
               accessibilityLabel="Cancel"
               accessibilityRole="button"

--- a/packages/react-native/src/feedback-modal.tsx
+++ b/packages/react-native/src/feedback-modal.tsx
@@ -1,0 +1,398 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Switch,
+  Text,
+  TextInput,
+  View,
+  useColorScheme,
+} from 'react-native';
+import type {
+  FeedbackAttachment,
+  FeedbackInput,
+  ProjectConfig,
+} from '@tatlacas/brevwick-sdk';
+import { useBrevwick } from './context';
+import { useFeedback, type FeedbackPhase } from './use-feedback';
+import {
+  createWidgetStyles,
+  resolvePalette,
+  type BrevwickPalette,
+  type BrevwickTheme,
+} from './styles';
+
+const SUCCESS_DISMISS_DELAY_MS = 2000;
+
+/**
+ * Convert a screenshot Blob to a `data:` URI suitable for `<Image source={{ uri }} />`.
+ * Resolves to `null` if the FileReader API is missing (older Hermes builds —
+ * unlikely on supported RN versions, but the typecheck stays defensive) or if
+ * the read fails. The preview falls back to a placeholder Text in that case.
+ */
+function blobToDataUri(blob: Blob): Promise<string | null> {
+  if (typeof FileReader === 'undefined') return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result;
+      resolve(typeof result === 'string' ? result : null);
+    };
+    reader.onerror = () => resolve(null);
+    try {
+      reader.readAsDataURL(blob);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Map the (`status`, `phase`) tuple returned by `useFeedback()` to the
+ * primary-button label. Same vocabulary as the web React adapter so a user
+ * who has seen the web widget recognises every state.
+ */
+function submitButtonLabel(
+  status: 'idle' | 'submitting' | 'success' | 'error',
+  phase: FeedbackPhase,
+): string {
+  if (status === 'success' || phase === 'sent') return 'Sent ✓';
+  if (status === 'error') return 'Try again';
+  if (status === 'submitting') {
+    if (phase === 'formatting') return 'Sending…';
+    return 'Capturing…';
+  }
+  return 'Send';
+}
+
+/**
+ * Props for {@link FeedbackModal}. The component is a controlled modal —
+ * the parent owns `visible` and the close callback so the FAB can drive
+ * open/close while the modal owns the form draft.
+ */
+export interface FeedbackModalProps {
+  /** Whether the modal is mounted and visible. */
+  visible: boolean;
+  /** Fired when the user taps Cancel, the close button, or the back gesture. */
+  onClose: () => void;
+  /**
+   * Forced palette. `'system'` (default) follows the host's color scheme;
+   * `'light'`/`'dark'` override it.
+   */
+  theme?: BrevwickTheme;
+}
+
+/**
+ * Drop-in feedback modal for React Native. Renders a slide-up sheet with
+ * description / expected / actual fields, a screenshot preview with a skip
+ * toggle, and a submit button driven by {@link useFeedback}.
+ *
+ * The draft state lives in component-local `useState`, so a Cancel or
+ * back-gesture (which only flips `visible` to `false`) preserves the
+ * draft for the next open. Successful submit clears the draft and calls
+ * `onClose` after a short confirmation delay.
+ *
+ * The "Format with AI" toggle is rendered exactly when the project's
+ * `getConfig()` reports `ai_enabled && ai_submitter_choice_allowed` —
+ * matching the web adapter's render-policy matrix.
+ */
+export function FeedbackModal({
+  visible,
+  onClose,
+  theme = 'system',
+}: FeedbackModalProps): ReactElement {
+  const brevwick = useBrevwick();
+  const { submit, captureScreenshot, status, phase, error, retry, reset } =
+    useFeedback();
+  const colorScheme = useColorScheme();
+  const palette: BrevwickPalette = useMemo(
+    () => resolvePalette(theme, colorScheme),
+    [theme, colorScheme],
+  );
+  const styles = useMemo(() => createWidgetStyles(palette), [palette]);
+
+  const [description, setDescription] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [includeScreenshot, setIncludeScreenshot] = useState(true);
+  const [useAi, setUseAi] = useState(true);
+  const [screenshotBlob, setScreenshotBlob] = useState<Blob | null>(null);
+  const [screenshotUri, setScreenshotUri] = useState<string | null>(null);
+  const [config, setConfig] = useState<ProjectConfig | null>(null);
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  // Tracks whether we've kicked off the on-open side-effects (config fetch +
+  // screenshot capture) for the current open. Reset on close so the next
+  // open re-runs them with whatever the SDK and view-tree look like then.
+  const openTriggeredRef = useRef(false);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      openTriggeredRef.current = false;
+      return;
+    }
+    if (openTriggeredRef.current) return;
+    openTriggeredRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cfg = await brevwick.getConfig();
+        if (!cancelled && mountedRef.current && cfg) setConfig(cfg);
+      } catch {
+        // getConfig() never throws under contract; defensive — leave
+        // config null so the AI toggle stays hidden.
+      }
+    })();
+    void (async () => {
+      try {
+        const blob = await captureScreenshot();
+        if (cancelled || !mountedRef.current) return;
+        setScreenshotBlob(blob);
+        const uri = await blobToDataUri(blob);
+        if (cancelled || !mountedRef.current) return;
+        setScreenshotUri(uri);
+      } catch {
+        // Capture failed — placeholder text covers the missing preview.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, brevwick, captureScreenshot]);
+
+  // Auto-dismiss + draft reset on success. Runs after the user has had a
+  // moment to read the "Sent ✓" confirmation. The cleanup clears the timer
+  // if the user manually closes the modal in the gap, so we don't fire
+  // `onClose` on an already-closed sheet.
+  useEffect(() => {
+    if (status !== 'success') return;
+    const id = setTimeout(() => {
+      if (!mountedRef.current) return;
+      setDescription('');
+      setExpected('');
+      setActual('');
+      setIncludeScreenshot(true);
+      setScreenshotBlob(null);
+      setScreenshotUri(null);
+      setDraftError(null);
+      reset();
+      onClose();
+    }, SUCCESS_DISMISS_DELAY_MS);
+    return () => clearTimeout(id);
+  }, [status, onClose, reset]);
+
+  const showAiToggle =
+    config?.ai_enabled === true && config.ai_submitter_choice_allowed === true;
+
+  const handleSubmit = useCallback(async () => {
+    if (status === 'submitting' || status === 'success') return;
+    if (!description.trim()) {
+      setDraftError('Please describe what happened.');
+      return;
+    }
+    setDraftError(null);
+    const attachments: Array<Blob | FeedbackAttachment> = [];
+    if (includeScreenshot && screenshotBlob) {
+      attachments.push({ blob: screenshotBlob, filename: 'screenshot.png' });
+    }
+    const input: FeedbackInput = {
+      description,
+      expected: expected.trim() || undefined,
+      actual: actual.trim() || undefined,
+      attachments: attachments.length ? attachments : undefined,
+      ...(showAiToggle ? { use_ai: useAi } : {}),
+    };
+    await submit(input);
+  }, [
+    status,
+    description,
+    expected,
+    actual,
+    includeScreenshot,
+    screenshotBlob,
+    showAiToggle,
+    useAi,
+    submit,
+  ]);
+
+  const handleRetry = useCallback(() => {
+    setDraftError(null);
+    void retry();
+  }, [retry]);
+
+  const submitting = status === 'submitting';
+  const showRetry = status === 'error';
+  const submitDisabled = submitting || status === 'success';
+  const primaryLabel = submitButtonLabel(status, phase);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View
+        style={styles.scrim}
+        // Real iOS VoiceOver scopes accessibility focus to the topmost view
+        // marked with `accessibilityViewIsModal`. RN's TS types accept the
+        // prop on `View` already, but we only pass it on iOS — Android's
+        // TalkBack uses a different prop family and ignores this one.
+        {...(Platform.OS === 'ios' ? { accessibilityViewIsModal: true } : null)}
+      >
+        <View style={styles.card}>
+          <View style={styles.headerRow}>
+            <Text style={styles.title} accessibilityRole="header">
+              Send feedback
+            </Text>
+            <Pressable
+              onPress={onClose}
+              style={styles.closeButton}
+              accessibilityLabel="Close feedback form"
+              accessibilityRole="button"
+            >
+              <Text style={styles.closeLabel}>×</Text>
+            </Pressable>
+          </View>
+          <ScrollView keyboardShouldPersistTaps="handled">
+            <Text style={styles.fieldLabel}>What happened?</Text>
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              multiline
+              placeholder="Describe the bug or feedback…"
+              placeholderTextColor={palette.fgMuted}
+              style={[styles.input, styles.descriptionInput]}
+              accessibilityLabel="Feedback description"
+              editable={!submitDisabled}
+            />
+            <Text style={styles.fieldLabel}>What did you expect?</Text>
+            <TextInput
+              value={expected}
+              onChangeText={setExpected}
+              placeholder="Optional"
+              placeholderTextColor={palette.fgMuted}
+              style={styles.input}
+              accessibilityLabel="Expected behaviour"
+              editable={!submitDisabled}
+            />
+            <Text style={styles.fieldLabel}>What actually happened?</Text>
+            <TextInput
+              value={actual}
+              onChangeText={setActual}
+              placeholder="Optional"
+              placeholderTextColor={palette.fgMuted}
+              style={styles.input}
+              accessibilityLabel="Actual behaviour"
+              editable={!submitDisabled}
+            />
+
+            <View style={styles.toggleRow}>
+              <Text style={styles.toggleLabel}>Include screenshot</Text>
+              <Switch
+                value={includeScreenshot}
+                onValueChange={setIncludeScreenshot}
+                disabled={submitDisabled}
+                accessibilityLabel="Include screenshot"
+              />
+            </View>
+
+            {includeScreenshot ? (
+              <View style={styles.screenshotPreview}>
+                {screenshotUri ? (
+                  <Image
+                    source={{ uri: screenshotUri }}
+                    style={styles.screenshotImage}
+                    resizeMode="cover"
+                    accessibilityLabel="Screenshot preview"
+                  />
+                ) : (
+                  <Text style={styles.screenshotPlaceholder}>
+                    Screenshot will be captured on send.
+                  </Text>
+                )}
+              </View>
+            ) : null}
+
+            {showAiToggle ? (
+              <View style={styles.toggleRow}>
+                <Text style={styles.toggleLabel}>Format with AI</Text>
+                <Switch
+                  value={useAi}
+                  onValueChange={setUseAi}
+                  disabled={submitDisabled}
+                  accessibilityLabel="Format with AI"
+                />
+              </View>
+            ) : null}
+
+            {draftError ? (
+              <Text style={styles.errorText}>{draftError}</Text>
+            ) : null}
+            {!draftError && error ? (
+              <Text style={styles.errorText}>{error.message}</Text>
+            ) : null}
+          </ScrollView>
+
+          <View style={styles.actionsRow}>
+            <Pressable
+              onPress={onClose}
+              style={styles.secondaryButton}
+              accessibilityLabel="Cancel"
+              accessibilityRole="button"
+              disabled={submitting}
+            >
+              <Text style={styles.secondaryLabel}>Cancel</Text>
+            </Pressable>
+            {showRetry ? (
+              <Pressable
+                onPress={handleRetry}
+                style={styles.primaryButton}
+                accessibilityLabel="Retry submission"
+                accessibilityRole="button"
+              >
+                <Text style={styles.primaryLabel}>Try again</Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                onPress={handleSubmit}
+                style={[
+                  styles.primaryButton,
+                  submitDisabled && styles.primaryButtonDisabled,
+                ]}
+                accessibilityLabel={primaryLabel}
+                accessibilityRole="button"
+                disabled={submitDisabled}
+              >
+                {submitting ? (
+                  <ActivityIndicator color={palette.accentFg} size="small" />
+                ) : null}
+                <Text style={styles.primaryLabel}>{primaryLabel}</Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -43,6 +43,15 @@ export type {
   UseFeedbackResult,
 } from './use-feedback';
 
+export { FeedbackButton } from './feedback-button';
+export type {
+  FeedbackButtonProps,
+  FeedbackButtonPosition,
+} from './feedback-button';
+export { FeedbackModal } from './feedback-modal';
+export type { FeedbackModalProps } from './feedback-modal';
+export type { BrevwickTheme } from './styles';
+
 // Re-export the SDK types RN consumers most often touch so they don't need a
 // second `@tatlacas/brevwick-sdk` import in app code. The full SDK surface is
 // still available via the underlying package.

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -54,12 +54,16 @@ export type { BrevwickTheme } from './styles';
 
 // Re-export the SDK types RN consumers most often touch so they don't need a
 // second `@tatlacas/brevwick-sdk` import in app code. The full SDK surface is
-// still available via the underlying package.
+// still available via the underlying package. `ProjectConfig` is included
+// because the FeedbackModal's "Format with AI" toggle gate keys off it; any
+// consumer composing their own modal alongside `useFeedback()` needs the
+// type to discriminate `ai_enabled` / `ai_submitter_choice_allowed`.
 export type {
   Brevwick,
   BrevwickConfig,
   FeedbackAttachment,
   FeedbackInput,
+  ProjectConfig,
   SubmitError,
   SubmitErrorCode,
   SubmitResult,

--- a/packages/react-native/src/styles.ts
+++ b/packages/react-native/src/styles.ts
@@ -1,0 +1,232 @@
+import { StyleSheet } from 'react-native';
+
+/**
+ * Forced-palette choice for the React Native widget. Mirrors the
+ * `BrevwickTheme` type exported by `@tatlacas/brevwick-react` so consumers
+ * can switch adapters without changing the prop's value space. `'system'`
+ * defers to the host's color-scheme via `useColorScheme()`.
+ */
+export type BrevwickTheme = 'light' | 'dark' | 'system';
+
+/**
+ * Set of colour tokens the widget consumes. Kept structurally minimal —
+ * the widget doesn't expose CSS-variable-style overrides on RN; consumers
+ * hand-in `theme="light|dark|system"` and we resolve to one of the two
+ * shipped palettes. Re-themed UIs that need to deviate further render
+ * their own FAB and call `useFeedback()` directly.
+ */
+export interface BrevwickPalette {
+  panelBg: string;
+  fg: string;
+  fgMuted: string;
+  border: string;
+  inputBg: string;
+  accent: string;
+  accentFg: string;
+  error: string;
+  scrim: string;
+  shadow: string;
+}
+
+export const LIGHT_PALETTE: BrevwickPalette = {
+  panelBg: '#ffffff',
+  fg: '#0f172a',
+  fgMuted: '#64748b',
+  border: '#e2e8f0',
+  inputBg: '#f8fafc',
+  accent: '#0f172a',
+  accentFg: '#ffffff',
+  error: '#b91c1c',
+  scrim: 'rgba(15, 23, 42, 0.45)',
+  shadow: 'rgba(15, 23, 42, 0.18)',
+};
+
+export const DARK_PALETTE: BrevwickPalette = {
+  panelBg: '#0b1220',
+  fg: '#f8fafc',
+  fgMuted: '#94a3b8',
+  border: '#1e293b',
+  inputBg: '#0f172a',
+  accent: '#f8fafc',
+  accentFg: '#0f172a',
+  error: '#f87171',
+  scrim: 'rgba(0, 0, 0, 0.6)',
+  shadow: 'rgba(0, 0, 0, 0.55)',
+};
+
+/**
+ * Resolve a `BrevwickTheme` against the host's current color scheme to a
+ * concrete palette. `theme="system"` falls back to light when the host hasn't
+ * reported a scheme yet (e.g. early in app startup) — matches the web
+ * adapter's `prefers-color-scheme` default.
+ */
+export function resolvePalette(
+  theme: BrevwickTheme,
+  systemScheme: 'light' | 'dark' | null | undefined,
+): BrevwickPalette {
+  const effective =
+    theme === 'system' ? (systemScheme === 'dark' ? 'dark' : 'light') : theme;
+  return effective === 'dark' ? DARK_PALETTE : LIGHT_PALETTE;
+}
+
+/**
+ * Build the StyleSheet for one resolved palette. Returned object is
+ * memoised by callers (`useMemo` keyed on the palette identity) so a
+ * stable theme avoids re-running `StyleSheet.create` between renders.
+ */
+export function createWidgetStyles(palette: BrevwickPalette) {
+  return StyleSheet.create({
+    fab: {
+      position: 'absolute',
+      minWidth: 48,
+      height: 48,
+      paddingHorizontal: 18,
+      borderRadius: 24,
+      backgroundColor: palette.accent,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row',
+      shadowColor: palette.shadow,
+      shadowOffset: { width: 0, height: 6 },
+      shadowOpacity: 1,
+      shadowRadius: 12,
+      elevation: 6,
+    },
+    fabPressed: {
+      opacity: 0.85,
+    },
+    fabDisabled: {
+      opacity: 0.5,
+    },
+    fabLabel: {
+      color: palette.accentFg,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    scrim: {
+      flex: 1,
+      backgroundColor: palette.scrim,
+      justifyContent: 'flex-end',
+    },
+    card: {
+      backgroundColor: palette.panelBg,
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 20,
+      padding: 20,
+      maxHeight: '90%',
+    },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 12,
+    },
+    title: {
+      color: palette.fg,
+      fontSize: 18,
+      fontWeight: '600',
+    },
+    closeButton: {
+      paddingHorizontal: 8,
+      paddingVertical: 4,
+    },
+    closeLabel: {
+      color: palette.fgMuted,
+      fontSize: 16,
+    },
+    fieldLabel: {
+      color: palette.fgMuted,
+      fontSize: 12,
+      marginBottom: 4,
+      marginTop: 12,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    input: {
+      backgroundColor: palette.inputBg,
+      color: palette.fg,
+      borderColor: palette.border,
+      borderWidth: 1,
+      borderRadius: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 14,
+    },
+    descriptionInput: {
+      minHeight: 88,
+      textAlignVertical: 'top',
+    },
+    toggleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginTop: 16,
+    },
+    toggleLabel: {
+      color: palette.fg,
+      fontSize: 14,
+    },
+    screenshotPreview: {
+      marginTop: 12,
+      borderColor: palette.border,
+      borderWidth: 1,
+      borderRadius: 8,
+      overflow: 'hidden',
+      backgroundColor: palette.inputBg,
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: 140,
+    },
+    screenshotImage: {
+      width: '100%',
+      height: '100%',
+    },
+    screenshotPlaceholder: {
+      color: palette.fgMuted,
+      fontSize: 12,
+    },
+    actionsRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: 12,
+      marginTop: 20,
+    },
+    secondaryButton: {
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: palette.border,
+      backgroundColor: 'transparent',
+    },
+    secondaryLabel: {
+      color: palette.fg,
+      fontSize: 14,
+      fontWeight: '500',
+    },
+    primaryButton: {
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 8,
+      backgroundColor: palette.accent,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    primaryButtonDisabled: {
+      opacity: 0.5,
+    },
+    primaryLabel: {
+      color: palette.accentFg,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    errorText: {
+      color: palette.error,
+      fontSize: 13,
+      marginTop: 12,
+    },
+  });
+}
+
+export type BrevwickWidgetStyles = ReturnType<typeof createWidgetStyles>;

--- a/packages/react-native/test/__mocks__/react-native.cjs
+++ b/packages/react-native/test/__mocks__/react-native.cjs
@@ -106,6 +106,87 @@ const StyleSheet = {
       {},
     );
   },
+  // Real RN's `StyleSheet.create` interns styles into a numeric registry; the
+  // FeedbackButton + FeedbackModal evaluate a `create({...})` call at module
+  // load time, so even hook-only tests (which don't render the components)
+  // would crash if this stub omitted it. The simplest faithful behaviour is
+  // to pass the input through — call sites use the resulting object's keys
+  // for `style={styles.foo}` props, and the equality semantics React applies
+  // for style props are unchanged by interning.
+  create(styles) {
+    return styles;
+  },
+  hairlineWidth: 1,
+  absoluteFillObject: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+};
+
+// Lightweight shims for the host components the feedback widget renders. Each
+// is a class component (mirroring `View`) so `react-test-renderer` can locate
+// them by constructor reference and `findAllByProps` traversals from tests
+// remain stable even when the production code refactors children.
+class Text extends Component {
+  render() {
+    return this.props.children ?? null;
+  }
+}
+class TextInput extends Component {
+  render() {
+    return this.props.children ?? null;
+  }
+}
+class Image extends Component {
+  render() {
+    return null;
+  }
+}
+class ActivityIndicator extends Component {
+  render() {
+    return null;
+  }
+}
+class Switch extends Component {
+  render() {
+    return null;
+  }
+}
+class ScrollView extends Component {
+  render() {
+    return this.props.children ?? null;
+  }
+}
+class Modal extends Component {
+  render() {
+    // Match real RN: when `visible={false}` the children are not mounted.
+    if (this.props.visible === false) return null;
+    return this.props.children ?? null;
+  }
+}
+class Pressable extends Component {
+  render() {
+    const { children } = this.props;
+    if (typeof children === 'function') {
+      // Real RN passes `{ pressed }` (and more in newer versions); tests
+      // never assert on the pressed state from the render-prop path.
+      return children({ pressed: false });
+    }
+    return children ?? null;
+  }
+}
+
+// Hook + module surfaces consumed by the widget. `useColorScheme` returns
+// `'light'` so the default theme resolution lands on the light palette
+// without needing a per-test mock; tests that need to exercise the dark
+// branch override `<FeedbackButton theme="dark" />` directly.
+const useColorScheme = () => 'light';
+const Appearance = {
+  getColorScheme: () => 'light',
+  addChangeListener: () => ({ remove: () => {} }),
 };
 
 module.exports = {
@@ -114,5 +195,15 @@ module.exports = {
   I18nManager,
   NativeModules,
   View,
+  Text,
+  TextInput,
+  Image,
+  ActivityIndicator,
+  Switch,
+  ScrollView,
+  Modal,
+  Pressable,
   StyleSheet,
+  useColorScheme,
+  Appearance,
 };


### PR DESCRIPTION
Closes #88

Drop-in FAB + Modal feedback form for React Native. Mirrors `@tatlacas/brevwick-react` UX 1:1 with RN primitives (Pressable + Modal + StyleSheet). Honors project AI config flags.

## Summary

- `<FeedbackButton />` floating Pressable, default bottom-right, themeable; `position` accepts `'bottom-right' | 'bottom-left' | { bottom?, right?, left? }` (RN-specific widening for safe-area / tab-bar insets — documented in the prop's JSDoc).
- `<FeedbackModal />` form: description / expected / actual / screenshot toggle / AI toggle, with on-open lazy `getConfig()` + `captureScreenshot()`, draft preserved across cancel/back (text fields AND toggles), auto-dismiss 2 s after success. Success-dismiss timer is cleared on Cancel during the dwell so it cannot fire on a hidden modal. Inline draft-error note clears on the first keystroke in any of the three text fields. Screenshot capture failures surface as an inline note ("Couldn't attach screenshot — sending without one.") and emit one `console.warn` matching the `screenshot.ts` `logFailure` pattern.
- Phase-based primary-button label (`Send` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`) and FAB label (`Send feedback` → same lifecycle). The FAB owns a single `useFeedback()` instance and forwards it to the modal so both render against the same `status`/`phase`/`error` tuple — the FAB observes terminal states (`Sent ✓` / `Try again`) the SDK's phase bus does not emit.
- `disabled` prop is enforced both via `Pressable`'s native gating and an explicit guard in `handleOpen` (defence-in-depth against future wrappers that call `onPress` directly).
- Public-API re-exports: `BrevwickTheme` and `ProjectConfig` (the latter needed by any consumer composing their own modal alongside `useFeedback()`).
- Accessible: FAB has `accessibilityLabel='Send feedback'` + `accessibilityRole='button'`; iOS gets `accessibilityViewIsModal` for VoiceOver focus trap.
- 20 new tests covering render, press-to-open, submit, retry, success-close, AI toggle gating, screenshot toggle, draft preservation, FAB label transitions through error/success, dark theme, bottom-left position, disabled-press defence, draft-error edit-clearing, screenshot-capture rejection, and Cancel-during-dismiss-window timer cleanup. All `pnpm` CI gates pass (`format:check`, `lint`, `type-check`, `test:cover`, `build`, `size`).
- `.size-limit.js` now enforces the < 25 kB gzip ceiling for the RN adapter (mirrors the React entry).

## Bundle

- `packages/react-native/dist/index.js`: **5.84 kB gzip**
- `packages/react-native/dist/index.cjs`: **6.11 kB gzip**
- Budget: < 25 kB gzip — well within (now CI-enforced).

## Out of scope

- Annotation / markup on screenshot — Phase 5
- Image picker for additional attachments — follow-up

## Test plan

- [x] Render + interact tests pass (91/91 in `packages/react-native`)
- [x] Bundle within budget (recorded above; CI-enforced via `.size-limit.js`)
- [ ] Manual test in example app (Tier 2 dependency — AC #1 "no z-index/positioning glitches in any RN navigation stack" is gated on the #94 example-app worktree and unverified by automated tests in this PR)