### PR TITLE
docs(react-native): example Expo app + canonical README

### DIFF
--- a/.changeset/rn-route-ring-helper-and-docs.md
+++ b/.changeset/rn-route-ring-helper-and-docs.md
@@ -1,0 +1,53 @@
+---
+'@tatlacas/brevwick-react-native': minor
+'@tatlacas/brevwick-sdk': minor
+'@tatlacas/brevwick-react': minor
+---
+
+feat(react-native): public `useRouteRing` hook + RN-aware
+`useFeedback().captureScreenshot(viewRef)`; SDK exports
+`PROJECT_KEY_PATTERN` (#89, #90)
+
+Public surface added by this PR (PR #101 review action items):
+
+- `useRouteRing(navigationRef?)` from `@tatlacas/brevwick-react-native` —
+  owns the `_internal.push` reach-around the example previously copy/
+  pasted into every consumer's `RouteRingBridge`. Resolves both the
+  `Brevwick` instance and the `navigationRef` from context, attaches via
+  `attachRouteRing`, and detaches on unmount. Pass an explicit
+  `navigationRef` for layouts that mount the bridge outside the provider
+  tree.
+- `useFeedback().captureScreenshot` now accepts an optional `viewRef`
+  (and `CaptureScreenshotOpts`) and routes RN captures through the
+  package's native `captureScreenshot` (`react-native-view-shot` when
+  the peer is installed, placeholder PNG otherwise) instead of always
+  falling through to the core SDK's DOM-based path. Calls without a
+  `viewRef` keep the previous behaviour.
+- `BrevwickNavigationRef.current.addListener` now narrows the event
+  parameter to the `'state'` literal (the only event the route ring
+  subscribes to), so `useNavigationContainerRef<TParamList>()`'s
+  strictly-typed ref is structurally assignable to
+  `BrevwickProviderProps.navigationRef` without an
+  `as unknown as BrevwickNavigationRef` cast at the consumer site.
+
+Core SDK surface widens narrowly to support adapter + example
+composition without duplication:
+
+- `PROJECT_KEY_PATTERN` — the validator's project-key regex, exported
+  so adapters and example apps can gate UI on the same source of truth
+  `validateConfig` enforces. Use as `PROJECT_KEY_PATTERN.test(value)`;
+  no boolean-returning helper is shipped because the eager bundle is
+  within ~30 B of its 2.85 kB ceiling and a one-line `.test(value)` is
+  no friction for callers.
+
+Also fixes the `examples/react-native` peer-dep mismatch: the package
+now declares `react-native-view-shot: >=3.8.0 <5` so both Expo SDK 51
+(`~3.8.0`) and bare RN (`^4.0.0`) sit inside the supported range. CI
+gains a `pnpm --filter @tatlacas/brevwick-react-native build` step
+ahead of `pnpm type-check` so a clean checkout no longer fails on
+TS2307 from `examples/react-native/tsconfig.json` (`moduleResolution:
+Bundler`) trying to resolve `dist/` before it has been built.
+
+The `@tatlacas/brevwick-sdk` bump is the lockstep pre-1.0 minor; the
+linked group in `.changeset/config.json` propagates the bump across
+the suite.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
       # signal that ng-packagr's substitution pipeline produced a valid
       # artefact — the kind of guard issue #67 rev-1 was missing.
       - run: pnpm --filter @tatlacas/brevwick-angular build
+      # Build @tatlacas/brevwick-react-native before `pnpm type-check` so
+      # `examples/react-native/tsconfig.json` (`moduleResolution: Bundler`)
+      # can resolve `@tatlacas/brevwick-react-native` via its
+      # `package.json#exports` → `dist/index.d.ts` entry. Metro alone reads
+      # the top-level `react-native` field (`./src/index.ts`); tsc does
+      # not, so without a built `dist/` the example's recursive
+      # `pnpm -r type-check` fails with TS2307 on a clean checkout.
+      - run: pnpm --filter @tatlacas/brevwick-react-native build
       - run: pnpm type-check
       - run: pnpm test:cover
       - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ export default function App() {
 }
 ```
 
-Build a custom feedback UI with `useFeedback()` (the drop-in `<FeedbackButton />` lands with #88), wire the React Navigation route ring with `attachRouteRing` + `useBrevwickNavigationRef`, and capture screenshots via the optional `react-native-view-shot` peer.
+Build a custom feedback UI with `useFeedback()` (the drop-in `<FeedbackButton />` lands with #88), wire the React Navigation route ring by rendering `useRouteRing()` inside the provider, and capture screenshots via the optional `react-native-view-shot` peer.
 
 Full API → [packages/react-native/README.md](./packages/react-native/README.md).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm (solid)](https://img.shields.io/npm/v/@tatlacas/brevwick-solid/beta?label=@tatlacas/brevwick-solid%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-solid)
 [![npm (vue)](https://img.shields.io/npm/v/@tatlacas/brevwick-vue/beta?label=@tatlacas/brevwick-vue%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-vue)
 [![npm (angular)](https://img.shields.io/npm/v/@tatlacas/brevwick-angular/beta?label=@tatlacas/brevwick-angular%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-angular)
+[![npm (react-native)](https://img.shields.io/npm/v/@tatlacas/brevwick-react-native/beta?label=@tatlacas/brevwick-react-native%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-react-native)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 Ship feedback from any browser app straight into clean, AI-formatted GitHub issues. Drop in a floating button, collect a description + screenshot + the console/network rings that preceded the bug, and Brevwick turns it all into a triage-ready issue on your repo.
@@ -13,14 +14,15 @@ Ship feedback from any browser app straight into clean, AI-formatted GitHub issu
 
 ## Packages
 
-| Package                                            | Description                                                                                          | API reference                                              |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| [`@tatlacas/brevwick-sdk`](./packages/sdk)         | Framework-agnostic core: submit, screenshot, rings.                                                  | [packages/sdk/README.md](./packages/sdk/README.md)         |
-| [`@tatlacas/brevwick-react`](./packages/react)     | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19.                              | [packages/react/README.md](./packages/react/README.md)     |
-| [`@tatlacas/brevwick-solid`](./packages/solid)     | Provider, floating FAB widget, and `useFeedback` hook for Solid 1.8+.                                | [packages/solid/README.md](./packages/solid/README.md)     |
-| [`@tatlacas/brevwick-vue`](./packages/vue)         | Plugin, floating FAB component, and `useFeedback` composable for Vue 3.4+.                           | [packages/vue/README.md](./packages/vue/README.md)         |
-| [`@tatlacas/brevwick-svelte`](./packages/svelte)   | Context setter, FAB, and `getFeedback()` for Svelte 5 and SvelteKit.                                 | [packages/svelte/README.md](./packages/svelte/README.md)   |
-| [`@tatlacas/brevwick-angular`](./packages/angular) | `provideBrevwick`, `BrevwickService`, and `bw-feedback-button` standalone component for Angular 17+. | [packages/angular/README.md](./packages/angular/README.md) |
+| Package                                                      | Description                                                                                                   | API reference                                                        |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`@tatlacas/brevwick-sdk`](./packages/sdk)                   | Framework-agnostic core: submit, screenshot, rings.                                                           | [packages/sdk/README.md](./packages/sdk/README.md)                   |
+| [`@tatlacas/brevwick-react`](./packages/react)               | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19.                                       | [packages/react/README.md](./packages/react/README.md)               |
+| [`@tatlacas/brevwick-solid`](./packages/solid)               | Provider, floating FAB widget, and `useFeedback` hook for Solid 1.8+.                                         | [packages/solid/README.md](./packages/solid/README.md)               |
+| [`@tatlacas/brevwick-vue`](./packages/vue)                   | Plugin, floating FAB component, and `useFeedback` composable for Vue 3.4+.                                    | [packages/vue/README.md](./packages/vue/README.md)                   |
+| [`@tatlacas/brevwick-svelte`](./packages/svelte)             | Context setter, FAB, and `getFeedback()` for Svelte 5 and SvelteKit.                                          | [packages/svelte/README.md](./packages/svelte/README.md)             |
+| [`@tatlacas/brevwick-angular`](./packages/angular)           | `provideBrevwick`, `BrevwickService`, and `bw-feedback-button` standalone component for Angular 17+.          | [packages/angular/README.md](./packages/angular/README.md)           |
+| [`@tatlacas/brevwick-react-native`](./packages/react-native) | Provider, `useFeedback` hook, route-ring helper, and native screenshot path for Expo SDK 51+ / bare RN 0.72+. | [packages/react-native/README.md](./packages/react-native/README.md) |
 
 ## Install
 
@@ -41,6 +43,9 @@ npm install @tatlacas/brevwick-vue@beta @tatlacas/brevwick-sdk@beta
 
 # Angular 17+ standalone — pulls @tatlacas/brevwick-sdk in as a peer dep
 npm install @tatlacas/brevwick-angular@beta @tatlacas/brevwick-sdk@beta
+
+# Expo / bare React Native — pulls @tatlacas/brevwick-sdk in as a peer dep
+npx expo install @tatlacas/brevwick-react-native @tatlacas/brevwick-sdk
 ```
 
 Works with `pnpm add`, `yarn add`, `bun add` — same package names.
@@ -139,6 +144,34 @@ export class AppComponent {}
 
 Full API → [packages/angular/README.md](./packages/angular/README.md).
 
+### React Native (Expo + bare)
+
+```tsx
+import { useMemo } from 'react';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
+import { BrevwickProvider } from '@tatlacas/brevwick-react-native';
+
+export default function App() {
+  const navigationRef = useNavigationContainerRef();
+  const config = useMemo(() => ({ projectKey: 'pk_live_...' }), []);
+
+  return (
+    <BrevwickProvider config={config} navigationRef={navigationRef}>
+      <NavigationContainer ref={navigationRef}>
+        <YourStack />
+      </NavigationContainer>
+    </BrevwickProvider>
+  );
+}
+```
+
+Build a custom feedback UI with `useFeedback()` (the drop-in `<FeedbackButton />` lands with #88), wire the React Navigation route ring with `attachRouteRing` + `useBrevwickNavigationRef`, and capture screenshots via the optional `react-native-view-shot` peer.
+
+Full API → [packages/react-native/README.md](./packages/react-native/README.md).
+
 ### Vanilla / any framework
 
 ```ts
@@ -184,6 +217,7 @@ ES2020 targets — modern evergreen browsers (Chrome/Edge 90+, Firefox 90+, Safa
 - **API reference (Solid):** [packages/solid/README.md](./packages/solid/README.md)
 - **API reference (Vue):** [packages/vue/README.md](./packages/vue/README.md)
 - **API reference (Angular):** [packages/angular/README.md](./packages/angular/README.md)
+- **API reference (React Native):** [packages/react-native/README.md](./packages/react-native/README.md)
 - **Issues & feature requests:** [github.com/tatlacas-com/brevwick-sdk-js/issues](https://github.com/tatlacas-com/brevwick-sdk-js/issues)
 - **Contributing:** [CONTRIBUTING.md](./CONTRIBUTING.md)
 - **License:** [MIT](./LICENSE)

--- a/examples/react-native/.env.example
+++ b/examples/react-native/.env.example
@@ -1,0 +1,9 @@
+# Copy to `.env` (Expo loads `.env` automatically) and replace the project
+# key with a real `pk_test_…` from your project at https://brevwick.dev.
+#
+# Both vars must be `EXPO_PUBLIC_*`-prefixed — that is the only naming
+# convention Expo will inline into client code; everything else stays
+# server-side and is `undefined` at runtime.
+
+EXPO_PUBLIC_BREVWICK_PROJECT_KEY=pk_test_replace_me
+EXPO_PUBLIC_BREVWICK_ENDPOINT=https://staging-api.brevwick.com

--- a/examples/react-native/.env.example
+++ b/examples/react-native/.env.example
@@ -6,4 +6,9 @@
 # server-side and is `undefined` at runtime.
 
 EXPO_PUBLIC_BREVWICK_PROJECT_KEY=pk_test_replace_me
-EXPO_PUBLIC_BREVWICK_ENDPOINT=https://staging-api.brevwick.com
+
+# Optional. Override the SDK's default `https://api.brevwick.com`. Useful
+# for hitting `https://staging-api.brevwick.com` from a Brevwick test key
+# without rewiring `App.tsx`. Leave blank to hit production (matches the
+# SDK default).
+EXPO_PUBLIC_BREVWICK_ENDPOINT=

--- a/examples/react-native/.gitignore
+++ b/examples/react-native/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.expo
+dist
+web-build
+
+.env
+.env.local
+*.log
+
+# macOS / IDE noise
+.DS_Store

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -1,0 +1,5 @@
+// Expo's default `AppEntry.js` imports `./App` and registers it via
+// `registerRootComponent`. We keep the actual app under `./src/App.tsx`
+// alongside the screens — this file is a thin re-export so the entry
+// path stays the Expo default.
+export { default } from './src/App';

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -1,0 +1,78 @@
+# brevwick-example-react-native
+
+Minimal Expo SDK 51 + TypeScript app wired up with `BrevwickProvider` from
+[`@tatlacas/brevwick-react-native`](../../packages/react-native), a Stack
+navigator (`Home` + `Details`), and demo buttons for each of the four
+context streams the SDK attaches to every submission (console, network,
+route, screenshot).
+
+## Run locally
+
+1. From the repo root, install:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Copy `.env.example` to `.env` and replace the placeholder key with a
+   real `pk_test_…` from your project at <https://brevwick.dev>:
+
+   ```bash
+   cp examples/react-native/.env.example examples/react-native/.env
+   # edit EXPO_PUBLIC_BREVWICK_PROJECT_KEY=pk_test_…
+   ```
+
+3. Start the Expo dev server:
+
+   ```bash
+   pnpm --filter brevwick-example-react-native start
+   ```
+
+4. Scan the QR with Expo Go or open in a custom dev client (see below for
+   when each is appropriate).
+
+## Expo Go vs. dev client
+
+| Concern                 | Expo Go (default)                                  | Custom dev client                               |
+| ----------------------- | -------------------------------------------------- | ----------------------------------------------- |
+| Provider + hooks        | ✅ work                                            | ✅ work                                         |
+| Console / network rings | ✅ captured                                        | ✅ captured                                     |
+| Route ring              | ✅ captured                                        | ✅ captured                                     |
+| Screenshot capture      | ⚠️ falls back to a 1×1 transparent PNG placeholder | ✅ real screenshot via `react-native-view-shot` |
+
+`react-native-view-shot` ships native code, so a custom dev client is
+required to actually rasterise the view tree. In Expo Go the
+`@tatlacas/brevwick-react-native` package falls through to the placeholder
+PNG (the never-throws contract from SDD § 12). For a quick sanity check
+of the wiring, Expo Go is fine; for screenshot QA, build a dev client per
+<https://docs.expo.dev/develop/development-builds/introduction/>.
+
+## Environment
+
+Expo only inlines env vars whose names start with `EXPO_PUBLIC_`. Anything
+else stays server-side and is `undefined` at runtime.
+
+| Variable                           | Required | Purpose                                                                                                     |
+| ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `EXPO_PUBLIC_BREVWICK_PROJECT_KEY` | yes      | Public ingest key (`pk_test_…` or `pk_live_…`).                                                             |
+| `EXPO_PUBLIC_BREVWICK_ENDPOINT`    | no       | Override ingest endpoint. Defaults to `staging-api.brevwick.com` in `.env.example`; omit to hit production. |
+
+## What the demo does
+
+- `Home` screen has four buttons — three populate context rings (console,
+  network, route via stack push), the fourth opens the feedback FAB.
+- `Details` is a trivial second screen that exists so the route ring
+  records `Home → Details → Home` transitions.
+- The floating <kbd>Feedback</kbd> button at the bottom-right opens a
+  modal, calls `useFeedback().submit({ description })`, and surfaces the
+  staged success / error states inline.
+
+## Verifying the submission
+
+After submitting from the example, check your project dashboard at
+<https://brevwick.dev> for an issue with:
+
+- `device_context.platform = 'react-native-ios'` or `'react-native-android'`
+- `console_log`, `network_log`, and `route_trail` populated with the
+  entries triggered by the demo buttons
+- a screenshot attachment (or the 1×1 placeholder if running in Expo Go)

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -52,10 +52,10 @@ of the wiring, Expo Go is fine; for screenshot QA, build a dev client per
 Expo only inlines env vars whose names start with `EXPO_PUBLIC_`. Anything
 else stays server-side and is `undefined` at runtime.
 
-| Variable                           | Required | Purpose                                                                                                     |
-| ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| `EXPO_PUBLIC_BREVWICK_PROJECT_KEY` | yes      | Public ingest key (`pk_test_…` or `pk_live_…`).                                                             |
-| `EXPO_PUBLIC_BREVWICK_ENDPOINT`    | no       | Override ingest endpoint. Defaults to `staging-api.brevwick.com` in `.env.example`; omit to hit production. |
+| Variable                           | Required | Purpose                                                                                                                                                                                            |
+| ---------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXPO_PUBLIC_BREVWICK_PROJECT_KEY` | yes      | Public ingest key (`pk_test_…` or `pk_live_…`).                                                                                                                                                    |
+| `EXPO_PUBLIC_BREVWICK_ENDPOINT`    | no       | Override ingest endpoint. Blank in `.env.example` so the SDK default (`https://api.brevwick.com`) is used; set to `https://staging-api.brevwick.com` to point at staging from a Brevwick test key. |
 
 ## What the demo does
 

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -67,6 +67,27 @@ else stays server-side and is `undefined` at runtime.
   modal, calls `useFeedback().submit({ description })`, and surfaces the
   staged success / error states inline.
 
+## Why `@types/react@19` with React 18.2 runtime?
+
+Expo SDK 51 ships React 18.2 at runtime, but `@types/react` is pinned to
+`^19.2.14` in this example's `devDependencies`. This is intentional and
+specific to the monorepo / pnpm setup, not advice for your own app:
+
+- The workspace also publishes a React 19 web adapter, so pnpm hoists
+  `@types/react@19.2.14` into the store.
+- React Navigation v6 declares `@types/react` as an optional dependency
+  rather than a peer, so its `.d.ts` files resolve `react` against
+  whatever the package manager hoisted — here, the React 19 types.
+- When the example pulls `<NavigationContainer>` (typed via React 19) into
+  the same JSX position as `<BrevwickProvider>` (typed via React 18),
+  TypeScript rejects the union: React 18's `ReactNode` does not accept
+  React 19's `ReactElement<unknown>`. Aligning `@types/react` to `^19`
+  here makes both sides agree.
+
+In a single-package consumer app (no monorepo), pin `@types/react` to the
+same major as your `react` runtime — `^18.3` for Expo SDK 51, `^19` for
+SDK 53+.
+
 ## Verifying the submission
 
 After submitting from the example, check your project dashboard at

--- a/examples/react-native/app.json
+++ b/examples/react-native/app.json
@@ -1,0 +1,24 @@
+{
+  "expo": {
+    "name": "Brevwick RN Example",
+    "slug": "brevwick-rn-example",
+    "version": "0.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": false,
+    "scheme": "brevwick-rn-example",
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "dev.brevwick.example"
+    },
+    "android": {
+      "package": "dev.brevwick.example",
+      "adaptiveIcon": {
+        "backgroundColor": "#ffffff"
+      }
+    },
+    "web": {
+      "bundler": "metro"
+    }
+  }
+}

--- a/examples/react-native/babel.config.js
+++ b/examples/react-native/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/examples/react-native/metro.config.js
+++ b/examples/react-native/metro.config.js
@@ -1,0 +1,30 @@
+// Expo Metro config tuned for the pnpm monorepo.
+//
+// `watchFolders` points Metro at the workspace root so it can resolve the
+// `workspace:*` link to `@tatlacas/brevwick-react-native` (and its peer,
+// `@tatlacas/brevwick-sdk`). Metro defaults to walking only the project
+// directory's `node_modules`, which under pnpm only contains a symlink — the
+// real files live under the root `node_modules/.pnpm/` store.
+//
+// `disableHierarchicalLookup` + an explicit `nodeModulesPaths` whitelist
+// avoids the classic "duplicate React" error you get when Metro discovers
+// two copies of `react` along the way (the example's own `node_modules` and
+// the workspace root's). Both arrays-of-paths are required: the project
+// node_modules first, then the workspace root.
+
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [workspaceRoot];
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+config.resolver.disableHierarchicalLookup = true;
+
+module.exports = config;

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -22,7 +22,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
-    "react-native-view-shot": "3.8.0"
+    "react-native-view-shot": "~3.8.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "brevwick-example-react-native",
+  "version": "0.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.18",
+    "@react-navigation/stack": "^6.4.1",
+    "@tatlacas/brevwick-react-native": "workspace:*",
+    "@tatlacas/brevwick-sdk": "workspace:*",
+    "expo": "~51.0.0",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.5",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "3.31.1",
+    "react-native-view-shot": "3.8.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "typescript": "~5.3.3"
+  }
+}

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -1,0 +1,76 @@
+import { useMemo, type ReactElement } from 'react';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import {
+  BrevwickProvider,
+  type BrevwickConfig,
+  type BrevwickNavigationRef,
+} from '@tatlacas/brevwick-react-native';
+import { Home } from './screens/Home';
+import { Details } from './screens/Details';
+import { FeedbackFab } from './FeedbackFab';
+import { RouteRingBridge } from './RouteRingBridge';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Details: { from?: string } | undefined;
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+// Mirrors `validateConfig` from `@tatlacas/brevwick-sdk` so the example
+// renders without crashing the React tree when `.env` still holds the
+// seeded placeholder. `createBrevwick(...)` would throw synchronously
+// inside the provider's `useMemo` otherwise.
+const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
+const PLACEHOLDER_KEY = 'pk_test_replace_me';
+const PROJECT_KEY = process.env.EXPO_PUBLIC_BREVWICK_PROJECT_KEY ?? '';
+const ENDPOINT = process.env.EXPO_PUBLIC_BREVWICK_ENDPOINT;
+const KEY_IS_READY =
+  PROJECT_KEY.length > 0 &&
+  PROJECT_KEY !== PLACEHOLDER_KEY &&
+  PROJECT_KEY_PATTERN.test(PROJECT_KEY);
+
+export default function App(): ReactElement {
+  const navigationRef = useNavigationContainerRef<RootStackParamList>();
+
+  // Hoisted via `useMemo` so the provider doesn't cycle install/uninstall
+  // on every render — it keys its SDK instance on config identity.
+  const config = useMemo<BrevwickConfig>(
+    () => ({
+      projectKey: KEY_IS_READY ? PROJECT_KEY : 'pk_test_placeholder0000000',
+      endpoint: ENDPOINT,
+      environment: 'stg',
+      enabled: KEY_IS_READY,
+    }),
+    [],
+  );
+
+  return (
+    // React Navigation's `addListener<T extends keyof EventMap>` is more
+    // strictly typed than `BrevwickNavigationRef`'s structural slot
+    // (which accepts any string event name), so we cast to the loose
+    // shape the provider expects. Both surfaces agree at runtime — the
+    // route ring only ever subscribes to `'state'`.
+    <BrevwickProvider
+      config={config}
+      navigationRef={navigationRef as unknown as BrevwickNavigationRef}
+    >
+      <NavigationContainer ref={navigationRef}>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Home"
+            component={Home}
+            options={{ title: 'Brevwick RN Example' }}
+          />
+          <Stack.Screen name="Details" component={Details} />
+        </Stack.Navigator>
+      </NavigationContainer>
+      <RouteRingBridge />
+      <FeedbackFab keyReady={KEY_IS_READY} />
+    </BrevwickProvider>
+  );
+}

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -28,7 +28,14 @@ const Stack = createStackNavigator<RootStackParamList>();
 // of crashing inside `useMemo` on `createBrevwick(...)`.
 const PLACEHOLDER_KEY = 'pk_test_replace_me';
 const PROJECT_KEY = process.env.EXPO_PUBLIC_BREVWICK_PROJECT_KEY ?? '';
-const ENDPOINT = process.env.EXPO_PUBLIC_BREVWICK_ENDPOINT;
+// `.env` files load env vars as strings, so a present-but-blank
+// `EXPO_PUBLIC_BREVWICK_ENDPOINT=` (the seeded value in `.env.example`)
+// surfaces here as `''`. `validateConfig` parses `endpoint` as a URL and
+// would reject `''` — coerce to `undefined` so the SDK falls through to
+// its default `https://api.brevwick.com`.
+const RAW_ENDPOINT = process.env.EXPO_PUBLIC_BREVWICK_ENDPOINT;
+const ENDPOINT =
+  RAW_ENDPOINT && RAW_ENDPOINT.length > 0 ? RAW_ENDPOINT : undefined;
 const KEY_IS_READY =
   PROJECT_KEY.length > 0 &&
   PROJECT_KEY !== PLACEHOLDER_KEY &&

--- a/examples/react-native/src/App.tsx
+++ b/examples/react-native/src/App.tsx
@@ -7,8 +7,8 @@ import { createStackNavigator } from '@react-navigation/stack';
 import {
   BrevwickProvider,
   type BrevwickConfig,
-  type BrevwickNavigationRef,
 } from '@tatlacas/brevwick-react-native';
+import { PROJECT_KEY_PATTERN } from '@tatlacas/brevwick-sdk';
 import { Home } from './screens/Home';
 import { Details } from './screens/Details';
 import { FeedbackFab } from './FeedbackFab';
@@ -21,11 +21,11 @@ export type RootStackParamList = {
 
 const Stack = createStackNavigator<RootStackParamList>();
 
-// Mirrors `validateConfig` from `@tatlacas/brevwick-sdk` so the example
-// renders without crashing the React tree when `.env` still holds the
-// seeded placeholder. `createBrevwick(...)` would throw synchronously
-// inside the provider's `useMemo` otherwise.
-const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
+// Defer to the SDK's public `PROJECT_KEY_PATTERN` rather than re-
+// implementing the regex — single source of truth with `validateConfig`.
+// When the env var still holds the seeded placeholder, render with
+// `enabled: false` so the provider memoises a no-op SDK instance instead
+// of crashing inside `useMemo` on `createBrevwick(...)`.
 const PLACEHOLDER_KEY = 'pk_test_replace_me';
 const PROJECT_KEY = process.env.EXPO_PUBLIC_BREVWICK_PROJECT_KEY ?? '';
 const ENDPOINT = process.env.EXPO_PUBLIC_BREVWICK_ENDPOINT;
@@ -33,6 +33,11 @@ const KEY_IS_READY =
   PROJECT_KEY.length > 0 &&
   PROJECT_KEY !== PLACEHOLDER_KEY &&
   PROJECT_KEY_PATTERN.test(PROJECT_KEY);
+// Keep this in lockstep with the SDK's `PROJECT_KEY_PATTERN`
+// (`/^pk_(live|test)_[A-Za-z0-9]{16,}$/`) — 24 alphanumeric chars after the
+// prefix, well above the 16-char floor. Re-exported from the SDK so a
+// future tightening flows here automatically.
+const FALLBACK_PROJECT_KEY = 'pk_test_placeholder0000000';
 
 export default function App(): ReactElement {
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
@@ -41,7 +46,7 @@ export default function App(): ReactElement {
   // on every render — it keys its SDK instance on config identity.
   const config = useMemo<BrevwickConfig>(
     () => ({
-      projectKey: KEY_IS_READY ? PROJECT_KEY : 'pk_test_placeholder0000000',
+      projectKey: KEY_IS_READY ? PROJECT_KEY : FALLBACK_PROJECT_KEY,
       endpoint: ENDPOINT,
       environment: 'stg',
       enabled: KEY_IS_READY,
@@ -50,15 +55,7 @@ export default function App(): ReactElement {
   );
 
   return (
-    // React Navigation's `addListener<T extends keyof EventMap>` is more
-    // strictly typed than `BrevwickNavigationRef`'s structural slot
-    // (which accepts any string event name), so we cast to the loose
-    // shape the provider expects. Both surfaces agree at runtime — the
-    // route ring only ever subscribes to `'state'`.
-    <BrevwickProvider
-      config={config}
-      navigationRef={navigationRef as unknown as BrevwickNavigationRef}
-    >
+    <BrevwickProvider config={config} navigationRef={navigationRef}>
       <NavigationContainer ref={navigationRef}>
         <Stack.Navigator>
           <Stack.Screen

--- a/examples/react-native/src/FeedbackFab.tsx
+++ b/examples/react-native/src/FeedbackFab.tsx
@@ -1,0 +1,176 @@
+import { useRef, useState, type ReactElement } from 'react';
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useFeedback } from '@tatlacas/brevwick-react-native';
+
+export interface FeedbackFabProps {
+  /**
+   * When false, render a disabled banner-style FAB instead of opening the
+   * modal — the example's `App.tsx` wires this to whether
+   * `EXPO_PUBLIC_BREVWICK_PROJECT_KEY` parses as a real `pk_test_…`. The
+   * provider itself is passed `enabled: false` in that case so the SDK is
+   * a no-op; this is purely for the user-facing affordance.
+   */
+  keyReady: boolean;
+}
+
+/**
+ * Inline replacement for `<FeedbackButton />` — the real drop-in component
+ * lands with #88. Until it does, the example demonstrates the same UX (and
+ * the same `useFeedback()` plumbing the canonical button uses internally)
+ * with a hand-rolled `<Pressable>` + RN `<Modal>` pair.
+ */
+export function FeedbackFab({ keyReady }: FeedbackFabProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const { submit, status, error, reset } = useFeedback();
+  const submittingRef = useRef(false);
+
+  async function handleSubmit(): Promise<void> {
+    if (submittingRef.current || !description.trim()) return;
+    submittingRef.current = true;
+    const result = await submit({ description });
+    submittingRef.current = false;
+    if (result.ok) {
+      setDescription('');
+      setTimeout(() => {
+        setOpen(false);
+        reset();
+      }, 1500);
+    }
+  }
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Send feedback"
+        accessibilityState={{ disabled: !keyReady }}
+        onPress={keyReady ? () => setOpen(true) : undefined}
+        style={[styles.fab, keyReady ? styles.fabReady : styles.fabDisabled]}
+      >
+        <Text style={styles.fabLabel}>
+          {keyReady ? 'Feedback' : 'Set EXPO_PUBLIC_BREVWICK_PROJECT_KEY'}
+        </Text>
+      </Pressable>
+
+      <Modal
+        animationType="slide"
+        transparent
+        visible={open}
+        onRequestClose={() => setOpen(false)}
+      >
+        <View style={styles.modalScrim}>
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>Send feedback</Text>
+            <TextInput
+              accessibilityLabel="Feedback description"
+              style={styles.input}
+              multiline
+              placeholder="What happened?"
+              value={description}
+              onChangeText={setDescription}
+              editable={status !== 'submitting'}
+            />
+            {status === 'success' && (
+              <Text style={styles.successText}>
+                Thanks! Filed to your inbox.
+              </Text>
+            )}
+            {status === 'error' && error && (
+              <Text style={styles.errorText}>{error.message}</Text>
+            )}
+            <View style={styles.row}>
+              <Pressable
+                onPress={() => {
+                  setOpen(false);
+                  setDescription('');
+                  reset();
+                }}
+                style={[styles.btn, styles.btnGhost]}
+              >
+                <Text style={styles.btnGhostLabel}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSubmit}
+                disabled={status === 'submitting' || !description.trim()}
+                style={[
+                  styles.btn,
+                  styles.btnPrimary,
+                  (status === 'submitting' || !description.trim()) &&
+                    styles.btnDisabled,
+                ]}
+              >
+                <Text style={styles.btnPrimaryLabel}>
+                  {status === 'submitting' ? 'Sending…' : 'Send'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    right: 24,
+    bottom: 48,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderRadius: 999,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  fabReady: { backgroundColor: '#7c3aed' },
+  fabDisabled: { backgroundColor: '#94a3b8' },
+  fabLabel: { color: '#fff', fontWeight: '600' },
+  modalScrim: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  modalCard: {
+    backgroundColor: '#fff',
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 32,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  modalTitle: { fontSize: 18, fontWeight: '600', marginBottom: 12 },
+  input: {
+    minHeight: 96,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 15,
+    textAlignVertical: 'top',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 16,
+  },
+  btn: { paddingHorizontal: 16, paddingVertical: 10, borderRadius: 8 },
+  btnGhost: { backgroundColor: '#f1f5f9' },
+  btnGhostLabel: { color: '#0f172a', fontWeight: '500' },
+  btnPrimary: { backgroundColor: '#7c3aed' },
+  btnPrimaryLabel: { color: '#fff', fontWeight: '600' },
+  btnDisabled: { opacity: 0.5 },
+  successText: { marginTop: 12, color: '#15803d' },
+  errorText: { marginTop: 12, color: '#b91c1c' },
+});

--- a/examples/react-native/src/FeedbackFab.tsx
+++ b/examples/react-native/src/FeedbackFab.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type ReactElement } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import {
   Modal,
   Pressable,
@@ -30,20 +30,49 @@ export function FeedbackFab({ keyReady }: FeedbackFabProps): ReactElement {
   const [open, setOpen] = useState(false);
   const [description, setDescription] = useState('');
   const { submit, status, error, reset } = useFeedback();
-  const submittingRef = useRef(false);
+  // Hold the post-success dismiss timer so we can cancel it on unmount or
+  // on early Cancel — without this, the timer would fire after teardown
+  // and call `reset()` / `setOpen(false)` against a stale render tree.
+  const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (dismissTimeoutRef.current !== null) {
+        clearTimeout(dismissTimeoutRef.current);
+        dismissTimeoutRef.current = null;
+      }
+    },
+    [],
+  );
+
+  function clearDismissTimer(): void {
+    if (dismissTimeoutRef.current !== null) {
+      clearTimeout(dismissTimeoutRef.current);
+      dismissTimeoutRef.current = null;
+    }
+  }
 
   async function handleSubmit(): Promise<void> {
-    if (submittingRef.current || !description.trim()) return;
-    submittingRef.current = true;
+    // `useFeedback().status` is the single source of truth for an in-flight
+    // submission — re-shadowing it with a local ref would just risk drift.
+    if (status === 'submitting' || !description.trim()) return;
     const result = await submit({ description });
-    submittingRef.current = false;
     if (result.ok) {
       setDescription('');
-      setTimeout(() => {
+      clearDismissTimer();
+      dismissTimeoutRef.current = setTimeout(() => {
+        dismissTimeoutRef.current = null;
         setOpen(false);
         reset();
       }, 1500);
     }
+  }
+
+  function handleCancel(): void {
+    clearDismissTimer();
+    setOpen(false);
+    setDescription('');
+    reset();
   }
 
   return (
@@ -64,7 +93,7 @@ export function FeedbackFab({ keyReady }: FeedbackFabProps): ReactElement {
         animationType="slide"
         transparent
         visible={open}
-        onRequestClose={() => setOpen(false)}
+        onRequestClose={handleCancel}
       >
         <View style={styles.modalScrim}>
           <View style={styles.modalCard}>
@@ -88,11 +117,7 @@ export function FeedbackFab({ keyReady }: FeedbackFabProps): ReactElement {
             )}
             <View style={styles.row}>
               <Pressable
-                onPress={() => {
-                  setOpen(false);
-                  setDescription('');
-                  reset();
-                }}
+                onPress={handleCancel}
                 style={[styles.btn, styles.btnGhost]}
               >
                 <Text style={styles.btnGhostLabel}>Cancel</Text>

--- a/examples/react-native/src/RouteRingBridge.tsx
+++ b/examples/react-native/src/RouteRingBridge.tsx
@@ -1,0 +1,35 @@
+import { useEffect, type ReactElement } from 'react';
+import {
+  attachRouteRing,
+  useBrevwick,
+  useBrevwickNavigationRef,
+  type Brevwick,
+} from '@tatlacas/brevwick-react-native';
+import type { RouteEntry } from '@tatlacas/brevwick-sdk';
+
+// Wires React Navigation `state` events into the SDK's 20-entry route
+// ring buffer. The `BrevwickProvider` only forwards `navigationRef` to
+// descendants via context (see `BrevwickNavigationRefContext`); the
+// actual subscription is owned by this bridge so apps that prefer to
+// drive the route ring from a different navigator can swap us out.
+//
+// `_internal.push` is the SDK's lockstep coupling between adapters and
+// the core ring buffers. The same backdoor is documented in
+// `packages/react-native/src/internal-bridge.ts` — both are stable
+// because the SDK + adapters version in lockstep.
+type BrevwickWithInternal = Brevwick & {
+  _internal?: { push?: (entry: RouteEntry) => void };
+};
+
+export function RouteRingBridge(): ReactElement | null {
+  const brevwick = useBrevwick() as BrevwickWithInternal;
+  const navigationRef = useBrevwickNavigationRef();
+
+  useEffect(() => {
+    const push = brevwick._internal?.push;
+    if (!navigationRef || typeof push !== 'function') return undefined;
+    return attachRouteRing(navigationRef, push);
+  }, [brevwick, navigationRef]);
+
+  return null;
+}

--- a/examples/react-native/src/RouteRingBridge.tsx
+++ b/examples/react-native/src/RouteRingBridge.tsx
@@ -1,35 +1,16 @@
-import { useEffect, type ReactElement } from 'react';
-import {
-  attachRouteRing,
-  useBrevwick,
-  useBrevwickNavigationRef,
-  type Brevwick,
-} from '@tatlacas/brevwick-react-native';
-import type { RouteEntry } from '@tatlacas/brevwick-sdk';
+import { type ReactElement } from 'react';
+import { useRouteRing } from '@tatlacas/brevwick-react-native';
 
-// Wires React Navigation `state` events into the SDK's 20-entry route
-// ring buffer. The `BrevwickProvider` only forwards `navigationRef` to
-// descendants via context (see `BrevwickNavigationRefContext`); the
-// actual subscription is owned by this bridge so apps that prefer to
-// drive the route ring from a different navigator can swap us out.
-//
-// `_internal.push` is the SDK's lockstep coupling between adapters and
-// the core ring buffers. The same backdoor is documented in
-// `packages/react-native/src/internal-bridge.ts` — both are stable
-// because the SDK + adapters version in lockstep.
-type BrevwickWithInternal = Brevwick & {
-  _internal?: { push?: (entry: RouteEntry) => void };
-};
-
+/**
+ * Wires React Navigation `state` events into the SDK's 20-entry route
+ * ring buffer via the public {@link useRouteRing} hook. The hook owns the
+ * lockstep `_internal.push` coupling so consumer apps don't need to
+ * re-implement the cast or the runtime guard.
+ *
+ * Render this component anywhere inside `<BrevwickProvider>` and the
+ * provider's forwarded `navigationRef` is picked up via context.
+ */
 export function RouteRingBridge(): ReactElement | null {
-  const brevwick = useBrevwick() as BrevwickWithInternal;
-  const navigationRef = useBrevwickNavigationRef();
-
-  useEffect(() => {
-    const push = brevwick._internal?.push;
-    if (!navigationRef || typeof push !== 'function') return undefined;
-    return attachRouteRing(navigationRef, push);
-  }, [brevwick, navigationRef]);
-
+  useRouteRing();
   return null;
 }

--- a/examples/react-native/src/screens/Details.tsx
+++ b/examples/react-native/src/screens/Details.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../App';
+
+type Props = StackScreenProps<RootStackParamList, 'Details'>;
+
+export function Details({ navigation, route }: Props): ReactElement {
+  const from = route.params?.from ?? 'unknown';
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Details</Text>
+      <Text style={styles.body}>
+        Arrived from <Text style={styles.bold}>{from}</Text>. The route ring now
+        has two entries — pop back, then open feedback to verify both are listed
+        under <Text style={styles.bold}>route_trail</Text> on the dashboard.
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Back to Home"
+        onPress={() => navigation.goBack()}
+        style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+      >
+        <Text style={styles.btnLabel}>Back to Home</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, gap: 16 },
+  heading: { fontSize: 22, fontWeight: '700' },
+  body: { fontSize: 15, color: '#334155', lineHeight: 22 },
+  bold: { fontWeight: '600', color: '#0f172a' },
+  btn: {
+    backgroundColor: '#0f172a',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  btnPressed: { opacity: 0.85 },
+  btnLabel: { color: '#fff', fontWeight: '600' },
+});

--- a/examples/react-native/src/screens/Home.tsx
+++ b/examples/react-native/src/screens/Home.tsx
@@ -1,0 +1,132 @@
+import { useState, type ReactElement } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { StackScreenProps } from '@react-navigation/stack';
+import type { RootStackParamList } from '../App';
+
+type Props = StackScreenProps<RootStackParamList, 'Home'>;
+
+export function Home({ navigation }: Props): ReactElement {
+  const [lastAction, setLastAction] = useState<string>('—');
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.heading}>Brevwick — RN demo</Text>
+      <Text style={styles.body}>
+        Tap each button to populate one of the four context streams the SDK
+        attaches to every submission, then tap{' '}
+        <Text style={styles.bold}>Feedback</Text> to file an issue.
+      </Text>
+
+      <Section title="1. Console ring">
+        <DemoButton
+          label="Throw a test error"
+          onPress={() => {
+            setLastAction('console.error fired + thrown error caught');
+            console.error('[brevwick-rn-example] Demo error from Home screen');
+            try {
+              throw new Error('Simulated render-path error');
+            } catch (err) {
+              console.warn('[brevwick-rn-example] Caught:', err);
+            }
+          }}
+        />
+      </Section>
+
+      <Section title="2. Network ring">
+        <DemoButton
+          label="Trigger failed fetch"
+          onPress={async () => {
+            setLastAction('Failed fetch in flight');
+            try {
+              await fetch('https://httpbin.org/status/503');
+              await fetch('https://this-host-does-not-exist.brevwick.invalid');
+            } catch {
+              // Expected — example wants the error in the network ring.
+            }
+            setLastAction('Failed fetch resolved (check network ring)');
+          }}
+        />
+      </Section>
+
+      <Section title="3. Route ring">
+        <DemoButton
+          label="Navigate to Details"
+          onPress={() => {
+            setLastAction('Navigated to Details — new route entry');
+            navigation.navigate('Details', { from: 'Home' });
+          }}
+        />
+      </Section>
+
+      <Section title="4. Open feedback">
+        <Text style={styles.helperText}>
+          Use the floating <Text style={styles.bold}>Feedback</Text> button in
+          the corner. It opens the composer and submits to your project inbox
+          once the form is filled.
+        </Text>
+      </Section>
+
+      <View style={styles.lastAction}>
+        <Text style={styles.lastActionLabel}>Last action:</Text>
+        <Text style={styles.lastActionValue}>{lastAction}</Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: ReactElement | ReactElement[];
+}
+function Section({ title, children }: SectionProps): ReactElement {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+interface DemoButtonProps {
+  label: string;
+  onPress: () => void;
+}
+function DemoButton({ label, onPress }: DemoButtonProps): ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+    >
+      <Text style={styles.btnLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 20, gap: 16, paddingBottom: 160 },
+  heading: { fontSize: 22, fontWeight: '700' },
+  body: { fontSize: 15, color: '#334155', lineHeight: 22 },
+  bold: { fontWeight: '600', color: '#0f172a' },
+  section: { gap: 8 },
+  sectionTitle: { fontSize: 13, fontWeight: '600', color: '#64748b' },
+  helperText: { fontSize: 14, color: '#475569', lineHeight: 20 },
+  btn: {
+    backgroundColor: '#0f172a',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  btnPressed: { opacity: 0.85 },
+  btnLabel: { color: '#fff', fontWeight: '600' },
+  lastAction: {
+    marginTop: 8,
+    padding: 12,
+    backgroundColor: '#f1f5f9',
+    borderRadius: 8,
+  },
+  lastActionLabel: { fontSize: 12, color: '#64748b' },
+  lastActionValue: { marginTop: 4, fontSize: 14, color: '#0f172a' },
+});

--- a/examples/react-native/src/screens/Home.tsx
+++ b/examples/react-native/src/screens/Home.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { StackScreenProps } from '@react-navigation/stack';
 import type { RootStackParamList } from '../App';
@@ -38,7 +38,11 @@ export function Home({ navigation }: Props): ReactElement {
           onPress={async () => {
             setLastAction('Failed fetch in flight');
             try {
-              await fetch('https://httpbin.org/status/503');
+              // `.invalid` is a reserved TLD (RFC 2606) — every resolver
+              // MUST return NXDOMAIN, so the failure is deterministic on
+              // every device and every network. Avoid third-party hosts
+              // (httpbin.org etc.) here: their flakiness reads as "the
+              // SDK is broken" in screenshots.
               await fetch('https://this-host-does-not-exist.brevwick.invalid');
             } catch {
               // Expected — example wants the error in the network ring.
@@ -76,7 +80,10 @@ export function Home({ navigation }: Props): ReactElement {
 
 interface SectionProps {
   title: string;
-  children: ReactElement | ReactElement[];
+  // `ReactNode` is the union the React docs recommend for arbitrary children:
+  // it accepts strings, fragments, conditional renders, and arrays — all of
+  // which the example screens elsewhere already use.
+  children: ReactNode;
 }
 function Section({ title, children }: SectionProps): ReactElement {
   return (

--- a/examples/react-native/tsconfig.json
+++ b/examples/react-native/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "moduleResolution": "Bundler",
     "noEmit": true
   },
   "include": ["src", "App.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]

--- a/examples/react-native/tsconfig.json
+++ b/examples/react-native/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  },
+  "include": ["src", "App.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+}

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,10 +4,10 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 React Native bindings for [Brevwick](https://brevwick.dev) — a provider, a
-`useFeedback` hook, a route-ring helper for React Navigation / Expo Router,
-a `BrevwickSkip` wrapper, and a native screenshot path that gracefully
-falls back to a placeholder when the optional `react-native-view-shot` peer
-isn't installed.
+`useFeedback` hook, a `useRouteRing` helper for React Navigation / Expo
+Router, a `BrevwickSkip` wrapper, and a native screenshot path that
+gracefully falls back to a placeholder when the optional
+`react-native-view-shot` peer isn't installed.
 
 Wraps [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
 — all configuration, redaction, and submit semantics live there. This
@@ -41,12 +41,12 @@ deps (npm 7+, pnpm, yarn 3+) pull it in automatically.
 
 ### Peer dependency matrix
 
-| Peer                     | Range          | Notes                                                                   |
-| ------------------------ | -------------- | ----------------------------------------------------------------------- |
-| `react`                  | `>=18 <20`     | 18.x and 19.x both supported.                                           |
-| `react-native`           | `>=0.72 <0.78` | Hermes and JSC both work; New Architecture is supported.                |
-| `@tatlacas/brevwick-sdk` | `workspace:*`  | Lockstep with this package — installer pulls a matching version.        |
-| `react-native-view-shot` | `^4.0.0`       | **Optional.** Without it, screenshots resolve to a 1×1 placeholder PNG. |
+| Peer                     | Range          | Notes                                                                                                                                                                                                          |
+| ------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `react`                  | `>=18 <20`     | 18.x and 19.x both supported.                                                                                                                                                                                  |
+| `react-native`           | `>=0.72 <0.78` | Hermes and JSC both work; New Architecture is supported.                                                                                                                                                       |
+| `@tatlacas/brevwick-sdk` | `workspace:*`  | Lockstep with this package — installer pulls a matching version.                                                                                                                                               |
+| `react-native-view-shot` | `>=3.8.0 <5`   | **Optional.** Without it, screenshots resolve to a 1×1 placeholder PNG. Expo SDK 51 ships `~3.8.0`; bare RN typically pins `^4.0.0`. Both work — `captureRef` returns the same data-URI shape on either major. |
 
 ## Quick start
 
@@ -111,11 +111,11 @@ wiring.
 </BrevwickProvider>
 ```
 
-| Prop            | Type                                 | Description                                                                                                                              |
-| --------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `config`        | `BrevwickConfig`                     | SDK config — see the [core SDK reference](https://www.npmjs.com/package/@tatlacas/brevwick-sdk). **Reference-stable**: hoist or memoise. |
-| `navigationRef` | `BrevwickNavigationRef \| undefined` | Forwarded to descendants via `BrevwickNavigationRefContext`. Read by the route-ring helper; the provider does not subscribe directly.    |
-| `children`      | `ReactNode`                          | Your tree.                                                                                                                               |
+| Prop             | Type                    | Description                                                                                                                                     |
+| ---------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`         | `BrevwickConfig`        | SDK config — see the [core SDK reference](https://www.npmjs.com/package/@tatlacas/brevwick-sdk). **Reference-stable**: hoist or memoise.        |
+| `navigationRef?` | `BrevwickNavigationRef` | Optional. Forwarded to descendants via `BrevwickNavigationRefContext`. Read by the route-ring helper; the provider does not subscribe directly. |
+| `children?`      | `ReactNode`             | Your tree.                                                                                                                                      |
 
 ## Route ring (React Navigation + Expo Router)
 
@@ -124,29 +124,10 @@ ref accepted directly by `BrevwickProvider`. Expo Router rides on top of
 React Navigation, so the same wiring serves both.
 
 ```tsx
-import { useEffect } from 'react';
-import {
-  attachRouteRing,
-  useBrevwick,
-  useBrevwickNavigationRef,
-  type Brevwick,
-} from '@tatlacas/brevwick-react-native';
-import type { RouteEntry } from '@tatlacas/brevwick-sdk';
-
-type BrevwickWithInternal = Brevwick & {
-  _internal?: { push?: (entry: RouteEntry) => void };
-};
+import { useRouteRing } from '@tatlacas/brevwick-react-native';
 
 function RouteRingBridge() {
-  const brevwick = useBrevwick() as BrevwickWithInternal;
-  const navigationRef = useBrevwickNavigationRef();
-
-  useEffect(() => {
-    const push = brevwick._internal?.push;
-    if (!navigationRef || typeof push !== 'function') return undefined;
-    return attachRouteRing(navigationRef, push);
-  }, [brevwick, navigationRef]);
-
+  useRouteRing();
   return null;
 }
 ```
@@ -158,10 +139,21 @@ React Navigation `state` events flow into the SDK's 20-entry route ring
 redacted via the SDK's global `redact()` before percent-encoding so a JWT
 or email carried by a benign-named key is still scrubbed.
 
-> The bridge wires React Navigation's `state` event into the SDK's
-> internal `push`. The drop-in `<FeedbackButton />` (#88) will own this
-> wiring once it lands; until then, copy the bridge above (or the
-> equivalent from `examples/react-native/src/RouteRingBridge.tsx`).
+`useRouteRing` resolves both the `Brevwick` instance and the
+`navigationRef` from context (the prop you forwarded to
+`<BrevwickProvider>`). For unusual layouts where the bridge is mounted
+outside the provider tree, pass an explicit ref:
+
+```tsx
+useRouteRing(navigationRef);
+```
+
+The drop-in `<FeedbackButton />` (#88) will own this wiring once it lands.
+Under the hood the hook composes `attachRouteRing(navigationRef, push)`
+with a captured `Brevwick._internal.push` — the lockstep coupling that
+the SDK + adapters version together. Consumers should prefer the hook
+over reaching into `_internal` directly so the documented-private surface
+crosses the adapter boundary in exactly one place.
 
 ## `useFeedback`
 
@@ -212,15 +204,15 @@ export function FeedbackFab() {
 
 ### Return value
 
-| Field               | Type                                              | Description                                                                                              |
-| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union the core SDK returns.                                     |
-| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a screenshot. Never throws — returns the placeholder PNG on failure.                             |
-| `status`            | `FeedbackStatus`                                  | `'idle' \| 'submitting' \| 'success' \| 'error'`. Backwards-compatible lifecycle.                        |
-| `phase`             | `FeedbackPhase`                                   | Submit-pipeline phase driven by the SDK's internal phase event.                                          |
-| `error`             | `SubmitError \| null`                             | Tagged error from the most recent failed submit. Cleared on the next `submit()` / `retry()` / `reset()`. |
-| `retry`             | `() => Promise<SubmitResult \| undefined>`        | Re-run the most recent `submit()` with the same input. No-op when no submit has been attempted.          |
-| `reset`             | `() => void`                                      | Reset `status` + `phase` back to `'idle'`, clear `error`, and forget the last submitted input.           |
+| Field               | Type                                                                         | Description                                                                                                                                                                                                                                                                                                     |
+| ------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>`                            | Submit feedback. Returns the same tagged union the core SDK returns.                                                                                                                                                                                                                                            |
+| `captureScreenshot` | `(viewRef?: RefObject<View>, opts?: CaptureScreenshotOpts) => Promise<Blob>` | Capture a screenshot. **Pass a `viewRef` for real captures on RN** — it routes through `react-native-view-shot` (placeholder PNG when the optional peer is missing). Without a `viewRef` the call falls through to the core SDK's DOM-based path, which on RN always resolves to the placeholder. Never throws. |
+| `status`            | `FeedbackStatus`                                                             | `'idle' \| 'submitting' \| 'success' \| 'error'`. Backwards-compatible lifecycle.                                                                                                                                                                                                                               |
+| `phase`             | `FeedbackPhase`                                                              | Submit-pipeline phase driven by the SDK's internal phase event.                                                                                                                                                                                                                                                 |
+| `error`             | `SubmitError \| null`                                                        | Tagged error from the most recent failed submit. Cleared on the next `submit()` / `retry()` / `reset()`.                                                                                                                                                                                                        |
+| `retry`             | `() => Promise<SubmitResult \| undefined>`                                   | Re-run the most recent `submit()` with the same input. No-op when no submit has been attempted.                                                                                                                                                                                                                 |
+| `reset`             | `() => void`                                                                 | Reset `status` + `phase` back to `'idle'`, clear `error`, and forget the last submitted input.                                                                                                                                                                                                                  |
 
 Throws synchronously on mount when rendered outside a `BrevwickProvider`.
 
@@ -337,10 +329,33 @@ Reference:
 
 ### "Unable to resolve module react-native-view-shot"
 
-Either install it (`npx expo install react-native-view-shot`, then
-`pod install` for bare RN), or accept the placeholder fallback. Nothing
-in this package hard-imports `react-native-view-shot` — the import is
-guarded.
+Nothing in this package hard-imports `react-native-view-shot` — the
+runtime `await import('react-native-view-shot')` is wrapped in a
+`.catch(() => null)` so a missing peer falls through to the placeholder.
+Metro, however, walks `import()` calls statically at bundle time and
+will still raise the resolver error before the runtime guard runs.
+
+Pick one:
+
+- **Install the peer** (recommended). `npx expo install react-native-view-shot`,
+  then `pod install` for bare RN. The placeholder path then only fires
+  when the native module fails to load (e.g. running in Expo Go).
+- **Tell Metro to skip the resolution.** Add the package to Metro's
+  `resolver.blockList` so the dynamic `import()` is replaced with a
+  resolver miss the runtime guard catches:
+
+  ```js
+  // metro.config.js
+  const exclusionList = require('metro-config/src/defaults/exclusionList');
+
+  config.resolver.blockList = exclusionList([
+    /node_modules\/react-native-view-shot\/.*/,
+  ]);
+  ```
+
+  Captures resolve to the placeholder PNG; `useFeedback().captureScreenshot`
+  and the standalone `captureScreenshot(viewRef)` keep their never-throws
+  contract.
 
 ### Hermes vs JSC
 
@@ -393,10 +408,15 @@ import type {
 
 ## Bundle
 
-- `sideEffects: false` so bundlers tree-shake unused exports.
 - `react-native-view-shot` is dynamically `import()`-ed on first capture
   — not at provider mount, not at button render — so an app that never
-  takes a screenshot pays nothing for the peer.
+  takes a screenshot pays nothing for the peer (and the package can ship
+  as a true optional dependency).
+- `sideEffects: false` is set on the package. **Metro** does not honour
+  the `sideEffects` field today — its bundler runs its own dead-code
+  elimination pass instead. The flag is still present so non-Metro
+  consumers (web bundlers re-using this package's `dist/`, monorepo
+  bundle-analysis tooling) keep their tree-shaking guarantees intact.
 
 ## Links
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,7 +1,412 @@
 # @tatlacas/brevwick-react-native
 
-Drop-in QA feedback widget for React Native (Expo + bare). **Coming soon.**
+[![npm](https://img.shields.io/npm/v/@tatlacas/brevwick-react-native/beta?label=@tatlacas/brevwick-react-native%40beta)](https://www.npmjs.com/package/@tatlacas/brevwick-react-native)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
-Tracking issue: [tatlacas-com/brevwick-sdk-js#82](https://github.com/tatlacas-com/brevwick-sdk-js/issues/82).
+React Native bindings for [Brevwick](https://brevwick.dev) — a provider, a
+`useFeedback` hook, a route-ring helper for React Navigation / Expo Router,
+a `BrevwickSkip` wrapper, and a native screenshot path that gracefully
+falls back to a placeholder when the optional `react-native-view-shot` peer
+isn't installed.
 
-Canonical README lands with [#90](https://github.com/tatlacas-com/brevwick-sdk-js/issues/90).
+Wraps [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
+— all configuration, redaction, and submit semantics live there. This
+package adds the React Native ergonomics (Hermes-safe imports, RN device
+context, native screenshot via `react-native-view-shot`).
+
+For React on the web (Next.js, Remix, Vite, CRA, Astro), see
+[`@tatlacas/brevwick-react`](../react).
+
+## Install
+
+### Expo (managed or bare)
+
+```bash
+npx expo install @tatlacas/brevwick-react-native @tatlacas/brevwick-sdk
+# Optional — required for real screenshots; without it the SDK returns
+# a 1×1 transparent PNG placeholder (never-throws contract).
+npx expo install react-native-view-shot
+```
+
+### Bare React Native
+
+```bash
+npm install @tatlacas/brevwick-react-native @tatlacas/brevwick-sdk
+npm install react-native-view-shot   # optional — see Screenshots below
+cd ios && pod install && cd ..       # iOS only — react-native-view-shot ships native code
+```
+
+`@tatlacas/brevwick-sdk` is a peer dependency. Installers that respect peer
+deps (npm 7+, pnpm, yarn 3+) pull it in automatically.
+
+### Peer dependency matrix
+
+| Peer                     | Range          | Notes                                                                   |
+| ------------------------ | -------------- | ----------------------------------------------------------------------- |
+| `react`                  | `>=18 <20`     | 18.x and 19.x both supported.                                           |
+| `react-native`           | `>=0.72 <0.78` | Hermes and JSC both work; New Architecture is supported.                |
+| `@tatlacas/brevwick-sdk` | `workspace:*`  | Lockstep with this package — installer pulls a matching version.        |
+| `react-native-view-shot` | `^4.0.0`       | **Optional.** Without it, screenshots resolve to a 1×1 placeholder PNG. |
+
+## Quick start
+
+```tsx
+import { useMemo } from 'react';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import {
+  BrevwickProvider,
+  type BrevwickConfig,
+} from '@tatlacas/brevwick-react-native';
+import { Home } from './screens/Home';
+import { Details } from './screens/Details';
+import { FeedbackFab } from './FeedbackFab';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  const navigationRef = useNavigationContainerRef();
+  // Hoist or memoise — the provider keys its SDK instance on config identity.
+  const config = useMemo<BrevwickConfig>(
+    () => ({
+      projectKey: process.env.EXPO_PUBLIC_BREVWICK_PROJECT_KEY!,
+    }),
+    [],
+  );
+
+  return (
+    <BrevwickProvider config={config} navigationRef={navigationRef}>
+      <NavigationContainer ref={navigationRef}>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={Home} />
+          <Stack.Screen name="Details" component={Details} />
+        </Stack.Navigator>
+      </NavigationContainer>
+      <FeedbackFab />
+    </BrevwickProvider>
+  );
+}
+```
+
+End-to-end runnable app:
+[`examples/react-native`](https://github.com/tatlacas-com/brevwick-sdk-js/tree/main/examples/react-native).
+
+> **Hoist `config` to module scope or memoise with `useMemo`.** The provider
+> keys the underlying SDK instance on config identity — passing a new
+> literal each render would cycle `install` / `uninstall` on every render.
+
+## `BrevwickProvider`
+
+Top-level provider. Memoises a single SDK instance on `config` identity,
+calls `install()` on mount and `uninstall()` on unmount, and forwards an
+optional `navigationRef` to descendants via context for the route-ring
+wiring.
+
+```tsx
+<BrevwickProvider config={brevwickConfig} navigationRef={navigationRef}>
+  {children}
+</BrevwickProvider>
+```
+
+| Prop            | Type                                 | Description                                                                                                                              |
+| --------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `config`        | `BrevwickConfig`                     | SDK config — see the [core SDK reference](https://www.npmjs.com/package/@tatlacas/brevwick-sdk). **Reference-stable**: hoist or memoise. |
+| `navigationRef` | `BrevwickNavigationRef \| undefined` | Forwarded to descendants via `BrevwickNavigationRefContext`. Read by the route-ring helper; the provider does not subscribe directly.    |
+| `children`      | `ReactNode`                          | Your tree.                                                                                                                               |
+
+## Route ring (React Navigation + Expo Router)
+
+`useNavigationContainerRef()` from `@react-navigation/native` returns a
+ref accepted directly by `BrevwickProvider`. Expo Router rides on top of
+React Navigation, so the same wiring serves both.
+
+```tsx
+import { useEffect } from 'react';
+import {
+  attachRouteRing,
+  useBrevwick,
+  useBrevwickNavigationRef,
+  type Brevwick,
+} from '@tatlacas/brevwick-react-native';
+import type { RouteEntry } from '@tatlacas/brevwick-sdk';
+
+type BrevwickWithInternal = Brevwick & {
+  _internal?: { push?: (entry: RouteEntry) => void };
+};
+
+function RouteRingBridge() {
+  const brevwick = useBrevwick() as BrevwickWithInternal;
+  const navigationRef = useBrevwickNavigationRef();
+
+  useEffect(() => {
+    const push = brevwick._internal?.push;
+    if (!navigationRef || typeof push !== 'function') return undefined;
+    return attachRouteRing(navigationRef, push);
+  }, [brevwick, navigationRef]);
+
+  return null;
+}
+```
+
+Render `<RouteRingBridge />` anywhere inside `<BrevwickProvider>` and
+React Navigation `state` events flow into the SDK's 20-entry route ring
+(FIFO, capped automatically). Path params matching `:token`, `:auth`,
+`:key`, `:session`, or `:sig` are masked, and every other param value is
+redacted via the SDK's global `redact()` before percent-encoding so a JWT
+or email carried by a benign-named key is still scrubbed.
+
+> The bridge wires React Navigation's `state` event into the SDK's
+> internal `push`. The drop-in `<FeedbackButton />` (#88) will own this
+> wiring once it lands; until then, copy the bridge above (or the
+> equivalent from `examples/react-native/src/RouteRingBridge.tsx`).
+
+## `useFeedback`
+
+Hook for building a custom feedback UI against the `BrevwickProvider`
+instance.
+
+```tsx
+import { useState } from 'react';
+import { Modal, Pressable, Text, TextInput, View } from 'react-native';
+import { useFeedback } from '@tatlacas/brevwick-react-native';
+
+export function FeedbackFab() {
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const { submit, status, error, reset } = useFeedback();
+
+  async function handleSubmit() {
+    const result = await submit({ description });
+    if (result.ok) {
+      setDescription('');
+      setOpen(false);
+      reset();
+    }
+  }
+
+  return (
+    <>
+      <Pressable onPress={() => setOpen(true)}>
+        <Text>Feedback</Text>
+      </Pressable>
+      <Modal visible={open} animationType="slide" transparent>
+        <View>
+          <TextInput
+            multiline
+            value={description}
+            onChangeText={setDescription}
+          />
+          {status === 'error' && error ? <Text>{error.message}</Text> : null}
+          <Pressable onPress={handleSubmit} disabled={status === 'submitting'}>
+            <Text>{status === 'submitting' ? 'Sending…' : 'Send'}</Text>
+          </Pressable>
+        </View>
+      </Modal>
+    </>
+  );
+}
+```
+
+### Return value
+
+| Field               | Type                                              | Description                                                                                              |
+| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `submit`            | `(input: FeedbackInput) => Promise<SubmitResult>` | Submit feedback. Returns the same tagged union the core SDK returns.                                     |
+| `captureScreenshot` | `() => Promise<Blob>`                             | Capture a screenshot. Never throws — returns the placeholder PNG on failure.                             |
+| `status`            | `FeedbackStatus`                                  | `'idle' \| 'submitting' \| 'success' \| 'error'`. Backwards-compatible lifecycle.                        |
+| `phase`             | `FeedbackPhase`                                   | Submit-pipeline phase driven by the SDK's internal phase event.                                          |
+| `error`             | `SubmitError \| null`                             | Tagged error from the most recent failed submit. Cleared on the next `submit()` / `retry()` / `reset()`. |
+| `retry`             | `() => Promise<SubmitResult \| undefined>`        | Re-run the most recent `submit()` with the same input. No-op when no submit has been attempted.          |
+| `reset`             | `() => void`                                      | Reset `status` + `phase` back to `'idle'`, clear `error`, and forget the last submitted input.           |
+
+Throws synchronously on mount when rendered outside a `BrevwickProvider`.
+
+## Screenshots
+
+`react-native-view-shot` is an optional peer dependency. When present, the
+SDK rasterises the View tree rooted at the supplied ref via `captureRef`.
+When absent — or in Expo Go, where the native module is not bundled — the
+SDK returns a 1×1 transparent PNG placeholder so callers that always
+attach the result still see a valid `image/png` Blob (the never-throws
+contract from SDD § 12).
+
+```tsx
+import { useRef } from 'react';
+import { View } from 'react-native';
+import {
+  captureScreenshot,
+  BrevwickSkip,
+} from '@tatlacas/brevwick-react-native';
+
+function Screen() {
+  const ref = useRef<View>(null);
+
+  async function snap() {
+    const blob = await captureScreenshot(ref); // never throws
+    // …attach to your submit payload
+  }
+
+  return (
+    <View ref={ref}>
+      <BrevwickSkip>
+        {/* hidden during capture, restored after */}
+        <SecretToken />
+      </BrevwickSkip>
+    </View>
+  );
+}
+```
+
+> **Expo Go limitation.** `react-native-view-shot` ships native code, so
+> Expo Go cannot load it; capture falls through to the placeholder. Build
+> a custom dev client to see real screenshots:
+> <https://docs.expo.dev/develop/development-builds/introduction/>.
+
+## Device context
+
+`collectDeviceContext()` returns a wire-ready object that mirrors the
+core SDK's `device_context` shape with one deliberate divergence:
+`platform` is `'react-native-ios'` / `'react-native-android'` so triage
+dashboards can split the cohort without branching on `sdk.name`.
+
+```ts
+import { collectDeviceContext } from '@tatlacas/brevwick-react-native';
+
+const ctx = collectDeviceContext();
+// → { ua, locale?, viewport?: { w, h }, platform, sdk: { name, version, platform } }
+```
+
+Read once on first call (static fields) and re-reads `viewport` per call
+so orientation / locale changes show up on the next submit.
+
+## Theming
+
+A `theme` prop on the eventual `<FeedbackButton />` (lands with #88) will
+accept `'system' | 'light' | 'dark'` matching the React (web) widget. The
+underlying token surface (accent / panel / chip / border) is shared with
+`@tatlacas/brevwick-react`; until the RN button lands you control your
+own surface in custom UIs (see the `useFeedback` snippet above).
+
+## Hiding sensitive content from screenshots
+
+Wrap the subtree in `<BrevwickSkip>`. The wrapper installs a refcount-aware
+hide / restore on the underlying View ref so concurrent captures cannot
+strand the UI hidden:
+
+```tsx
+<BrevwickSkip>
+  <Text>{customerEmail}</Text>
+</BrevwickSkip>
+```
+
+The skip pattern mirrors `data-brevwick-skip` on the web SDK.
+
+## Troubleshooting
+
+### Metro can't resolve `@tatlacas/brevwick-react-native` in a monorepo
+
+In a pnpm / yarn workspace, Metro defaults to walking only the project's
+`node_modules` — which under pnpm only contains a symlink. Add the
+workspace root to `watchFolders`:
+
+```js
+// metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [workspaceRoot];
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+config.resolver.disableHierarchicalLookup = true;
+
+module.exports = config;
+```
+
+Reference:
+[`examples/react-native/metro.config.js`](https://github.com/tatlacas-com/brevwick-sdk-js/tree/main/examples/react-native/metro.config.js).
+
+### "Unable to resolve module react-native-view-shot"
+
+Either install it (`npx expo install react-native-view-shot`, then
+`pod install` for bare RN), or accept the placeholder fallback. Nothing
+in this package hard-imports `react-native-view-shot` — the import is
+guarded.
+
+### Hermes vs JSC
+
+Both are supported. The package uses no Hermes-specific features and no
+APIs missing from JSC. The screenshot path is the only place where the
+runtime matters, and it gates on `react-native-view-shot`'s presence (a
+native-module question, not a JS-engine one).
+
+### Workspace `react-native` field
+
+This package publishes `"react-native": "./src/index.ts"` so Metro
+prefers the source over the `dist/` build. If you see "Cannot find
+module … react-native-view-shot" only in production bundles, ensure your
+Metro `resolver.assetExts` / `resolver.sourceExts` defaults are intact —
+overriding them without including the originals strips `.ts` resolution.
+
+## `BREVWICK_REACT_NATIVE_VERSION`
+
+Exported semver string of the installed package — useful for diagnostics.
+
+```ts
+import { BREVWICK_REACT_NATIVE_VERSION } from '@tatlacas/brevwick-react-native';
+console.log('@tatlacas/brevwick-react-native', BREVWICK_REACT_NATIVE_VERSION);
+```
+
+## TypeScript
+
+Full types ship as `.d.ts` for both ESM and CJS. Re-exports include the
+SDK types RN consumers most often touch:
+
+```ts
+import type {
+  BrevwickProviderProps,
+  BrevwickNavigationRef,
+  CaptureScreenshotOpts,
+  DeviceContext,
+  FeedbackPhase,
+  FeedbackStatus,
+  UseFeedbackResult,
+  // re-exported from @tatlacas/brevwick-sdk for convenience:
+  Brevwick,
+  BrevwickConfig,
+  FeedbackAttachment,
+  FeedbackInput,
+  SubmitError,
+  SubmitErrorCode,
+  SubmitResult,
+} from '@tatlacas/brevwick-react-native';
+```
+
+## Bundle
+
+- `sideEffects: false` so bundlers tree-shake unused exports.
+- `react-native-view-shot` is dynamically `import()`-ed on first capture
+  — not at provider mount, not at button render — so an app that never
+  takes a screenshot pays nothing for the peer.
+
+## Links
+
+- **Core SDK:** [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk)
+- **React (web):** [`@tatlacas/brevwick-react`](../react/README.md)
+- **Example app:** [`examples/react-native`](https://github.com/tatlacas-com/brevwick-sdk-js/tree/main/examples/react-native)
+- **Docs / dashboard:** [brevwick.dev](https://brevwick.dev)
+- **Source:** [github.com/tatlacas-com/brevwick-sdk-js](https://github.com/tatlacas-com/brevwick-sdk-js)
+- **Issues:** [github.com/tatlacas-com/brevwick-sdk-js/issues](https://github.com/tatlacas-com/brevwick-sdk-js/issues)
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -41,12 +41,12 @@ deps (npm 7+, pnpm, yarn 3+) pull it in automatically.
 
 ### Peer dependency matrix
 
-| Peer                     | Range          | Notes                                                                                                                                                                                                          |
-| ------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `react`                  | `>=18 <20`     | 18.x and 19.x both supported.                                                                                                                                                                                  |
-| `react-native`           | `>=0.72 <0.78` | Hermes and JSC both work; New Architecture is supported.                                                                                                                                                       |
-| `@tatlacas/brevwick-sdk` | `workspace:*`  | Lockstep with this package — installer pulls a matching version.                                                                                                                                               |
-| `react-native-view-shot` | `>=3.8.0 <5`   | **Optional.** Without it, screenshots resolve to a 1×1 placeholder PNG. Expo SDK 51 ships `~3.8.0`; bare RN typically pins `^4.0.0`. Both work — `captureRef` returns the same data-URI shape on either major. |
+| Peer                     | Range                                     | Notes                                                                                                                                                                                                          |
+| ------------------------ | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `react`                  | `>=18 <20`                                | 18.x and 19.x both supported.                                                                                                                                                                                  |
+| `react-native`           | `>=0.72 <0.78`                            | Hermes and JSC both work; New Architecture is supported.                                                                                                                                                       |
+| `@tatlacas/brevwick-sdk` | matches `@tatlacas/brevwick-react-native` | Lockstep with this package — `npm install @tatlacas/brevwick-react-native` resolves the matching version automatically.                                                                                        |
+| `react-native-view-shot` | `>=3.8.0 <5`                              | **Optional.** Without it, screenshots resolve to a 1×1 placeholder PNG. Expo SDK 51 ships `~3.8.0`; bare RN typically pins `^4.0.0`. Both work — `captureRef` returns the same data-URI shape on either major. |
 
 ## Quick start
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -55,7 +55,7 @@
     "@tatlacas/brevwick-sdk": "workspace:*",
     "react": ">=18 <20",
     "react-native": ">=0.72 <0.78",
-    "react-native-view-shot": "^4.0.0"
+    "react-native-view-shot": ">=3.8.0 <5"
   },
   "peerDependenciesMeta": {
     "react-native-view-shot": {

--- a/packages/react-native/src/__tests__/use-feedback.test.tsx
+++ b/packages/react-native/src/__tests__/use-feedback.test.tsx
@@ -212,12 +212,28 @@ describe('useFeedback', () => {
     expect(retried).toBeUndefined();
   });
 
-  it('captureScreenshot passes through to the SDK', async () => {
+  it('captureScreenshot() with no viewRef passes through to the SDK (DOM path)', async () => {
     const blob = new Blob(['png'], { type: 'image/png' });
     captureScreenshot.mockResolvedValueOnce(blob);
     const { result } = renderHook(() => useFeedback(), { wrapper });
     await expect(result.current.captureScreenshot()).resolves.toBe(blob);
     expect(captureScreenshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('captureScreenshot(viewRef) routes through the RN-native path, not the SDK', async () => {
+    // The RN-native screenshot path falls through to a placeholder PNG when
+    // `react-native-view-shot` is not installed (the test runtime). We
+    // assert two things: the returned Blob is a non-empty `image/png`
+    // (the placeholder shape) AND the core SDK's `captureScreenshot` was
+    // NOT called — proving the hook routed to the RN path on viewRef
+    // presence, fixing the README claim that the no-arg form returns a
+    // working capture on RN.
+    const { result } = renderHook(() => useFeedback(), { wrapper });
+    const fakeViewRef = { current: null };
+    const out = await result.current.captureScreenshot(fakeViewRef);
+    expect(out.type).toBe('image/png');
+    expect(out.size).toBeGreaterThan(0);
+    expect(captureScreenshot).not.toHaveBeenCalled();
   });
 
   it('throws synchronously when used outside a provider', () => {

--- a/packages/react-native/src/__tests__/use-route-ring.test.tsx
+++ b/packages/react-native/src/__tests__/use-route-ring.test.tsx
@@ -1,0 +1,186 @@
+// Same `/pure` rationale as `provider.test.tsx`: the route-ring tests
+// inspect listener registration, not visual output, so we skip the
+// auto-extended matchers / cleanup.
+import { render } from '@testing-library/react-native/pure';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement, ReactNode } from 'react';
+import type {
+  Brevwick,
+  BrevwickConfig,
+  RouteEntry,
+} from '@tatlacas/brevwick-sdk';
+
+const install = vi.fn();
+const uninstall = vi.fn();
+const submit = vi.fn();
+const captureScreenshot = vi.fn();
+const createBrevwick = vi.fn<(config: BrevwickConfig) => Brevwick>();
+
+vi.mock('@tatlacas/brevwick-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
+    '@tatlacas/brevwick-sdk',
+  );
+  return {
+    ...actual,
+    createBrevwick: (config: BrevwickConfig) => createBrevwick(config),
+  };
+});
+
+import { BrevwickProvider } from '../provider';
+import { useRouteRing } from '../use-route-ring';
+import type { BrevwickNavigationRef } from '../navigation-ref-context';
+
+const stampInternal = (
+  base: Partial<Brevwick>,
+  push: (entry: RouteEntry) => void,
+): Brevwick =>
+  ({
+    install,
+    uninstall,
+    submit,
+    captureScreenshot,
+    ...base,
+    _internal: { push },
+  }) as unknown as Brevwick;
+
+const noInternalInstance = (): Brevwick =>
+  ({ install, uninstall, submit, captureScreenshot }) as unknown as Brevwick;
+
+// `addListener` is structurally `(event: 'state', cb: (...args: any[]) =>
+// void) => () => void`. Returning the typed signature directly from
+// `vi.fn<>()` lets the captured-call sites read the args without per-test
+// `.mock.calls[0]?.[0]` index assertions tripping noUncheckedIndexedAccess.
+type AddListener = (
+  event: 'state',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cb: (...args: any[]) => void,
+) => () => void;
+
+const Wrap = ({
+  children,
+  navigationRef,
+}: {
+  children: ReactNode;
+  navigationRef?: BrevwickNavigationRef;
+}): ReactElement => (
+  <BrevwickProvider
+    config={{ projectKey: 'pk_test_useRouteRingTests0000' }}
+    navigationRef={navigationRef}
+  >
+    {children}
+  </BrevwickProvider>
+);
+
+const Bridge = (): null => {
+  useRouteRing();
+  return null;
+};
+
+const ExplicitBridge = ({
+  navigationRef,
+}: {
+  navigationRef: BrevwickNavigationRef;
+}): null => {
+  useRouteRing(navigationRef);
+  return null;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useRouteRing', () => {
+  it('registers a `state` listener via the navigationRef forwarded by the provider', () => {
+    const detach = vi.fn();
+    const addListener = vi.fn<AddListener>(() => detach);
+    const push = vi.fn();
+    createBrevwick.mockReturnValueOnce(stampInternal({}, push));
+
+    const navigationRef: BrevwickNavigationRef = {
+      current: {
+        addListener,
+        getCurrentRoute: () => ({ name: 'Home' }),
+      },
+    };
+
+    const { unmount } = render(
+      <Wrap navigationRef={navigationRef}>
+        <Bridge />
+      </Wrap>,
+    );
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+    const [event, cb] = addListener.mock.calls[0] ?? ['state', () => {}];
+    expect(event).toBe('state');
+
+    // Firing the captured listener should funnel a RouteEntry into push.
+    cb();
+    expect(push).toHaveBeenCalledTimes(1);
+    const entry = push.mock.calls[0]?.[0] as RouteEntry;
+    expect(entry.kind).toBe('route');
+    expect(entry.path).toBe('Home');
+
+    unmount();
+    expect(detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when no navigationRef is forwarded by the provider', () => {
+    createBrevwick.mockReturnValueOnce(stampInternal({}, vi.fn()));
+    // No `navigationRef` prop on the wrapper — the hook must not crash and
+    // must not leak any side effects when the provider's slot is empty.
+    expect(() =>
+      render(
+        <Wrap>
+          <Bridge />
+        </Wrap>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('is a no-op when the Brevwick instance does not expose `_internal.push`', () => {
+    // Real `createBrevwick(...)` always stamps `_internal`; this branch
+    // covers consumer-supplied mocks that do not. Without the guard the
+    // hook would call `attachRouteRing(ref, undefined)` and crash on the
+    // first navigation event.
+    const addListener = vi.fn<AddListener>(() => () => {});
+    createBrevwick.mockReturnValueOnce(noInternalInstance());
+
+    const navigationRef: BrevwickNavigationRef = {
+      current: {
+        addListener,
+        getCurrentRoute: () => ({ name: 'Home' }),
+      },
+    };
+
+    render(
+      <Wrap navigationRef={navigationRef}>
+        <Bridge />
+      </Wrap>,
+    );
+
+    expect(addListener).not.toHaveBeenCalled();
+  });
+
+  it('accepts an explicit navigationRef argument that overrides context', () => {
+    const detach = vi.fn();
+    const addListener = vi.fn<AddListener>(() => detach);
+    createBrevwick.mockReturnValueOnce(stampInternal({}, vi.fn()));
+
+    const navigationRef: BrevwickNavigationRef = {
+      current: {
+        addListener,
+        getCurrentRoute: () => ({ name: 'Details' }),
+      },
+    };
+
+    render(
+      <Wrap>
+        <ExplicitBridge navigationRef={navigationRef} />
+      </Wrap>,
+    );
+
+    expect(addListener).toHaveBeenCalledTimes(1);
+    const [event] = addListener.mock.calls[0] ?? ['state', () => {}];
+    expect(event).toBe('state');
+  });
+});

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -20,6 +20,12 @@ export type {
   NavigationRefLike,
 } from './rings/route';
 
+// Public route-ring hook. Owns the `_internal.push` reach-around so the
+// documented-private SDK surface only crosses the adapter boundary in one
+// place — every consumer that needs the route ring uses this hook (or the
+// lower-level `attachRouteRing`) rather than re-implementing the cast.
+export { useRouteRing } from './use-route-ring';
+
 export { collectDeviceContext, type DeviceContext } from './device';
 
 export { captureScreenshot } from './screenshot';

--- a/packages/react-native/src/navigation-ref-context.ts
+++ b/packages/react-native/src/navigation-ref-context.ts
@@ -7,11 +7,20 @@ import { createContext, useContext } from 'react';
  * the adapter does not pull React Navigation in as a hard dependency for
  * consumers that don't use it. The route-ring worktree (#87) reads this
  * via {@link useBrevwickNavigationRef} and subscribes through `addListener`.
+ *
+ * `addListener` is typed against the `'state'` event literal — the only
+ * event the route ring subscribes to — so the strict overloaded signature
+ * exposed by `useNavigationContainerRef<TParamList>()` (where `event` is
+ * narrowed to a union of literal event names) is structurally assignable
+ * **without** a `as unknown as BrevwickNavigationRef` cast at the call
+ * site. Function parameter types are contravariant in TypeScript, so a
+ * narrower event type here means consumer refs widen to fit; the previous
+ * `event: string` shape did the opposite.
  */
 export interface BrevwickNavigationRef {
   current: {
     addListener: (
-      event: string,
+      event: 'state',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       cb: (...args: any[]) => void,
     ) => () => void;

--- a/packages/react-native/src/screenshot.ts
+++ b/packages/react-native/src/screenshot.ts
@@ -134,7 +134,7 @@ export interface CaptureScreenshotOpts {
  * fallback must land in core's submit before the RN adapter can submit.
  */
 export async function captureScreenshot(
-  viewRef: RefObject<View | null> | RefObject<View>,
+  viewRef: RefObject<View | null>,
   opts?: CaptureScreenshotOpts,
 ): Promise<Blob> {
   const quality = opts?.quality ?? DEFAULT_QUALITY;

--- a/packages/react-native/src/use-feedback.ts
+++ b/packages/react-native/src/use-feedback.ts
@@ -74,7 +74,7 @@ export interface UseFeedbackResult {
    * the SDK's never-throws contract from SDD § 12).
    */
   captureScreenshot: (
-    viewRef?: RefObject<View | null> | RefObject<View>,
+    viewRef?: RefObject<View | null>,
     opts?: CaptureScreenshotOpts,
   ) => Promise<Blob>;
   /** Current submission status. */
@@ -201,7 +201,7 @@ export function useFeedback(): UseFeedbackResult {
 
   const captureScreenshot = useCallback(
     (
-      viewRef?: RefObject<View | null> | RefObject<View>,
+      viewRef?: RefObject<View | null>,
       opts?: CaptureScreenshotOpts,
     ): Promise<Blob> => {
       // When the caller hands us a viewRef, route through the RN-native

--- a/packages/react-native/src/use-feedback.ts
+++ b/packages/react-native/src/use-feedback.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import type { View } from 'react-native';
 import type {
   FeedbackInput,
   SubmitError,
@@ -6,6 +13,10 @@ import type {
 } from '@tatlacas/brevwick-sdk';
 import { useBrevwick } from './context';
 import { getPhaseBus, type PhaseEvent } from './internal-bridge';
+import {
+  captureScreenshot as captureScreenshotNative,
+  type CaptureScreenshotOpts,
+} from './screenshot';
 
 /**
  * Submission lifecycle surfaced by {@link useFeedback}. Held for backward
@@ -48,8 +59,24 @@ export type FeedbackPhase =
 export interface UseFeedbackResult {
   /** Submit feedback. Returns the same tagged union the core SDK returns. */
   submit: (input: FeedbackInput) => Promise<SubmitResult>;
-  /** Capture a screenshot via the core SDK. RN-specific capture lands in #86. */
-  captureScreenshot: () => Promise<Blob>;
+  /**
+   * Capture a screenshot.
+   *
+   * - **With a `viewRef`** (recommended on RN), delegates to the package's
+   *   {@link captureScreenshotNative} which uses `react-native-view-shot`
+   *   when the optional peer is installed.
+   * - **Without a `viewRef`**, delegates to the core SDK's
+   *   {@link Brevwick.captureScreenshot} — that path depends on `document`
+   *   and on RN always resolves to the placeholder PNG. Pass a `viewRef`
+   *   for real captures.
+   *
+   * Never throws — returns the placeholder PNG on any failure (preserves
+   * the SDK's never-throws contract from SDD § 12).
+   */
+  captureScreenshot: (
+    viewRef?: RefObject<View | null> | RefObject<View>,
+    opts?: CaptureScreenshotOpts,
+  ) => Promise<Blob>;
   /** Current submission status. */
   status: FeedbackStatus;
   /**
@@ -173,7 +200,20 @@ export function useFeedback(): UseFeedbackResult {
   }, [runSubmit]);
 
   const captureScreenshot = useCallback(
-    (): Promise<Blob> => brevwick.captureScreenshot(),
+    (
+      viewRef?: RefObject<View | null> | RefObject<View>,
+      opts?: CaptureScreenshotOpts,
+    ): Promise<Blob> => {
+      // When the caller hands us a viewRef, route through the RN-native
+      // capture path (`react-native-view-shot` when available, placeholder
+      // on failure / missing peer). Without a viewRef we cannot reach the
+      // RN view tree, so fall back to the core SDK's capture — on RN that
+      // path always resolves to the placeholder because `document` is
+      // undefined, but the contract stays consistent: never throws, always
+      // a Blob.
+      if (viewRef) return captureScreenshotNative(viewRef, opts);
+      return brevwick.captureScreenshot();
+    },
     [brevwick],
   );
 

--- a/packages/react-native/src/use-route-ring.ts
+++ b/packages/react-native/src/use-route-ring.ts
@@ -1,0 +1,94 @@
+/**
+ * Public route-ring helper. Wraps the `_internal.push` reach-around the
+ * route bridge previously copy-pasted into every consumer (`docs/issue-89-90`
+ * review #101) so the documented-private SDK surface only crosses the
+ * adapter boundary in **one** place.
+ *
+ * The previous shape (a copy/pasted `BrevwickWithInternal` cast in every
+ * consumer) violated the encapsulation `INTERNAL_KEY` exists to enforce —
+ * widening `_internal.push` to N consumer apps means the SDK can never
+ * tighten the backdoor without breaking each one. This hook owns the cast
+ * (and the runtime guard) so the SDK can evolve the internal contract
+ * freely as long as this file keeps up.
+ */
+import { useEffect } from 'react';
+import type { Brevwick, RouteEntry } from '@tatlacas/brevwick-sdk';
+import { useBrevwick } from './context';
+import {
+  useBrevwickNavigationRef,
+  type BrevwickNavigationRef,
+} from './navigation-ref-context';
+import { attachRouteRing, type NavigationRefLike } from './rings/route';
+
+/**
+ * Adapter-internal lockstep coupling with the SDK's `_internal` backdoor.
+ * Documented in `internal-bridge.ts` for the phase bus; this file owns the
+ * coupling for the route ring. Both surfaces live in lockstep with the
+ * core package via the linked changeset group, so the `'_internal'` /
+ * `'push'` strings are stable.
+ */
+type BrevwickWithInternal = Brevwick & {
+  _internal?: { push?: (entry: RouteEntry) => void };
+};
+
+function getPush(brevwick: Brevwick): ((entry: RouteEntry) => void) | null {
+  const internal = (brevwick as BrevwickWithInternal)._internal;
+  if (!internal) return null;
+  const push = internal.push;
+  return typeof push === 'function' ? push : null;
+}
+
+/**
+ * Subscribe React Navigation's `state` event to the SDK's route ring.
+ *
+ * Resolves both the {@link Brevwick} instance and the `navigationRef`
+ * forwarded by {@link BrevwickProvider} from context, attaches a listener
+ * via {@link attachRouteRing}, and detaches on unmount.
+ *
+ * No-op (returns silently from the effect) when:
+ * - The provider was rendered without a `navigationRef` prop, OR
+ * - The mounted `Brevwick` instance does not expose `_internal.push`
+ *   (e.g. a custom mock in a test). Apps that follow the documented setup
+ *   never hit this branch — the production `createBrevwick` always stamps
+ *   `_internal`.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const navigationRef = useNavigationContainerRef();
+ *   const config = useMemo(() => ({ projectKey: '…' }), []);
+ *   return (
+ *     <BrevwickProvider config={config} navigationRef={navigationRef}>
+ *       <NavigationContainer ref={navigationRef}>{routes}</NavigationContainer>
+ *       <RouteRingBridge />
+ *     </BrevwickProvider>
+ *   );
+ * }
+ *
+ * function RouteRingBridge() {
+ *   useRouteRing();
+ *   return null;
+ * }
+ * ```
+ *
+ * Pass an explicit `navigationRef` argument when the bridge is mounted
+ * outside the provider tree (rare — most consumers use the no-arg form
+ * and let the context resolve the ref).
+ */
+export function useRouteRing(navigationRef?: BrevwickNavigationRef): void {
+  const brevwick = useBrevwick();
+  const ctxNavigationRef = useBrevwickNavigationRef();
+  const ref = navigationRef ?? ctxNavigationRef;
+
+  useEffect(() => {
+    if (!ref) return undefined;
+    const push = getPush(brevwick);
+    if (!push) return undefined;
+    // `BrevwickNavigationRef` and `NavigationRefLike` describe the same
+    // structural shape (a `current` slot with `addListener` and an
+    // optional `getCurrentRoute`); the cast is safe and stays here so
+    // consumers never see it. `attachRouteRing`'s runtime guard handles
+    // the `null` / missing-method cases defensively.
+    return attachRouteRing(ref as unknown as NavigationRefLike, push);
+  }, [brevwick, ref]);
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,6 +7,8 @@ React bindings for [Brevwick](https://brevwick.dev) — a provider, a drop-in fl
 
 Wraps [`@tatlacas/brevwick-sdk`](https://www.npmjs.com/package/@tatlacas/brevwick-sdk) — all configuration and submit semantics live there. This package adds the React ergonomics.
 
+> **Building for React Native?** Use [`@tatlacas/brevwick-react-native`](../react-native/README.md) instead — same provider / `useFeedback` ergonomics, but with RN-native primitives (Hermes-safe imports, `react-native-view-shot` for screenshots, React Navigation route ring).
+
 ## Install
 
 ```bash

--- a/packages/sdk/src/core/__tests__/validate.test.ts
+++ b/packages/sdk/src/core/__tests__/validate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { INVALID_CONFIG_CODE, validateConfig } from '../validate';
+import {
+  INVALID_CONFIG_CODE,
+  PROJECT_KEY_PATTERN,
+  validateConfig,
+} from '../validate';
 
 const VALID_KEY = 'pk_live_abcdefghijklmnop01';
 
@@ -231,5 +235,46 @@ describe('validateConfig', () => {
     } catch (err) {
       expect((err as { code?: string }).code).toBe(INVALID_CONFIG_CODE);
     }
+  });
+});
+
+// `PROJECT_KEY_PATTERN` is exported so adapter packages and example apps
+// can gate UI on the same source of truth `validateConfig` enforces.
+// These tests pin the contract — if anyone tightens the pattern, the
+// failures here force a coordinated update at every consumer that
+// imports it.
+describe('PROJECT_KEY_PATTERN', () => {
+  it.each([
+    ['pk_live_abcdefghijklmnop'],
+    ['pk_test_abcdefghijklmnop'],
+    ['pk_live_ABCDEFGHIJKLMNOP01'],
+    ['pk_test_placeholder0000000'], // 24 chars after prefix; matches the example fallback.
+  ])('accepts %s', (key) => {
+    expect(PROJECT_KEY_PATTERN.test(key)).toBe(true);
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['placeholder seed', 'pk_test_replace_me'],
+    ['wrong prefix', 'sk_live_abcdefghijklmnop'],
+    ['wrong env', 'pk_dev_abcdefghijklmnop'],
+    ['too short', 'pk_live_short'],
+    ['contains hyphen', 'pk_live_abcdefghijk-mnop'],
+  ])('rejects %s', (_label, value) => {
+    expect(PROJECT_KEY_PATTERN.test(value)).toBe(false);
+  });
+
+  it('agrees with validateConfig (single source of truth)', () => {
+    // Property-style: any string the regex accepts must be accepted by
+    // validateConfig, and vice versa for the rejections sample. If these
+    // ever diverge, the regex has stopped being a useful gate and a
+    // consumer would render UI that crashes on createBrevwick(...).
+    const valid = 'pk_live_abcdefghijklmnop';
+    expect(PROJECT_KEY_PATTERN.test(valid)).toBe(true);
+    expect(() => validateConfig({ projectKey: valid })).not.toThrow();
+
+    const invalid = 'pk_live_short';
+    expect(PROJECT_KEY_PATTERN.test(invalid)).toBe(false);
+    expect(() => validateConfig({ projectKey: invalid })).toThrow();
   });
 });

--- a/packages/sdk/src/core/validate.ts
+++ b/packages/sdk/src/core/validate.ts
@@ -16,7 +16,20 @@ export class BrevwickConfigError extends Error {
   }
 }
 
-const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
+/**
+ * Public regex that gates accepted `projectKey` strings — exported so adapter
+ * packages and example apps can validate user-supplied keys before constructing
+ * a `Brevwick` instance, without duplicating (and risking drift from) the
+ * single source of truth used by {@link validateConfig}. The pattern accepts
+ * `pk_live_…` or `pk_test_…` followed by 16+ alphanumeric characters; tighten
+ * here and every consumer picks up the change automatically.
+ *
+ * The regex is the only export — a `boolean`-returning helper would have
+ * cost ~25 B gzipped on top of the eager bundle (we are 30 B from the
+ * 2.85 kB ceiling), and `PROJECT_KEY_PATTERN.test(value)` is a one-line
+ * call for consumers anyway.
+ */
+export const PROJECT_KEY_PATTERN = /^pk_(live|test)_[A-Za-z0-9]{16,}$/;
 const DEFAULT_ENDPOINT = 'https://api.brevwick.com';
 const VALID_ENVIRONMENTS = [
   'dev',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,18 @@ export { createBrevwick } from './core/client';
  */
 export { redact, SENSITIVE_PARAM_KEYS } from './core/internal/redact';
 
+/**
+ * Project-key regex surfaced for adapter packages and example apps that
+ * need to gate UI on whether a user-supplied env var would be accepted by
+ * {@link createBrevwick}. Single source of truth — the SDK's own validator
+ * (`validateConfig`) consumes the same regex, so any tightening here flows
+ * to every consumer without per-call-site drift. Use as
+ * `PROJECT_KEY_PATTERN.test(value)`; we don't ship a wrapped boolean
+ * helper because the eager bundle is within ~30 B of its 2.85 kB ceiling
+ * (CLAUDE.md / SDD § 12) and a one-line `.test(value)` is no friction.
+ */
+export { PROJECT_KEY_PATTERN } from './core/validate';
+
 export type {
   Brevwick,
   BrevwickConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         specifier: 3.31.1
         version: 3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-view-shot:
-        specifier: 3.8.0
+        specifier: ~3.8.0
         version: 3.8.0(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@types/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,52 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/react-native:
+    dependencies:
+      '@react-navigation/native':
+        specifier: ^6.1.18
+        version: 6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/stack':
+        specifier: ^6.4.1
+        version: 6.4.1(@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tatlacas/brevwick-react-native':
+        specifier: workspace:*
+        version: link:../../packages/react-native
+      '@tatlacas/brevwick-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      expo:
+        specifier: ~51.0.0
+        version: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      expo-status-bar:
+        specifier: ~1.12.1
+        version: 1.12.1
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-native:
+        specifier: 0.74.5
+        version: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler:
+        specifier: ~2.16.1
+        version: 2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context:
+        specifier: 4.10.5
+        version: 4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens:
+        specifier: 3.31.1
+        version: 3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-view-shot:
+        specifier: 3.8.0
+        version: 3.8.0(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: ~5.3.3
+        version: 5.3.3
+
   examples/remix:
     dependencies:
       '@remix-run/node':
@@ -480,7 +526,7 @@ importers:
         version: link:../sdk
       '@testing-library/react-native':
         specifier: ^13.0.0
-        version: 13.3.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react-test-renderer@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 13.3.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react-test-renderer@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -492,10 +538,10 @@ importers:
         version: 19.2.5
       react-native:
         specifier: ^0.76.0
-        version: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
+        version: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
       react-native-view-shot:
         specifier: ^4.0.0
-        version: 4.0.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)
+        version: 4.0.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)
       react-test-renderer:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
@@ -783,6 +829,9 @@ packages:
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
 
+  '@babel/code-frame@7.10.4':
+    resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
+
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
@@ -813,6 +862,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
+
+  '@babel/generator@7.2.0':
+    resolution: {integrity: sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==}
 
   '@babel/generator@7.26.10':
     resolution: {integrity: sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==}
@@ -850,6 +902,10 @@ packages:
     resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  '@babel/helper-environment-visitor@7.24.7':
+    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
@@ -921,6 +977,10 @@ packages:
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/highlight@7.25.9':
+    resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -956,6 +1016,13 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-proposal-async-generator-functions@7.20.7':
+    resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-proposal-class-properties@7.18.6':
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
@@ -975,6 +1042,13 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-proposal-logical-assignment-operators@7.20.7':
+    resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6':
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
@@ -986,6 +1060,20 @@ packages:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-object-rest-spread@7.20.7':
+    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6':
+    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1763,6 +1851,10 @@ packages:
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+
+  '@egjs/hammerjs@2.0.17':
+    resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
+    engines: {node: '>=0.8.0'}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -2858,6 +2950,95 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@expo/bunyan@4.0.1':
+    resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
+    engines: {'0': node >=0.10.0}
+
+  '@expo/cli@0.18.31':
+    resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
+    hasBin: true
+
+  '@expo/code-signing-certificates@0.0.5':
+    resolution: {integrity: sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==}
+
+  '@expo/config-plugins@8.0.11':
+    resolution: {integrity: sha512-oALE1HwnLFthrobAcC9ocnR9KXLzfWEjgIe4CPe+rDsfC6GDs8dGYCXfRFoCEzoLN4TGYs9RdZ8r0KoCcNrm2A==}
+
+  '@expo/config-types@51.0.3':
+    resolution: {integrity: sha512-hMfuq++b8VySb+m9uNNrlpbvGxYc8OcFCUX9yTmi9tlx6A4k8SDabWFBgmnr4ao3wEArvWrtUQIfQCVtPRdpKA==}
+
+  '@expo/config@9.0.4':
+    resolution: {integrity: sha512-g5ns5u1JSKudHYhjo1zaSfkJ/iZIcWmUmIQptMJZ6ag1C0ShL2sj8qdfU8MmAMuKLOgcIfSaiWlQnm4X3VJVkg==}
+
+  '@expo/devcert@1.2.1':
+    resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
+
+  '@expo/env@0.3.0':
+    resolution: {integrity: sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==}
+
+  '@expo/image-utils@0.5.1':
+    resolution: {integrity: sha512-U/GsFfFox88lXULmFJ9Shfl2aQGcwoKPF7fawSCLixIKtMCpsI+1r0h+5i0nQnmt9tHuzXZDL8+Dg1z6OhkI9A==}
+
+  '@expo/json-file@10.0.13':
+    resolution: {integrity: sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==}
+
+  '@expo/json-file@8.3.3':
+    resolution: {integrity: sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==}
+
+  '@expo/metro-config@0.18.11':
+    resolution: {integrity: sha512-/uOq55VbSf9yMbUO1BudkUM2SsGW1c5hr9BnhIqYqcsFv0Jp5D3DtJ4rljDKaUeNLbwr6m7pqIrkSMq5NrYf4Q==}
+
+  '@expo/osascript@2.4.2':
+    resolution: {integrity: sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==}
+    engines: {node: '>=12'}
+
+  '@expo/package-manager@1.10.4':
+    resolution: {integrity: sha512-y9Mr4Kmpk4abAVZrNNPCdzOZr8nLLyi18p1SXr0RCVA8IfzqZX/eY4H+50a0HTmXqIsPZrQdcdb4I3ekMS9GvQ==}
+
+  '@expo/plist@0.1.3':
+    resolution: {integrity: sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==}
+
+  '@expo/prebuild-config@7.0.9':
+    resolution: {integrity: sha512-9i6Cg7jInpnGEHN0jxnW0P+0BexnePiBzmbUvzSbRXpdXihYUX2AKMu73jgzxn5P1hXOSkzNS7umaY+BZ+aBag==}
+    peerDependencies:
+      expo-modules-autolinking: '>=0.8.1'
+
+  '@expo/rudder-sdk-node@1.1.1':
+    resolution: {integrity: sha512-uy/hS/awclDJ1S88w9UGpc6Nm9XnNUjzOAAib1A3PVAnGQIwebg8DpFqOthFBTlZxeuV/BKbZ5jmTbtNZkp1WQ==}
+    engines: {node: '>=12'}
+
+  '@expo/sdk-runtime-versions@1.0.0':
+    resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
+
+  '@expo/spawn-async@1.7.2':
+    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+    engines: {node: '>=12'}
+
+  '@expo/sudo-prompt@9.3.2':
+    resolution: {integrity: sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==}
+
+  '@expo/vector-icons@14.1.0':
+    resolution: {integrity: sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==}
+    peerDependencies:
+      expo-font: '*'
+      react: '*'
+      react-native: '*'
+
+  '@expo/xcpretty@4.4.3':
+    resolution: {integrity: sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==}
+    hasBin: true
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
+  '@hapi/topo@5.1.0':
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -3171,6 +3352,14 @@ packages:
   '@jest/transform@29.7.0':
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@24.9.0':
+    resolution: {integrity: sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==}
+    engines: {node: '>= 6'}
+
+  '@jest/types@26.6.2':
+    resolution: {integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==}
+    engines: {node: '>= 10.14.2'}
 
   '@jest/types@27.5.1':
     resolution: {integrity: sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==}
@@ -3795,13 +3984,65 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-native-community/cli-clean@13.6.9':
+    resolution: {integrity: sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==}
+
+  '@react-native-community/cli-config@13.6.9':
+    resolution: {integrity: sha512-rFfVBcNojcMm+KKHE/xqpqXg8HoKl4EC7bFHUrahMJ+y/tZll55+oX/PGG37rzB8QzP2UbMQ19DYQKC1G7kXeg==}
+
+  '@react-native-community/cli-debugger-ui@13.6.9':
+    resolution: {integrity: sha512-TkN7IdFmGPPvTpAo3nCAH9uwGCPxWBEAwpqEZDrq0NWllI7Tdie8vDpGdrcuCcKalmhq6OYnkXzeBah7O1Ztpw==}
+
+  '@react-native-community/cli-doctor@13.6.9':
+    resolution: {integrity: sha512-5quFaLdWFQB+677GXh5dGU9I5eg2z6Vg4jOX9vKnc9IffwyIFAyJfCZHrxLSRPDGNXD7biDQUdoezXYGwb6P/A==}
+
+  '@react-native-community/cli-hermes@13.6.9':
+    resolution: {integrity: sha512-GvwiwgvFw4Ws+krg2+gYj8sR3g05evmNjAHkKIKMkDTJjZ8EdyxbkifRUs1ZCq3TMZy2oeblZBXCJVOH4W7ZbA==}
+
+  '@react-native-community/cli-platform-android@13.6.9':
+    resolution: {integrity: sha512-9KsYGdr08QhdvT3Ht7e8phQB3gDX9Fs427NJe0xnoBh+PDPTI2BD5ks5ttsH8CzEw8/P6H8tJCHq6hf2nxd9cw==}
+
+  '@react-native-community/cli-platform-apple@13.6.9':
+    resolution: {integrity: sha512-KoeIHfhxMhKXZPXmhQdl6EE+jGKWwoO9jUVWgBvibpVmsNjo7woaG/tfJMEWfWF3najX1EkQAoJWpCDBMYWtlA==}
+
+  '@react-native-community/cli-platform-ios@13.6.9':
+    resolution: {integrity: sha512-CiUcHlGs8vE0CAB4oi1f+dzniqfGuhWPNrDvae2nm8dewlahTBwIcK5CawyGezjcJoeQhjBflh9vloska+nlnw==}
+
+  '@react-native-community/cli-server-api@13.6.9':
+    resolution: {integrity: sha512-W8FSlCPWymO+tlQfM3E0JmM8Oei5HZsIk5S0COOl0MRi8h0NmHI4WSTF2GCfbFZkcr2VI/fRsocoN8Au4EZAug==}
+
+  '@react-native-community/cli-tools@13.6.9':
+    resolution: {integrity: sha512-OXaSjoN0mZVw3nrAwcY1PC0uMfyTd9fz7Cy06dh+EJc+h0wikABsVRzV8cIOPrVV+PPEEXE0DBrH20T2puZzgQ==}
+
+  '@react-native-community/cli-types@13.6.9':
+    resolution: {integrity: sha512-RLxDppvRxXfs3hxceW/mShi+6o5yS+kFPnPqZTaMKKR5aSg7LwDpLQW4K2D22irEG8e6RKDkZUeH9aL3vO2O0w==}
+
+  '@react-native-community/cli@13.6.9':
+    resolution: {integrity: sha512-hFJL4cgLPxncJJd/epQ4dHnMg5Jy/7Q56jFvA3MHViuKpzzfTCJCB+pGY54maZbtym53UJON9WTGpM3S81UfjQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@react-native/assets-registry@0.74.87':
+    resolution: {integrity: sha512-1XmRhqQchN+pXPKEKYdpJlwESxVomJOxtEnIkbo7GAlaN2sym84fHEGDXAjLilih5GVPpcpSmFzTy8jx3LtaFg==}
+    engines: {node: '>=18'}
+
   '@react-native/assets-registry@0.76.9':
     resolution: {integrity: sha512-pN0Ws5xsjWOZ8P37efh0jqHHQmq+oNGKT4AyAoKRpxBDDDmlAmpaYjer9Qz7PpDKF+IUyRjF/+rBsM50a8JcUg==}
+    engines: {node: '>=18'}
+
+  '@react-native/babel-plugin-codegen@0.74.87':
+    resolution: {integrity: sha512-+vJYpMnENFrwtgvDfUj+CtVJRJuUnzAUYT0/Pb68Sq9RfcZ5xdcCuUgyf7JO+akW2VTBoJY427wkcxU30qrWWw==}
     engines: {node: '>=18'}
 
   '@react-native/babel-plugin-codegen@0.76.9':
     resolution: {integrity: sha512-vxL/vtDEIYHfWKm5oTaEmwcnNGsua/i9OjIxBDBFiJDu5i5RU3bpmDiXQm/bJxrJNPRp5lW0I0kpGihVhnMAIQ==}
     engines: {node: '>=18'}
+
+  '@react-native/babel-preset@0.74.87':
+    resolution: {integrity: sha512-hyKpfqzN2nxZmYYJ0tQIHG99FQO0OWXp/gVggAfEUgiT+yNKas1C60LuofUsK7cd+2o9jrpqgqW4WzEDZoBlTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/babel-preset@0.76.9':
     resolution: {integrity: sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==}
@@ -3809,11 +4050,21 @@ packages:
     peerDependencies:
       '@babel/core': '*'
 
+  '@react-native/codegen@0.74.87':
+    resolution: {integrity: sha512-GMSYDiD+86zLKgMMgz9z0k6FxmRn+z6cimYZKkucW4soGbxWsbjUAZoZ56sJwt2FJ3XVRgXCrnOCgXoH/Bkhcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+
   '@react-native/codegen@0.76.9':
     resolution: {integrity: sha512-AzlCHMTKrAVC2709V4ZGtBXmGVtWTpWm3Ruv5vXcd3/anH4mGucfJ4rjbWKdaYQJMpXa3ytGomQrsIsT/s8kgA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/preset-env': ^7.1.6
+
+  '@react-native/community-cli-plugin@0.74.87':
+    resolution: {integrity: sha512-EgJG9lSr8x3X67dHQKQvU6EkO+3ksVlJHYIVv6U/AmW9dN80BEFxgYbSJ7icXS4wri7m4kHdgeq2PQ7/3vvrTQ==}
+    engines: {node: '>=18'}
 
   '@react-native/community-cli-plugin@0.76.9':
     resolution: {integrity: sha512-08jx8ixCjjd4jNQwNpP8yqrjrDctN2qvPPlf6ebz1OJQk8e1sbUl3wVn1zhhMvWrYcaraDnatPb5uCPq+dn3NQ==}
@@ -3824,21 +4075,51 @@ packages:
       '@react-native-community/cli':
         optional: true
 
+  '@react-native/debugger-frontend@0.74.85':
+    resolution: {integrity: sha512-gUIhhpsYLUTYWlWw4vGztyHaX/kNlgVspSvKe2XaPA7o3jYKUoNLc3Ov7u70u/MBWfKdcEffWq44eSe3j3s5JQ==}
+    engines: {node: '>=18'}
+
+  '@react-native/debugger-frontend@0.74.87':
+    resolution: {integrity: sha512-MN95DJLYTv4EqJc+9JajA3AJZSBYJz2QEJ3uWlHrOky2vKrbbRVaW1ityTmaZa2OXIvNc6CZwSRSE7xCoHbXhQ==}
+    engines: {node: '>=18'}
+
   '@react-native/debugger-frontend@0.76.9':
     resolution: {integrity: sha512-0Ru72Bm066xmxFuOXhhvrryxvb57uI79yDSFf+hxRpktkC98NMuRenlJhslMrbJ6WjCu1vOe/9UjWNYyxXTRTA==}
+    engines: {node: '>=18'}
+
+  '@react-native/dev-middleware@0.74.85':
+    resolution: {integrity: sha512-BRmgCK5vnMmHaKRO+h8PKJmHHH3E6JFuerrcfE3wG2eZ1bcSr+QTu8DAlpxsDWvJvHpCi8tRJGauxd+Ssj/c7w==}
+    engines: {node: '>=18'}
+
+  '@react-native/dev-middleware@0.74.87':
+    resolution: {integrity: sha512-7TmZ3hTHwooYgIHqc/z87BMe1ryrIqAUi+AF7vsD+EHCGxHFdMjSpf1BZ2SUPXuLnF2cTiTfV2RwhbPzx0tYIA==}
     engines: {node: '>=18'}
 
   '@react-native/dev-middleware@0.76.9':
     resolution: {integrity: sha512-xkd3C3dRcmZLjFTEAOvC14q3apMLouIvJViCZY/p1EfCMrNND31dgE1dYrLTiI045WAWMt5bD15i6f7dE2/QWA==}
     engines: {node: '>=18'}
 
+  '@react-native/gradle-plugin@0.74.87':
+    resolution: {integrity: sha512-T+VX0N1qP+U9V4oAtn7FTX7pfsoVkd1ocyw9swYXgJqU2fK7hC9famW7b3s3ZiufPGPr1VPJe2TVGtSopBjL6A==}
+    engines: {node: '>=18'}
+
   '@react-native/gradle-plugin@0.76.9':
     resolution: {integrity: sha512-uGzp3dL4GfNDz+jOb8Nik1Vrfq1LHm0zESizrGhHACFiFlUSflVAnWuUAjlZlz5XfLhzGVvunG4Vdrpw8CD2ng==}
+    engines: {node: '>=18'}
+
+  '@react-native/js-polyfills@0.74.87':
+    resolution: {integrity: sha512-M5Evdn76CuVEF0GsaXiGi95CBZ4IWubHqwXxV9vG9CC9kq0PSkoM2Pn7Lx7dgyp4vT7ccJ8a3IwHbe+5KJRnpw==}
     engines: {node: '>=18'}
 
   '@react-native/js-polyfills@0.76.9':
     resolution: {integrity: sha512-s6z6m8cK4SMjIX1hm8LT187aQ6//ujLrjzDBogqDCYXRbfjbAYovw5as/v2a2rhUIyJbS3UjokZm3W0H+Oh/RQ==}
     engines: {node: '>=18'}
+
+  '@react-native/metro-babel-transformer@0.74.87':
+    resolution: {integrity: sha512-UsJCO24sNax2NSPBmV1zLEVVNkS88kcgAiYrZHtYSwSjpl4WZ656tIeedBfiySdJ94Hr3kQmBYLipV5zk0NI1A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/metro-babel-transformer@0.76.9':
     resolution: {integrity: sha512-HGq11347UHNiO/NvVbAO35hQCmH8YZRs7in7nVq7SL99pnpZK4WXwLdAXmSuwz5uYqOuwnKYDlpadz8fkE94Mg==}
@@ -3846,8 +4127,25 @@ packages:
     peerDependencies:
       '@babel/core': '*'
 
+  '@react-native/normalize-colors@0.74.85':
+    resolution: {integrity: sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==}
+
+  '@react-native/normalize-colors@0.74.87':
+    resolution: {integrity: sha512-Xh7Nyk/MPefkb0Itl5Z+3oOobeG9lfLb7ZOY2DKpFnoCE1TzBmib9vMNdFaLdSxLIP+Ec6icgKtdzYg8QUPYzA==}
+
   '@react-native/normalize-colors@0.76.9':
     resolution: {integrity: sha512-TUdMG2JGk72M9d8DYbubdOlrzTYjw+YMe/xOnLU4viDgWRHsCbtRS9x0IAxRjs3amj/7zmK3Atm8jUPvdAc8qw==}
+
+  '@react-native/virtualized-lists@0.74.87':
+    resolution: {integrity: sha512-lsGxoFMb0lyK/MiplNKJpD+A1EoEUumkLrCjH4Ht+ZlG8S0BfCxmskLZ6qXn3BiDSkLjfjI/qyZ3pnxNBvkXpQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': ^18.2.6
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@react-native/virtualized-lists@0.76.9':
     resolution: {integrity: sha512-2neUfZKuqMK2LzfS8NyOWOyWUJOWgDym5fUph6fN9qF+LNPjAvnc4Zr9+o+59qjNu/yXwQgVMWNU4+8WJuPVWw==}
@@ -3859,6 +4157,38 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@react-navigation/core@6.4.17':
+    resolution: {integrity: sha512-Nd76EpomzChWAosGqWOYE3ItayhDzIEzzZsT7PfGcRFDgW5miHV2t4MZcq9YIK4tzxZjVVpYbIynOOQQd1e0Cg==}
+    peerDependencies:
+      react: '*'
+
+  '@react-navigation/elements@1.3.31':
+    resolution: {integrity: sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==}
+    peerDependencies:
+      '@react-navigation/native': ^6.0.0
+      react: '*'
+      react-native: '*'
+      react-native-safe-area-context: '>= 3.0.0'
+
+  '@react-navigation/native@6.1.18':
+    resolution: {integrity: sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  '@react-navigation/routers@6.1.9':
+    resolution: {integrity: sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA==}
+
+  '@react-navigation/stack@6.4.1':
+    resolution: {integrity: sha512-upMEHOKMtuMu4c9gmoPlO/JqI6mDlSqwXg1aXKOTQLXAF8H5koOLRfrmi7AkdiE9A7lDXWUAZoGuD9O88cYvDQ==}
+    peerDependencies:
+      '@react-navigation/native': ^6.0.0
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>= 1.0.0'
+      react-native-safe-area-context: '>= 3.0.0'
+      react-native-screens: '>= 3.0.0'
 
   '@remix-run/dev@2.17.4':
     resolution: {integrity: sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==}
@@ -3943,6 +4273,10 @@ packages:
 
   '@remix-run/web-stream@1.1.0':
     resolution: {integrity: sha512-KRJtwrjRV5Bb+pM7zxcTJkhIqWWSy+MYsIxHK+0m5atcznsf15YwUBWHWulZerV2+vvHH1Lp1DD7pw6qKW8SgA==}
+
+  '@rnx-kit/chromium-edge-launcher@1.0.0':
+    resolution: {integrity: sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==}
+    engines: {node: '>=14.15'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -4416,6 +4750,9 @@ packages:
     resolution: {integrity: sha512-S5HwYem5Yjeceb5OLvforNcjfTMh2qsHnTP1BAYL81XPpqeg2udjAkJjKBxCwxMZSqdCMw3ne0eKppEYTaEZ+A==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
+  '@segment/loosely-validate-event@2.0.0':
+    resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
+
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
 
@@ -4454,6 +4791,15 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sideway/address@4.1.5':
+    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
+
+  '@sideway/formula@3.0.1':
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+
+  '@sideway/pinpoint@2.0.0':
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@sigstore/bundle@2.3.2':
     resolution: {integrity: sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==}
@@ -4805,6 +5151,9 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
@@ -4825,6 +5174,9 @@ packages:
 
   '@types/istanbul-lib-report@3.0.3':
     resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@1.1.2':
+    resolution: {integrity: sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==}
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
@@ -4861,6 +5213,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
@@ -4955,6 +5310,12 @@ packages:
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@13.0.12':
+    resolution: {integrity: sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==}
+
+  '@types/yargs@15.0.20':
+    resolution: {integrity: sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==}
 
   '@types/yargs@16.0.11':
     resolution: {integrity: sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==}
@@ -5087,6 +5448,16 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@urql/core@2.3.6':
+    resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@urql/exchange-retry@0.3.0':
+    resolution: {integrity: sha512-hHqer2mcdVC0eYnVNbWyi28AlGOPb2vjH3lP3/Bc8Lc8BjhMsDwFMm7WhoP5C1+cfbr/QJ6Er3H/L08wznXxfg==}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
     resolution: {integrity: sha512-MeDWGICAF9zA/OZLOKwhoRlsUW+fiMwnfuOAqFVohL31Agj7Q/RBWAYweqjHLgFBCsdnr6XIfwjJnmb2znEWxw==}
@@ -5315,6 +5686,15 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xmldom/xmldom@0.7.13':
+    resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
+    engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5455,6 +5835,9 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-fragments@0.2.1:
+    resolution: {integrity: sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==}
+
   ansi-html-community@0.0.8:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
@@ -5464,6 +5847,10 @@ packages:
     resolution: {integrity: sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==}
     engines: {'0': node >= 0.8.0}
     hasBin: true
+
+  ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5499,6 +5886,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  appdirsjs@1.2.7:
+    resolution: {integrity: sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==}
 
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
@@ -5598,6 +5988,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  astral-regex@1.0.0:
+    resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
+    engines: {node: '>=4'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -5730,6 +6124,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-react-compiler@0.0.0-experimental-592953e-20240517:
+    resolution: {integrity: sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==}
+
+  babel-plugin-react-native-web@0.19.13:
+    resolution: {integrity: sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ==}
+
   babel-plugin-syntax-hermes-parser@0.23.1:
     resolution: {integrity: sha512-uNLD0tk2tLUjGFdmCk+u/3FEw2o+BAwW4g+z2QVlxJrzZYOOPADroEcNtTPt5lNiScctaUmnsTkVEnOwZUOLhA==}
 
@@ -5746,6 +6146,9 @@ packages:
     resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-expo@11.0.15:
+    resolution: {integrity: sha512-rgiMTYwqIPULaO7iZdqyL7aAff9QLOX6OWUtLZBlOrOTreGY1yHah/5+l8MvI6NVc/8Zj5LY4Y5uMSnJIuzTLw==}
 
   babel-preset-jest@27.5.1:
     resolution: {integrity: sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==}
@@ -5844,6 +6247,10 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -5851,6 +6258,10 @@ packages:
   bfj@7.1.0:
     resolution: {integrity: sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==}
     engines: {node: '>= 8.0.0'}
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
 
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -5882,6 +6293,20 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
+  bplist-creator@0.0.7:
+    resolution: {integrity: sha512-xp/tcaV3T5PCiaY04mXga7o/TE+t95gqeLmADeBI1CvZtdWTbgBt3uLpvh4UWtenKeBhCV6oVxGk38yZr2uYEA==}
+
+  bplist-creator@0.1.0:
+    resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
+
+  bplist-parser@0.3.1:
+    resolution: {integrity: sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==}
+    engines: {node: '>= 5.10.0'}
+
+  bplist-parser@0.3.2:
+    resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
+    engines: {node: '>= 5.10.0'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -5910,9 +6335,18 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-alloc-unsafe@1.1.0:
+    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
+
+  buffer-alloc@1.2.0:
+    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-fill@1.0.0:
+    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5926,6 +6360,9 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  builtins@1.0.3:
+    resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -6067,6 +6504,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   check-types@11.2.3:
     resolution: {integrity: sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==}
 
@@ -6137,6 +6577,10 @@ packages:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
 
+  cli-cursor@2.1.0:
+    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
+    engines: {node: '>=4'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -6156,6 +6600,9 @@ packages:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
@@ -6173,6 +6620,10 @@ packages:
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
 
   clsx@2.1.1:
@@ -6207,8 +6658,18 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -6219,6 +6680,9 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
 
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -6247,6 +6711,10 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -6262,6 +6730,9 @@ packages:
 
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
+
+  component-type@1.2.2:
+    resolution: {integrity: sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -6406,12 +6877,26 @@ packages:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
 
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  crypto-random-string@1.0.0:
+    resolution: {integrity: sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==}
+    engines: {node: '>=4'}
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -6568,6 +7053,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dag-map@1.0.2:
+    resolution: {integrity: sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -6601,6 +7089,9 @@ packages:
   dax-sh@0.43.2:
     resolution: {integrity: sha512-uULa1sSIHgXKGCqJ/pA0zsnzbHlVnuq7g8O2fkHokWFNwEGIhh5lAJlxZa1POG5En5ba7AU4KcBAvGQWMMf8rg==}
     deprecated: This package has moved to simply be 'dax' instead of 'dax-sh'
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -6653,11 +7144,19 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
 
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
@@ -6672,6 +7171,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -6690,6 +7193,10 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  default-gateway@4.2.0:
+    resolution: {integrity: sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==}
+    engines: {node: '>=6'}
 
   default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
@@ -6717,9 +7224,16 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  del@6.1.1:
+    resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
+    engines: {node: '>=10'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denodeify@1.2.1:
+    resolution: {integrity: sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -6751,6 +7265,11 @@ packages:
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
+
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -6864,12 +7383,20 @@ packages:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
     engines: {node: '>=20'}
 
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
   dotenv-expand@5.1.0:
     resolution: {integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==}
 
   dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -6980,9 +7507,18 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-editor@0.4.2:
+    resolution: {integrity: sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==}
+    engines: {node: '>=8'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -6999,6 +7535,10 @@ packages:
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
+
+  errorhandler@1.5.2:
+    resolution: {integrity: sha512-kNAL7hESndBCrWwS72QyV3IVOTrVmj9D062FV5BQswNL5zEdeRmz/WJFyh6Aj/plvvSOrzddkxW57HgkZcR9Fw==}
+    engines: {node: '>= 0.8'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -7363,6 +7903,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@1.0.0:
+    resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
+    engines: {node: '>=6'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7386,6 +7930,45 @@ packages:
   expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  expo-asset@10.0.10:
+    resolution: {integrity: sha512-0qoTIihB79k+wGus9wy0JMKq7DdenziVx3iUkGvMAy2azscSgWH6bd2gJ9CGnhC6JRd3qTMFBL0ou/fx7WZl7A==}
+    peerDependencies:
+      expo: '*'
+
+  expo-constants@16.0.2:
+    resolution: {integrity: sha512-9tNY3OVO0jfiMzl7ngb6IOyR5VFzNoN5OOazUWoeGfmMqVB5kltTemRvKraK9JRbBKIw+SOYLEmF0sEqgFZ6OQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-file-system@17.0.1:
+    resolution: {integrity: sha512-dYpnZJqTGj6HCYJyXAgpFkQWsiCH3HY1ek2cFZVHFoEc5tLz9gmdEgTF6nFHurvmvfmXqxi7a5CXyVm0aFYJBw==}
+    peerDependencies:
+      expo: '*'
+
+  expo-font@12.0.10:
+    resolution: {integrity: sha512-Q1i2NuYri3jy32zdnBaHHCya1wH1yMAsI+3CCmj9zlQzlhsS9Bdwcj2W3c5eU5FvH2hsNQy4O+O1NnM6o/pDaQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-keep-awake@13.0.2:
+    resolution: {integrity: sha512-kKiwkVg/bY0AJ5q1Pxnm/GvpeB6hbNJhcFsoOWDh2NlpibhCLaHL826KHUM+WsnJRbVRxJ+K9vbPRHEMvFpVyw==}
+    peerDependencies:
+      expo: '*'
+
+  expo-modules-autolinking@1.11.3:
+    resolution: {integrity: sha512-oYh8EZEvYF5TYppxEKUTTJmbr8j7eRRnrIxzZtMvxLTXoujThVPMFS/cbnSnf2bFm1lq50TdDNABhmEi7z0ngQ==}
+    hasBin: true
+
+  expo-modules-core@1.12.26:
+    resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
+
+  expo-status-bar@1.12.1:
+    resolution: {integrity: sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA==}
+
+  expo@51.0.39:
+    resolution: {integrity: sha512-Cs/9xopyzJrpXWbyVUZnr37rprdFJorRgfSp6cdBfvbjxZeKnw2MEu7wJwV/s626i5lZTPGjZPHUF9uQvt51cg==}
+    hasBin: true
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -7430,6 +8013,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-parser@4.5.6:
+    resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -7443,6 +8030,15 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fbemitter@3.0.0:
+    resolution: {integrity: sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==}
+
+  fbjs-css-vars@1.0.2:
+    resolution: {integrity: sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==}
+
+  fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -7451,6 +8047,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-retry@4.1.1:
+    resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -7479,6 +8078,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
 
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
@@ -7516,6 +8119,9 @@ packages:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -7552,6 +8158,9 @@ packages:
 
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
+
+  fontfaceobserver@2.3.0:
+    resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
@@ -7598,6 +8207,10 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  freeport-async@2.0.0:
+    resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
+    engines: {node: '>=8'}
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -7620,6 +8233,10 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@9.0.0:
+    resolution: {integrity: sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==}
+    engines: {node: '>=10'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -7699,6 +8316,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
+    engines: {node: '>=6'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -7710,6 +8331,10 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  getenv@1.0.0:
+    resolution: {integrity: sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==}
+    engines: {node: '>=6'}
 
   giget@3.2.0:
     resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
@@ -7737,6 +8362,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -7782,6 +8411,16 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  graphql-tag@2.12.6:
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  graphql@15.8.0:
+    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
+    engines: {node: '>= 10.x'}
 
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
@@ -7889,11 +8528,17 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  hermes-estree@0.19.1:
+    resolution: {integrity: sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==}
+
   hermes-estree@0.23.1:
     resolution: {integrity: sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.19.1:
+    resolution: {integrity: sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==}
 
   hermes-parser@0.23.1:
     resolution: {integrity: sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==}
@@ -7901,12 +8546,23 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hermes-profile-transformer@0.0.6:
+    resolution: {integrity: sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==}
+    engines: {node: '>=8'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
   hoopy@0.1.4:
     resolution: {integrity: sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==}
     engines: {node: '>= 6.0.0'}
+
+  hosted-git-info@3.0.8:
+    resolution: {integrity: sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==}
+    engines: {node: '>=10'}
 
   hosted-git-info@6.1.3:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
@@ -7981,6 +8637,10 @@ packages:
   http-errors@1.8.1:
     resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
     engines: {node: '>= 0.6'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -8152,6 +8812,10 @@ packages:
     resolution: {integrity: sha512-vI2w4zl/mDluHt9YEQ/543VTCwPKWiHzKtm9dM2V0NdFcqEexDAjUHzO1oA60HRNaVifGXXM1tRRNluLVHa0Kg==}
     engines: {node: '>=18'}
 
+  internal-ip@4.3.0:
+    resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
+    engines: {node: '>=6'}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -8166,6 +8830,10 @@ packages:
   ip-address@10.1.1:
     resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
+
+  ip-regex@2.1.0:
+    resolution: {integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==}
+    engines: {node: '>=4'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -8195,6 +8863,9 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -8210,6 +8881,9 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -8251,6 +8925,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extglob@1.0.0:
+    resolution: {integrity: sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -8258,6 +8936,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -8270,6 +8952,10 @@ packages:
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
+
+  is-glob@2.0.1:
+    resolution: {integrity: sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==}
+    engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -8294,6 +8980,10 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-invalid-path@0.1.0:
+    resolution: {integrity: sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==}
+    engines: {node: '>=0.10.0'}
 
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -8323,6 +9013,14 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
+
+  is-path-cwd@2.2.0:
+    resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
+    engines: {node: '>=6'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
 
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
@@ -8369,6 +9067,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -8400,6 +9102,10 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
+  is-valid-path@0.1.1:
+    resolution: {integrity: sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==}
+    engines: {node: '>=0.10.0'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -8422,6 +9128,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@1.1.0:
+    resolution: {integrity: sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==}
+    engines: {node: '>=4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -8703,6 +9413,9 @@ packages:
       node-notifier:
         optional: true
 
+  jimp-compact@0.16.1:
+    resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -8710,6 +9423,12 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  joi@17.13.3:
+    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  join-component@1.1.0:
+    resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -8771,6 +9490,11 @@ packages:
       canvas:
         optional: true
 
+  jsesc@2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
@@ -8793,6 +9517,10 @@ packages:
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  json-schema-deref-sync@0.13.0:
+    resolution: {integrity: sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==}
+    engines: {node: '>=6.0.0'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -8923,10 +9651,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-darwin-arm64@1.19.0:
+    resolution: {integrity: sha512-wIJmFtYX0rXHsXHSr4+sC5clwblEMji7HHQ4Ub1/CznVRxtCFha6JIt5JZaNf8vQrfdZnBxLLC6R8pC818jXqg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.19.0:
+    resolution: {integrity: sha512-Lif1wD6P4poaw9c/4Uh2z+gmrWhw/HtXFoeZ3bEsv6Ia4tt8rOJBdkfVaUJ6VXmpKHALve+iTyP2+50xY1wKPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
@@ -8941,14 +9681,32 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  lightningcss-linux-arm-gnueabihf@1.19.0:
+    resolution: {integrity: sha512-P15VXY5682mTXaiDtbnLYQflc8BYb774j2R84FgDLJTN6Qp0ZjWEFyN1SPqyfTj2B2TFjRHRUvQSSZ7qN4Weig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm64-gnu@1.19.0:
+    resolution: {integrity: sha512-zwXRjWqpev8wqO0sv0M1aM1PpjHz6RVIsBcxKszIG83Befuh4yNysjgHVplF9RTU7eozGe3Ts7r6we1+Qkqsww==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.19.0:
+    resolution: {integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -8959,8 +9717,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-x64-gnu@1.19.0:
+    resolution: {integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.19.0:
+    resolution: {integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -8977,11 +9747,21 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.19.0:
+    resolution: {integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
+
+  lightningcss@1.19.0:
+    resolution: {integrity: sha512-yV5UR7og+Og7lQC+70DA7a8ta1uiOPnWPJfxa0wnxylev5qfo4P+4iMpzWAdYWOca4jdNQZii+bDL/l+4hUXIA==}
+    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -9077,9 +9857,17 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@2.2.0:
+    resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
+    engines: {node: '>=4'}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  logkitty@0.7.1:
+    resolution: {integrity: sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==}
+    hasBin: true
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -9161,6 +9949,20 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  md5-file@3.2.3:
+    resolution: {integrity: sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  md5@2.2.1:
+    resolution: {integrity: sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+
+  md5hex@1.0.0:
+    resolution: {integrity: sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==}
 
   mdast-util-definitions@5.1.2:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
@@ -9260,6 +10062,9 @@ packages:
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
+  memory-cache@0.2.0:
+    resolution: {integrity: sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==}
+
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
     engines: {node: '>=12.13'}
@@ -9278,58 +10083,116 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
+  metro-babel-transformer@0.80.12:
+    resolution: {integrity: sha512-YZziRs0MgA3pzCkkvOoQRXjIoVjvrpi/yRlJnObyIvMP6lFdtyG4nUGIwGY9VXnBvxmXD6mPY2e+NSw6JAyiRg==}
+    engines: {node: '>=18'}
+
   metro-babel-transformer@0.81.5:
     resolution: {integrity: sha512-oKCQuajU5srm+ZdDcFg86pG/U8hkSjBlkyFjz380SZ4TTIiI5F+OQB830i53D8hmqmcosa4wR/pnKv8y4Q3dLw==}
     engines: {node: '>=18.18'}
+
+  metro-cache-key@0.80.12:
+    resolution: {integrity: sha512-o4BspKnugg/pE45ei0LGHVuBJXwRgruW7oSFAeSZvBKA/sGr0UhOGY3uycOgWInnS3v5yTTfiBA9lHlNRhsvGA==}
+    engines: {node: '>=18'}
 
   metro-cache-key@0.81.5:
     resolution: {integrity: sha512-lGWnGVm1UwO8faRZ+LXQUesZSmP1LOg14OVR+KNPBip8kbMECbQJ8c10nGesw28uQT7AE0lwQThZPXlxDyCLKQ==}
     engines: {node: '>=18.18'}
 
+  metro-cache@0.80.12:
+    resolution: {integrity: sha512-p5kNHh2KJ0pbQI/H7ZBPCEwkyNcSz7OUkslzsiIWBMPQGFJ/xArMwkV7I+GJcWh+b4m6zbLxE5fk6fqbVK1xGA==}
+    engines: {node: '>=18'}
+
   metro-cache@0.81.5:
     resolution: {integrity: sha512-wOsXuEgmZMZ5DMPoz1pEDerjJ11AuMy9JifH4yNW7NmWS0ghCRqvDxk13LsElzLshey8C+my/tmXauXZ3OqZgg==}
     engines: {node: '>=18.18'}
+
+  metro-config@0.80.12:
+    resolution: {integrity: sha512-4rwOWwrhm62LjB12ytiuR5NgK1ZBNr24/He8mqCsC+HXZ+ATbrewLNztzbAZHtFsrxP4D4GLTGgh96pCpYLSAQ==}
+    engines: {node: '>=18'}
 
   metro-config@0.81.5:
     resolution: {integrity: sha512-oDRAzUvj6RNRxratFdcVAqtAsg+T3qcKrGdqGZFUdwzlFJdHGR9Z413sW583uD2ynsuOjA2QB6US8FdwiBdNKg==}
     engines: {node: '>=18.18'}
 
+  metro-core@0.80.12:
+    resolution: {integrity: sha512-QqdJ/yAK+IpPs2HU/h5v2pKEdANBagSsc6DRSjnwSyJsCoHlmyJKCaCJ7KhWGx+N4OHxh37hoA8fc2CuZbx0Fw==}
+    engines: {node: '>=18'}
+
   metro-core@0.81.5:
     resolution: {integrity: sha512-+2R0c8ByfV2N7CH5wpdIajCWa8escUFd8TukfoXyBq/vb6yTCsznoA25FhNXJ+MC/cz1L447Zj3vdUfCXIZBwg==}
     engines: {node: '>=18.18'}
+
+  metro-file-map@0.80.12:
+    resolution: {integrity: sha512-sYdemWSlk66bWzW2wp79kcPMzwuG32x1ZF3otI0QZTmrnTaaTiGyhE66P1z6KR4n2Eu5QXiABa6EWbAQv0r8bw==}
+    engines: {node: '>=18'}
 
   metro-file-map@0.81.5:
     resolution: {integrity: sha512-mW1PKyiO3qZvjeeVjj1brhkmIotObA3/9jdbY1fQQYvEWM6Ml7bN/oJCRDGn2+bJRlG+J8pwyJ+DgdrM4BsKyg==}
     engines: {node: '>=18.18'}
 
+  metro-minify-terser@0.80.12:
+    resolution: {integrity: sha512-muWzUw3y5k+9083ZoX9VaJLWEV2Jcgi+Oan0Mmb/fBNMPqP9xVDuy4pOMn/HOiGndgfh/MK7s4bsjkyLJKMnXQ==}
+    engines: {node: '>=18'}
+
   metro-minify-terser@0.81.5:
     resolution: {integrity: sha512-/mn4AxjANnsSS3/Bb+zA1G5yIS5xygbbz/OuPaJYs0CPcZCaWt66D+65j4Ft/nJkffUxcwE9mk4ubpkl3rjgtw==}
     engines: {node: '>=18.18'}
+
+  metro-resolver@0.80.12:
+    resolution: {integrity: sha512-PR24gYRZnYHM3xT9pg6BdbrGbM/Cu1TcyIFBVlAk7qDAuHkUNQ1nMzWumWs+kwSvtd9eZGzHoucGJpTUEeLZAw==}
+    engines: {node: '>=18'}
 
   metro-resolver@0.81.5:
     resolution: {integrity: sha512-6BX8Nq3g3go3FxcyXkVbWe7IgctjDTk6D9flq+P201DfHHQ28J+DWFpVelFcrNTn4tIfbP/Bw7u/0g2BGmeXfQ==}
     engines: {node: '>=18.18'}
 
+  metro-runtime@0.80.12:
+    resolution: {integrity: sha512-LIx7+92p5rpI0i6iB4S4GBvvLxStNt6fF0oPMaUd1Weku7jZdfkCZzmrtDD9CSQ6EPb0T9NUZoyXIxlBa3wOCw==}
+    engines: {node: '>=18'}
+
   metro-runtime@0.81.5:
     resolution: {integrity: sha512-M/Gf71ictUKP9+77dV/y8XlAWg7xl76uhU7ggYFUwEdOHHWPG6gLBr1iiK0BmTjPFH8yRo/xyqMli4s3oGorPQ==}
     engines: {node: '>=18.18'}
 
+  metro-source-map@0.80.12:
+    resolution: {integrity: sha512-o+AXmE7hpvM8r8MKsx7TI21/eerYYy2DCDkWfoBkv+jNkl61khvDHlQn0cXZa6lrcNZiZkl9oHSMcwLLIrFmpw==}
+    engines: {node: '>=18'}
+
   metro-source-map@0.81.5:
     resolution: {integrity: sha512-Jz+CjvCKLNbJZYJTBeN3Kq9kIJf6b61MoLBdaOQZJ5Ajhw6Pf95Nn21XwA8BwfUYgajsi6IXsp/dTZsYJbN00Q==}
     engines: {node: '>=18.18'}
+
+  metro-symbolicate@0.80.12:
+    resolution: {integrity: sha512-/dIpNdHksXkGHZXARZpL7doUzHqSNxgQ8+kQGxwpJuHnDhGkENxB5PS2QBaTDdEcmyTMjS53CN1rl9n1gR6fmw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   metro-symbolicate@0.81.5:
     resolution: {integrity: sha512-X3HV3n3D6FuTE11UWFICqHbFMdTavfO48nXsSpnNGFkUZBexffu0Xd+fYKp+DJLNaQr3S+lAs8q9CgtDTlRRuA==}
     engines: {node: '>=18.18'}
     hasBin: true
 
+  metro-transform-plugins@0.80.12:
+    resolution: {integrity: sha512-WQWp00AcZvXuQdbjQbx1LzFR31IInlkCDYJNRs6gtEtAyhwpMMlL2KcHmdY+wjDO9RPcliZ+Xl1riOuBecVlPA==}
+    engines: {node: '>=18'}
+
   metro-transform-plugins@0.81.5:
     resolution: {integrity: sha512-MmHhVx/1dJC94FN7m3oHgv5uOjKH8EX8pBeu1pnPMxbJrx6ZuIejO0k84zTSaQTZ8RxX1wqwzWBpXAWPjEX8mA==}
     engines: {node: '>=18.18'}
 
+  metro-transform-worker@0.80.12:
+    resolution: {integrity: sha512-KAPFN1y3eVqEbKLx1I8WOarHPqDMUa8WelWxaJCNKO/yHCP26zELeqTJvhsQup+8uwB6EYi/sp0b6TGoh6lOEA==}
+    engines: {node: '>=18'}
+
   metro-transform-worker@0.81.5:
     resolution: {integrity: sha512-lUFyWVHa7lZFRSLJEv+m4jH8WrR5gU7VIjUlg4XmxQfV8ngY4V10ARKynLhMYPeQGl7Qvf+Ayg0eCZ272YZ4Mg==}
     engines: {node: '>=18.18'}
+
+  metro@0.80.12:
+    resolution: {integrity: sha512-1UsH5FzJd9quUsD1qY+zUG4JY3jo3YEMxbMYH9jT6NK3j4iORhlwTK8fYTfAUBhDKjgLfKjAh7aoazNE23oIRA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   metro@0.81.5:
     resolution: {integrity: sha512-YpFF0DDDpDVygeca2mAn7K0+us+XKmiGk4rIYMz/CRdjFoCGqAei/IQSpV0UrGfQbToSugpMQeQJveaWSH88Hg==}
@@ -9532,6 +10395,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -9541,6 +10409,10 @@ packages:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  mimic-fn@1.2.0:
+    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
+    engines: {node: '>=4'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -9742,6 +10614,9 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  nested-error-stacks@2.0.1:
+    resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
+
   next@16.2.3:
     resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
     engines: {node: '>=20.9.0'}
@@ -9780,6 +10655,9 @@ packages:
     resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
     os: ['!win32']
 
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
   nitropack@2.13.4:
     resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9795,6 +10673,13 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  nocache@3.0.4:
+    resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
+    engines: {node: '>=12.0.0'}
+
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
   node-addon-api@3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
@@ -9843,6 +10728,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  node-stream-zip@1.15.0:
+    resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
+    engines: {node: '>=0.12.0'}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -9894,6 +10783,9 @@ packages:
     resolution: {integrity: sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  npm-package-arg@7.0.0:
+    resolution: {integrity: sha512-xXxr8y5U0kl8dVkz2oK7yZjPBvqM2fwaO5l3Yg13p03v8+E3qQcD0JNhHzjL1vyGgxcKkD0cco+NLR72iuPk3g==}
+
   npm-packlist@8.0.2:
     resolution: {integrity: sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -9909,6 +10801,10 @@ packages:
   npm-registry-fetch@16.2.1:
     resolution: {integrity: sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  npm-run-path@2.0.2:
+    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
+    engines: {node: '>=4'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -9929,6 +10825,10 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  ob1@0.80.12:
+    resolution: {integrity: sha512-VMArClVT6LkhUGpnuEoBuyjG9rzUyEzg4PDkav6wK1cLhOK02gPCYFxoiB4mqVnrMhDpIzJcrGNAMVi9P+hXrw==}
+    engines: {node: '>=18'}
 
   ob1@0.81.5:
     resolution: {integrity: sha512-iNpbeXPLmaiT9I5g16gFFFjsF3sGxLpYG2EGP3dfFB4z+l9X60mp/yRzStHhMtuNt8qmf7Ww80nOPQHngHhnIQ==}
@@ -10001,6 +10901,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@2.0.1:
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
+    engines: {node: '>=4'}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -10022,6 +10926,10 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  open@6.4.0:
+    resolution: {integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==}
+    engines: {node: '>=8'}
+
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
@@ -10034,13 +10942,25 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  ora@3.4.0:
+    resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
+    engines: {node: '>=6'}
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
+  os-homedir@1.0.2:
+    resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
+    engines: {node: '>=0.10.0'}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  osenv@0.1.5:
+    resolution: {integrity: sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==}
+    deprecated: This package is no longer supported.
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -10058,6 +10978,10 @@ packages:
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -10161,6 +11085,10 @@ packages:
     resolution: {integrity: sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==}
     engines: {node: '>= 0.10'}
 
+  parse-png@2.1.0:
+    resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
+    engines: {node: '>=10'}
+
   parse5-html-rewriting-stream@7.0.0:
     resolution: {integrity: sha512-mazCyGWkmCRWDI15Zp+UiCqMp/0dgEmkZRvhlsqqKYr4SsVm/TvnSpD9fCvqCA2zoWJcfRym846ejWBBHRiYEg==}
 
@@ -10198,6 +11126,10 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -10259,6 +11191,10 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
+  picomatch@3.0.2:
+    resolution: {integrity: sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==}
+    engines: {node: '>=10'}
+
   picomatch@4.0.1:
     resolution: {integrity: sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==}
     engines: {node: '>=12'}
@@ -10311,6 +11247,14 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
+    engines: {node: '>=10.4.0'}
+
+  pngjs@3.4.0:
+    resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
+    engines: {node: '>=4.0.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -10826,6 +11770,14 @@ packages:
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
+  pretty-format@24.9.0:
+    resolution: {integrity: sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==}
+    engines: {node: '>= 6'}
+
+  pretty-format@26.6.2:
+    resolution: {integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==}
+    engines: {node: '>= 10'}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -10865,6 +11817,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
     peerDependencies:
@@ -10876,6 +11832,9 @@ packages:
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+
+  promise@7.3.1:
+    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
@@ -10932,6 +11891,10 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
+  qrcode-terminal@0.11.0:
+    resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
+    hasBin: true
+
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
@@ -10942,6 +11905,15 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
+  querystring@0.2.1:
+    resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -10971,6 +11943,10 @@ packages:
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-app-polyfill@3.0.0:
     resolution: {integrity: sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==}
@@ -11002,6 +11978,12 @@ packages:
   react-error-overlay@6.1.0:
     resolution: {integrity: sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==}
 
+  react-freeze@1.0.4:
+    resolution: {integrity: sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=17.0.0'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -11014,11 +11996,46 @@ packages:
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
 
+  react-native-gesture-handler@2.16.2:
+    resolution: {integrity: sha512-vGFlrDKlmyI+BT+FemqVxmvO7nqxU33cgXVsn6IKAFishvlG3oV2Ds67D5nPkHMea8T+s1IcuMm0bF8ntZtAyg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-safe-area-context@4.10.5:
+    resolution: {integrity: sha512-Wyb0Nqw2XJ6oZxW/cK8k5q7/UAhg/wbEG6UVf89rQqecDZTDA5ic//P9J6VvJRVZerzGmxWQpVuM7f+PRYUM4g==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-screens@3.31.1:
+    resolution: {integrity: sha512-8fRW362pfZ9y4rS8KY5P3DFScrmwo/vu1RrRMMx0PNHbeC9TLq0Kw1ubD83591yz64gLNHFLTVkTJmWeWCXKtQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-view-shot@3.8.0:
+    resolution: {integrity: sha512-4cU8SOhMn3YQIrskh+5Q8VvVRxQOu8/s1M9NAL4z5BY1Rm0HXMWkQJ4N0XsZ42+Yca+y86ISF3LC5qdLPvPuiA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-view-shot@4.0.3:
     resolution: {integrity: sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native@0.74.5:
+    resolution: {integrity: sha512-Bgg2WvxaGODukJMTZFTZBNMKVaROHLwSb8VAGEdrlvKwfb1hHg/3aXTUICYk7dwgAnb+INbGMwnF8yeAgIUmqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^18.2.6
+      react: 18.2.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-native@0.76.9:
     resolution: {integrity: sha512-+LRwecWmTDco7OweGsrECIqJu0iyrREd6CTCgC/uLLYipiHvk+MH9nd6drFtCw/6Blz6eoKTcH9YTTJusNtrWg==}
@@ -11092,6 +12109,11 @@ packages:
       typescript:
         optional: true
 
+  react-shallow-renderer@16.15.0:
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -11106,6 +12128,10 @@ packages:
     resolution: {integrity: sha512-kwViRpdISMTpcpy5B6TSewfJzRjnajihRaj57ZmOWKD+SPN6k9LUM13O0pfOuW8ir6B6OOiAXwCRqOoVxRNykA==}
     peerDependencies:
       react: ^19.2.5
+
+  react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -11285,6 +12311,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remove-trailing-slash@0.1.1:
+    resolution: {integrity: sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==}
+
   renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
@@ -11304,6 +12333,13 @@ packages:
 
   require-like@0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  requireg@0.2.2:
+    resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
+    engines: {node: '>= 4.0.0'}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -11340,6 +12376,9 @@ packages:
     resolution: {integrity: sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==}
     engines: {node: '>=12'}
 
+  resolve-workspace-root@2.0.1:
+    resolution: {integrity: sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==}
+
   resolve.exports@1.1.1:
     resolution: {integrity: sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==}
     engines: {node: '>=10'}
@@ -11357,10 +12396,17 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
+  resolve@1.7.1:
+    resolution: {integrity: sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==}
+
   resolve@2.0.0-next.6:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  restore-cursor@2.0.0:
+    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
+    engines: {node: '>=4'}
 
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -11611,6 +12657,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -11658,6 +12708,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -11676,6 +12729,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -11687,9 +12743,17 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
+
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -11735,6 +12799,12 @@ packages:
     resolution: {integrity: sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  simple-plist@1.3.1:
+    resolution: {integrity: sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -11763,6 +12833,14 @@ packages:
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
+
+  slice-ansi@2.1.0:
+    resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
+    engines: {node: '>=6'}
+
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -11873,6 +12951,10 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
 
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -11908,6 +12990,10 @@ packages:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
 
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -11925,6 +13011,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-buffers@2.2.0:
+    resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
+    engines: {node: '>= 0.10.0'}
+
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
@@ -11936,6 +13026,10 @@ packages:
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
 
   string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
@@ -11999,6 +13093,10 @@ packages:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
     engines: {node: '>=4'}
 
+  strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -12019,6 +13117,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-eof@1.0.0:
+    resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
+    engines: {node: '>=0.10.0'}
+
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
@@ -12031,12 +13133,22 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+
+  structured-headers@0.4.1:
+    resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
   style-loader@3.3.4:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
@@ -12066,10 +13178,19 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
 
+  sucrase@3.34.0:
+    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  sudo-prompt@9.2.1:
+    resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -12182,6 +13303,10 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  temp-dir@1.0.0:
+    resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
+    engines: {node: '>=4'}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -12190,8 +13315,16 @@ packages:
     resolution: {integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==}
     engines: {node: '>=6.0.0'}
 
+  tempy@0.3.0:
+    resolution: {integrity: sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==}
+    engines: {node: '>=8'}
+
   tempy@0.6.0:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
+    engines: {node: '>=10'}
+
+  tempy@0.7.1:
+    resolution: {integrity: sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==}
     engines: {node: '>=10'}
 
   term-size@2.2.1:
@@ -12356,12 +13489,20 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  traverse@0.6.11:
+    resolution: {integrity: sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==}
+    engines: {node: '>= 0.4'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trim-right@1.0.1:
+    resolution: {integrity: sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==}
+    engines: {node: '>=0.10.0'}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -12452,6 +13593,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@0.3.1:
+    resolution: {integrity: sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==}
+    engines: {node: '>=6'}
+
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -12490,6 +13635,10 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
+  typedarray.prototype.slice@1.0.5:
+    resolution: {integrity: sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==}
+    engines: {node: '>= 0.4'}
+
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
 
@@ -12508,6 +13657,11 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
+  typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
@@ -12516,6 +13670,10 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
   ufo@1.6.3:
@@ -12539,6 +13697,9 @@ packages:
 
   underscore@1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@5.28.4:
     resolution: {integrity: sha512-3OeMF5Lyowe8VW0skf5qaIE7Or3yS9LS7fvMUI0gg4YxpIBVg0L8BxCmROw2CcYhSkpR68Epz7CGc8MPj94Uww==}
@@ -12605,6 +13766,10 @@ packages:
     resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  unique-string@1.0.0:
+    resolution: {integrity: sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg==}
+    engines: {node: '>=4'}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -12667,6 +13832,10 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@1.0.0:
+    resolution: {integrity: sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==}
+    engines: {node: '>= 10.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -12783,6 +13952,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-join@4.0.0:
+    resolution: {integrity: sha512-EGXjXJZhIHiQMK2pQukuFcL303nskqIRzWvPvV5O8miOfwoUb9G+a/Cld60kUyeaybEI94wvVClT10DtfeAExA==}
+
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
@@ -12795,6 +13967,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-latest-callback@0.2.6:
+    resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
+    peerDependencies:
+      react: '>=16.8'
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -12825,6 +14002,11 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
+  uuid@7.0.3:
+    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -12847,8 +14029,14 @@ packages:
       typescript:
         optional: true
 
+  valid-url@1.0.9:
+    resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@3.0.0:
+    resolution: {integrity: sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -13200,6 +14388,9 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  warn-once@0.1.1:
+    resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
+
   watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
     engines: {node: '>=10.13.0'}
@@ -13345,6 +14536,10 @@ packages:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
+  whatwg-url-without-unicode@8.0.0-3:
+    resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
+    engines: {node: '>=10'}
+
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
@@ -13370,6 +14565,9 @@ packages:
   which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -13409,6 +14607,9 @@ packages:
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
+
+  wonka@4.0.15:
+    resolution: {integrity: sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -13539,12 +14740,32 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xcode@3.0.1:
+    resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
+    engines: {node: '>=10.0.0'}
+
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml2js@0.6.0:
+    resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
+  xmlbuilder@14.0.0:
+    resolution: {integrity: sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==}
+    engines: {node: '>=8.0'}
+
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -13555,6 +14776,9 @@ packages:
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -13588,6 +14812,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -13599,6 +14827,10 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -13655,6 +14887,12 @@ packages:
     peerDependencies:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
+
+  zod-validation-error@2.1.0:
+    resolution: {integrity: sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.18.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -14023,6 +15261,10 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
+  '@babel/code-frame@7.10.4':
+    dependencies:
+      '@babel/highlight': 7.25.9
+
   '@babel/code-frame@7.26.2':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -14104,6 +15346,14 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
+
+  '@babel/generator@7.2.0':
+    dependencies:
+      '@babel/types': 7.29.0
+      jsesc: 2.5.2
+      lodash: 4.18.1
+      source-map: 0.5.7
+      trim-right: 1.0.1
 
   '@babel/generator@7.26.10':
     dependencies:
@@ -14198,6 +15448,10 @@ snapshots:
       resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-environment-visitor@7.24.7':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/helper-globals@7.28.0': {}
 
@@ -14318,6 +15572,13 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
+  '@babel/highlight@7.25.9':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
@@ -14392,6 +15653,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -14417,10 +15688,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
 
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.26.10)':
     dependencies:
@@ -14439,6 +15725,27 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.10)
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.26.10)':
     dependencies:
@@ -14527,6 +15834,11 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
@@ -15251,6 +16563,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -15286,6 +16605,12 @@ snapshots:
   '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
@@ -15652,6 +16977,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-typescript@7.28.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -15988,6 +17325,10 @@ snapshots:
       which: 4.0.0
 
   '@discoveryjs/json-ext@0.5.7': {}
+
+  '@egjs/hammerjs@2.0.17':
+    dependencies:
+      '@types/hammerjs': 2.0.46
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -16592,6 +17933,284 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@expo/bunyan@4.0.1':
+    dependencies:
+      uuid: 8.3.2
+
+  '@expo/cli@0.18.31(encoding@0.1.13)(expo-modules-autolinking@1.11.3)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@expo/code-signing-certificates': 0.0.5
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/devcert': 1.2.1
+      '@expo/env': 0.3.0
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
+      '@expo/json-file': 8.3.3
+      '@expo/metro-config': 0.18.11
+      '@expo/osascript': 2.4.2
+      '@expo/package-manager': 1.10.4
+      '@expo/plist': 0.1.3
+      '@expo/prebuild-config': 7.0.9(encoding@0.1.13)(expo-modules-autolinking@1.11.3)
+      '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
+      '@expo/spawn-async': 1.7.2
+      '@expo/xcpretty': 4.4.3
+      '@react-native/dev-middleware': 0.74.85(encoding@0.1.13)
+      '@urql/core': 2.3.6(graphql@15.8.0)
+      '@urql/exchange-retry': 0.3.0(graphql@15.8.0)
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-creator: 0.0.7
+      bplist-parser: 0.3.2
+      cacache: 18.0.4
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      connect: 3.7.0
+      debug: 4.4.3
+      env-editor: 0.4.2
+      fast-glob: 3.3.3
+      find-yarn-workspace-root: 2.0.0
+      form-data: 3.0.4
+      freeport-async: 2.0.0
+      fs-extra: 8.1.0
+      getenv: 1.0.0
+      glob: 7.2.3
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      https-proxy-agent: 5.0.1
+      internal-ip: 4.3.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+      js-yaml: 3.14.2
+      json-schema-deref-sync: 0.13.0
+      lodash.debounce: 4.0.8
+      md5hex: 1.0.0
+      minimatch: 3.1.5
+      node-fetch: 2.7.0(encoding@0.1.13)
+      node-forge: 1.4.0
+      npm-package-arg: 7.0.0
+      open: 8.4.2
+      ora: 3.4.0
+      picomatch: 3.0.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.12
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.7.4
+      send: 0.18.0
+      slugify: 1.6.9
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      tar: 6.2.1
+      temp-dir: 2.0.0
+      tempy: 0.7.1
+      terminal-link: 2.1.1
+      text-table: 0.2.0
+      url-join: 4.0.0
+      wrap-ansi: 7.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - expo-modules-autolinking
+      - supports-color
+      - utf-8-validate
+
+  '@expo/code-signing-certificates@0.0.5':
+    dependencies:
+      node-forge: 1.4.0
+      nullthrows: 1.1.1
+
+  '@expo/config-plugins@8.0.11':
+    dependencies:
+      '@expo/config-types': 51.0.3
+      '@expo/json-file': 8.3.3
+      '@expo/plist': 0.1.3
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-up: 5.0.0
+      getenv: 1.0.0
+      glob: 7.1.6
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      slash: 3.0.0
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/config-types@51.0.3': {}
+
+  '@expo/config@9.0.4':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/config-types': 51.0.3
+      '@expo/json-file': 8.3.3
+      getenv: 1.0.0
+      glob: 7.1.6
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      slugify: 1.6.9
+      sucrase: 3.34.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/devcert@1.2.1':
+    dependencies:
+      '@expo/sudo-prompt': 9.3.2
+      debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/env@0.3.0':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/image-utils@0.5.1(encoding@0.1.13)':
+    dependencies:
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      fs-extra: 9.0.0
+      getenv: 1.0.0
+      jimp-compact: 0.16.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      parse-png: 2.1.0
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      tempy: 0.3.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@expo/json-file@10.0.13':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      json5: 2.2.3
+
+  '@expo/json-file@8.3.3':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      json5: 2.2.3
+      write-file-atomic: 2.4.3
+
+  '@expo/metro-config@0.18.11':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@expo/config': 9.0.4
+      '@expo/env': 0.3.0
+      '@expo/json-file': 8.3.3
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 9.1.0
+      getenv: 1.0.0
+      glob: 7.2.3
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.19.0
+      postcss: 8.4.35
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/osascript@2.4.2':
+    dependencies:
+      '@expo/spawn-async': 1.7.2
+
+  '@expo/package-manager@1.10.4':
+    dependencies:
+      '@expo/json-file': 10.0.13
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      npm-package-arg: 11.0.1
+      ora: 3.4.0
+      resolve-workspace-root: 2.0.1
+
+  '@expo/plist@0.1.3':
+    dependencies:
+      '@xmldom/xmldom': 0.7.13
+      base64-js: 1.5.1
+      xmlbuilder: 14.0.0
+
+  '@expo/prebuild-config@7.0.9(encoding@0.1.13)(expo-modules-autolinking@1.11.3)':
+    dependencies:
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/config-types': 51.0.3
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
+      '@expo/json-file': 8.3.3
+      '@react-native/normalize-colors': 0.74.85
+      debug: 4.4.3
+      expo-modules-autolinking: 1.11.3
+      fs-extra: 9.1.0
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@expo/rudder-sdk-node@1.1.1(encoding@0.1.13)':
+    dependencies:
+      '@expo/bunyan': 4.0.1
+      '@segment/loosely-validate-event': 2.0.0
+      fetch-retry: 4.1.1
+      md5: 2.3.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      remove-trailing-slash: 0.1.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+
+  '@expo/sdk-runtime-versions@1.0.0': {}
+
+  '@expo/spawn-async@1.7.2':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@expo/sudo-prompt@9.3.2': {}
+
+  '@expo/vector-icons@14.1.0(expo-font@12.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      expo-font: 12.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+
+  '@expo/xcpretty@4.4.3':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      chalk: 4.1.2
+      js-yaml: 4.1.1
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@15.8.0)':
+    dependencies:
+      graphql: 15.8.0
+
+  '@hapi/hoek@9.3.0': {}
+
+  '@hapi/topo@5.1.0':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -16973,6 +18592,20 @@ snapshots:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
+
+  '@jest/types@24.9.0':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 1.1.2
+      '@types/yargs': 13.0.12
+
+  '@jest/types@26.6.2':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 25.6.0
+      '@types/yargs': 15.0.20
+      chalk: 4.1.2
 
   '@jest/types@27.5.1':
     dependencies:
@@ -17574,11 +19207,216 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@react-native-community/cli-clean@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-glob: 3.3.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-config@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      cosmiconfig: 5.2.1
+      deepmerge: 4.3.1
+      fast-glob: 3.3.3
+      joi: 17.13.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-debugger-ui@13.6.9':
+    dependencies:
+      serve-static: 1.16.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native-community/cli-doctor@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-config': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-platform-apple': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      command-exists: 1.2.9
+      deepmerge: 4.3.1
+      envinfo: 7.21.0
+      execa: 5.1.1
+      hermes-profile-transformer: 0.0.6
+      node-stream-zip: 1.15.0
+      ora: 5.4.1
+      semver: 7.7.4
+      strip-ansi: 5.2.0
+      wcwidth: 1.0.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-hermes@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-platform-android': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      hermes-profile-transformer: 0.0.6
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-platform-android@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-glob: 3.3.3
+      fast-xml-parser: 4.5.6
+      logkitty: 0.7.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-platform-apple@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      chalk: 4.1.2
+      execa: 5.1.1
+      fast-glob: 3.3.3
+      fast-xml-parser: 4.5.6
+      ora: 5.4.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-platform-ios@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-platform-apple': 13.6.9(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-server-api@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-debugger-ui': 13.6.9
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      compression: 1.8.1
+      connect: 3.7.0
+      errorhandler: 1.5.2
+      nocache: 3.0.4
+      pretty-format: 26.6.2
+      serve-static: 1.16.3
+      ws: 6.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native-community/cli-tools@13.6.9(encoding@0.1.13)':
+    dependencies:
+      appdirsjs: 1.2.7
+      chalk: 4.1.2
+      execa: 5.1.1
+      find-up: 5.0.0
+      mime: 2.6.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      open: 6.4.0
+      ora: 5.4.1
+      semver: 7.7.4
+      shell-quote: 1.8.3
+      sudo-prompt: 9.2.1
+    transitivePeerDependencies:
+      - encoding
+
+  '@react-native-community/cli-types@13.6.9':
+    dependencies:
+      joi: 17.13.3
+
+  '@react-native-community/cli@13.6.9(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-clean': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-config': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-debugger-ui': 13.6.9
+      '@react-native-community/cli-doctor': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-hermes': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-server-api': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-types': 13.6.9
+      chalk: 4.1.2
+      commander: 9.5.0
+      deepmerge: 4.3.1
+      execa: 5.1.1
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+      graceful-fs: 4.2.11
+      prompts: 2.4.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/assets-registry@0.74.87': {}
+
   '@react-native/assets-registry@0.76.9': {}
+
+  '@react-native/babel-plugin-codegen@0.74.87(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
+    dependencies:
+      '@react-native/codegen': 0.74.87(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
 
   '@react-native/babel-plugin-codegen@0.76.9(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
     dependencies:
       '@react-native/codegen': 0.76.9(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.29.0)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.29.0)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.0)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.26.10(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@react-native/babel-plugin-codegen': 0.74.87(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      react-refresh: 0.14.2
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
@@ -17634,6 +19472,19 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/codegen@0.74.87(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/preset-env': 7.26.9(@babel/core@7.29.0)
+      glob: 7.2.3
+      hermes-parser: 0.19.1
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@react-native/codegen@0.76.9(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
     dependencies:
       '@babel/parser': 7.29.2
@@ -17648,7 +19499,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/community-cli-plugin@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)':
+  '@react-native/community-cli-plugin@0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.9(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.74.87(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.12
+      metro-config: 0.80.12
+      metro-core: 0.80.12
+      node-fetch: 2.7.0(encoding@0.1.13)
+      querystring: 0.2.1
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(encoding@0.1.13)':
     dependencies:
       '@react-native/dev-middleware': 0.76.9
       '@react-native/metro-babel-transformer': 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))
@@ -17661,6 +19534,8 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       readline: 1.3.0
       semver: 7.7.4
+    optionalDependencies:
+      '@react-native-community/cli': 13.6.9(encoding@0.1.13)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -17669,7 +19544,53 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@react-native/debugger-frontend@0.74.85': {}
+
+  '@react-native/debugger-frontend@0.74.87': {}
+
   '@react-native/debugger-frontend@0.76.9': {}
+
+  '@react-native/dev-middleware@0.74.85(encoding@0.1.13)':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.74.85
+      '@rnx-kit/chromium-edge-launcher': 1.0.0
+      chrome-launcher: 0.15.2
+      connect: 3.7.0
+      debug: 2.6.9
+      node-fetch: 2.7.0(encoding@0.1.13)
+      nullthrows: 1.1.1
+      open: 7.4.2
+      selfsigned: 2.4.1
+      serve-static: 1.16.3
+      temp-dir: 2.0.0
+      ws: 6.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/dev-middleware@0.74.87(encoding@0.1.13)':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.74.87
+      '@rnx-kit/chromium-edge-launcher': 1.0.0
+      chrome-launcher: 0.15.2
+      connect: 3.7.0
+      debug: 2.6.9
+      node-fetch: 2.7.0(encoding@0.1.13)
+      nullthrows: 1.1.1
+      open: 7.4.2
+      selfsigned: 2.4.1
+      serve-static: 1.16.3
+      temp-dir: 2.0.0
+      ws: 6.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@react-native/dev-middleware@0.76.9':
     dependencies:
@@ -17690,9 +19611,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@react-native/gradle-plugin@0.74.87': {}
+
   '@react-native/gradle-plugin@0.76.9': {}
 
+  '@react-native/js-polyfills@0.74.87': {}
+
   '@react-native/js-polyfills@0.76.9': {}
+
+  '@react-native/metro-babel-transformer@0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@react-native/babel-preset': 0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      hermes-parser: 0.19.1
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
 
   '@react-native/metro-babel-transformer@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))':
     dependencies:
@@ -17704,16 +19639,71 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/normalize-colors@0.74.85': {}
+
+  '@react-native/normalize-colors@0.74.87': {}
+
   '@react-native/normalize-colors@0.76.9': {}
 
-  '@react-native/virtualized-lists@0.76.9(@types/react@19.2.14)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)':
+  '@react-native/virtualized-lists@0.74.87(@types/react@19.2.14)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@react-native/virtualized-lists@0.76.9(@types/react@19.2.14)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.5
-      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@react-navigation/core@6.4.17(react@18.2.0)':
+    dependencies:
+      '@react-navigation/routers': 6.1.9
+      escape-string-regexp: 4.0.0
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 18.2.0
+      react-is: 16.13.1
+      use-latest-callback: 0.2.6(react@18.2.0)
+
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  '@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/core': 6.4.17(react@18.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.11
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+
+  '@react-navigation/routers@6.1.9':
+    dependencies:
+      nanoid: 3.3.11
+
+  '@react-navigation/stack@6.4.1(@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
 
   '@remix-run/dev@2.17.4(@remix-run/react@2.17.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@remix-run/serve@2.17.4(typescript@5.9.3))(@types/node@25.6.0)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.46.2)(typescript@5.9.3)(vite@5.4.21(@types/node@25.6.0)(less@4.6.4)(lightningcss@1.32.0)(sass@1.99.0)(terser@5.46.2))(yaml@2.8.3)':
     dependencies:
@@ -17883,6 +19873,17 @@ snapshots:
   '@remix-run/web-stream@1.1.0':
     dependencies:
       web-streams-polyfill: 3.3.3
+
+  '@rnx-kit/chromium-edge-launcher@1.0.0':
+    dependencies:
+      '@types/node': 18.19.130
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.4.2
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -18228,6 +20229,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@segment/loosely-validate-event@2.0.0':
+    dependencies:
+      component-type: 1.2.2
+      join-component: 1.1.0
+
   '@shikijs/core@1.29.2':
     dependencies:
       '@shikijs/engine-javascript': 1.29.2
@@ -18293,6 +20299,14 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sideway/address@4.1.5':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@sideway/formula@3.0.1': {}
+
+  '@sideway/pinpoint@2.0.0': {}
 
   '@sigstore/bundle@2.3.2':
     dependencies:
@@ -18597,13 +20611,13 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react-test-renderer@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@testing-library/react-native@13.3.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react-test-renderer@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       jest-matcher-utils: 30.3.0
       picocolors: 1.1.1
       pretty-format: 30.3.0
       react: 19.2.5
-      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
       react-test-renderer: 19.2.5(react@19.2.5)
       redent: 3.0.0
 
@@ -18742,6 +20756,8 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/hammerjs@2.0.46': {}
+
   '@types/hast@2.3.10':
     dependencies:
       '@types/unist': 2.0.11
@@ -18763,6 +20779,11 @@ snapshots:
   '@types/istanbul-lib-report@3.0.3':
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@1.1.2':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-lib-report': 3.0.3
 
   '@types/istanbul-reports@3.0.4':
     dependencies:
@@ -18799,6 +20820,10 @@ snapshots:
       '@types/node': 25.6.0
 
   '@types/node@12.20.55': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@20.19.39':
     dependencies:
@@ -18891,6 +20916,14 @@ snapshots:
       '@types/node': 25.6.0
 
   '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@13.0.12':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  '@types/yargs@15.0.20':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@types/yargs@16.0.11':
     dependencies:
@@ -19084,6 +21117,18 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@urql/core@2.3.6(graphql@15.8.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      graphql: 15.8.0
+      wonka: 4.0.15
+
+  '@urql/exchange-retry@0.3.0(graphql@15.8.0)':
+    dependencies:
+      '@urql/core': 2.3.6(graphql@15.8.0)
+      graphql: 15.8.0
+      wonka: 4.0.15
 
   '@vanilla-extract/babel-plugin-debug-ids@1.2.2':
     dependencies:
@@ -19518,6 +21563,10 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xmldom/xmldom@0.7.13': {}
+
+  '@xmldom/xmldom@0.9.10': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -19645,9 +21694,17 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-fragments@0.2.1:
+    dependencies:
+      colorette: 1.4.0
+      slice-ansi: 2.1.0
+      strip-ansi: 5.2.0
+
   ansi-html-community@0.0.8: {}
 
   ansi-html@0.0.9: {}
+
+  ansi-regex@4.1.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -19673,6 +21730,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  appdirsjs@1.2.7: {}
 
   archiver-utils@5.0.2:
     dependencies:
@@ -19821,6 +21880,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  astral-regex@1.0.0: {}
 
   astring@1.9.0: {}
 
@@ -20115,6 +22176,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-react-compiler@0.0.0-experimental-592953e-20240517:
+    dependencies:
+      '@babel/generator': 7.2.0
+      '@babel/types': 7.29.0
+      chalk: 4.1.2
+      invariant: 2.2.4
+      pretty-format: 24.9.0
+      zod: 3.25.76
+      zod-validation-error: 2.1.0(zod@3.25.76)
+
+  babel-plugin-react-native-web@0.19.13: {}
+
   babel-plugin-syntax-hermes-parser@0.23.1:
     dependencies:
       hermes-parser: 0.23.1
@@ -20168,6 +22241,23 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+
+  babel-preset-expo@11.0.15(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0)):
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/babel-preset': 0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      babel-plugin-react-compiler: 0.0.0-experimental-592953e-20240517
+      babel-plugin-react-native-web: 0.19.13
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - supports-color
 
   babel-preset-jest@27.5.1(@babel/core@7.26.10):
     dependencies:
@@ -20262,6 +22352,10 @@ snapshots:
 
   batch@0.6.1: {}
 
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -20273,6 +22367,8 @@ snapshots:
       hoopy: 0.1.4
       jsonpath: 1.3.0
       tryer: 1.0.1
+
+  big-integer@1.6.52: {}
 
   big.js@5.2.2: {}
 
@@ -20325,6 +22421,22 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  bplist-creator@0.0.7:
+    dependencies:
+      stream-buffers: 2.2.0
+
+  bplist-creator@0.1.0:
+    dependencies:
+      stream-buffers: 2.2.0
+
+  bplist-parser@0.3.1:
+    dependencies:
+      big-integer: 1.6.52
+
+  bplist-parser@0.3.2:
+    dependencies:
+      big-integer: 1.6.52
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -20360,7 +22472,16 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-alloc-unsafe@1.1.0: {}
+
+  buffer-alloc@1.2.0:
+    dependencies:
+      buffer-alloc-unsafe: 1.1.0
+      buffer-fill: 1.0.0
+
   buffer-crc32@1.0.0: {}
+
+  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -20375,6 +22496,8 @@ snapshots:
       ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
+
+  builtins@1.0.3: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -20524,6 +22647,8 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  charenc@0.0.2: {}
+
   check-types@11.2.3: {}
 
   chokidar@3.6.0:
@@ -20596,6 +22721,10 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
+  cli-cursor@2.1.0:
+    dependencies:
+      restore-cursor: 2.0.0
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -20611,6 +22740,12 @@ snapshots:
       execa: 8.0.1
       is-wsl: 3.1.1
       is64bit: 2.0.0
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@7.0.4:
     dependencies:
@@ -20638,6 +22773,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
@@ -20664,7 +22801,19 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   colord@2.9.3: {}
+
+  colorette@1.4.0: {}
 
   colorette@2.0.20: {}
 
@@ -20673,6 +22822,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  command-exists@1.2.9: {}
 
   commander@10.0.1: {}
 
@@ -20688,6 +22839,8 @@ snapshots:
 
   commander@8.3.0: {}
 
+  commander@9.5.0: {}
+
   common-ancestor-path@1.0.1: {}
 
   common-path-prefix@3.0.0: {}
@@ -20697,6 +22850,8 @@ snapshots:
   commondir@1.0.1: {}
 
   compatx@0.2.0: {}
+
+  component-type@1.2.2: {}
 
   compress-commons@6.0.2:
     dependencies:
@@ -20853,6 +23008,20 @@ snapshots:
 
   croner@10.0.1: {}
 
+  cross-fetch@3.2.0(encoding@0.1.13):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -20862,6 +23031,10 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
+
+  crypt@0.0.2: {}
+
+  crypto-random-string@1.0.0: {}
 
   crypto-random-string@2.0.0: {}
 
@@ -21034,6 +23207,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dag-map@1.0.2: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-uri-to-buffer@3.0.1: {}
@@ -21074,6 +23249,8 @@ snapshots:
       '@deno/shim-deno': 0.19.2
       undici-types: 5.28.4
 
+  dayjs@1.11.20: {}
+
   db0@0.3.4: {}
 
   de-indent@1.0.2: {}
@@ -21090,11 +23267,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
+
+  decode-uri-component@0.2.2: {}
 
   dedent-js@1.0.1: {}
 
@@ -21103,6 +23284,8 @@ snapshots:
   dedent@1.7.2(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -21116,6 +23299,11 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  default-gateway@4.2.0:
+    dependencies:
+      execa: 1.0.0
+      ip-regex: 2.1.0
 
   default-gateway@6.0.3:
     dependencies:
@@ -21143,7 +23331,20 @@ snapshots:
 
   defu@6.1.7: {}
 
+  del@6.1.1:
+    dependencies:
+      globby: 11.1.0
+      graceful-fs: 4.2.11
+      is-glob: 4.0.3
+      is-path-cwd: 2.2.0
+      is-path-inside: 3.0.3
+      p-map: 4.0.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+
   delayed-stream@1.0.0: {}
+
+  denodeify@1.2.1: {}
 
   denque@2.1.0: {}
 
@@ -21160,6 +23361,8 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -21275,9 +23478,15 @@ snapshots:
     dependencies:
       type-fest: 5.5.0
 
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.6.1
+
   dotenv-expand@5.1.0: {}
 
   dotenv@10.0.0: {}
+
+  dotenv@16.4.7: {}
 
   dotenv@16.6.1: {}
 
@@ -21369,7 +23578,11 @@ snapshots:
 
   entities@7.0.1: {}
 
+  env-editor@0.4.2: {}
+
   env-paths@2.2.1: {}
+
+  envinfo@7.21.0: {}
 
   err-code@2.0.3: {}
 
@@ -21387,6 +23600,11 @@ snapshots:
   error-stack-parser@2.1.4:
     dependencies:
       stackframe: 1.3.4
+
+  errorhandler@1.5.2:
+    dependencies:
+      accepts: 1.3.8
+      escape-html: 1.0.3
 
   es-abstract@1.24.2:
     dependencies:
@@ -22078,6 +24296,16 @@ snapshots:
 
   events@3.3.0: {}
 
+  execa@1.0.0:
+    dependencies:
+      cross-spawn: 6.0.6
+      get-stream: 4.1.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.7
+      strip-eof: 1.0.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -22114,6 +24342,79 @@ snapshots:
       jest-get-type: 27.5.1
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
+
+  expo-asset@10.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      expo-constants: 16.0.2(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      invariant: 2.2.4
+      md5-file: 3.2.3
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@16.0.2(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      '@expo/config': 9.0.4
+      '@expo/env': 0.3.0
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-file-system@17.0.1(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  expo-font@12.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      fontfaceobserver: 2.3.0
+
+  expo-keep-awake@13.0.2(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  expo-modules-autolinking@1.11.3:
+    dependencies:
+      chalk: 4.1.2
+      commander: 7.2.0
+      fast-glob: 3.3.3
+      find-up: 5.0.0
+      fs-extra: 9.1.0
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+
+  expo-modules-core@1.12.26:
+    dependencies:
+      invariant: 2.2.4
+
+  expo-status-bar@1.12.1: {}
+
+  expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@expo/cli': 0.18.31(encoding@0.1.13)(expo-modules-autolinking@1.11.3)
+      '@expo/config': 9.0.4
+      '@expo/config-plugins': 8.0.11
+      '@expo/metro-config': 0.18.11
+      '@expo/vector-icons': 14.1.0(expo-font@12.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)))(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      babel-preset-expo: 11.0.15(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      expo-asset: 10.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      expo-file-system: 17.0.1(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      expo-font: 12.0.10(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      expo-keep-awake: 13.0.2(expo@51.0.39(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      expo-modules-autolinking: 1.11.3
+      expo-modules-core: 1.12.26
+      fbemitter: 3.0.0(encoding@0.1.13)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
 
   exponential-backoff@3.1.3: {}
 
@@ -22191,6 +24492,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-parser@4.5.6:
+    dependencies:
+      strnum: 1.1.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -22207,9 +24512,31 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fbemitter@3.0.0(encoding@0.1.13):
+    dependencies:
+      fbjs: 3.0.5(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  fbjs-css-vars@1.0.2: {}
+
+  fbjs@3.0.5(encoding@0.1.13):
+    dependencies:
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      fbjs-css-vars: 1.0.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      promise: 7.3.1
+      setimmediate: 1.0.5
+      ua-parser-js: 1.0.41
+    transitivePeerDependencies:
+      - encoding
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-retry@4.1.1: {}
 
   figures@3.2.0:
     dependencies:
@@ -22236,6 +24563,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@1.1.0: {}
 
   finalhandler@1.1.2:
     dependencies:
@@ -22297,6 +24626,10 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
 
+  find-yarn-workspace-root@2.0.0:
+    dependencies:
+      micromatch: 4.0.8
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -22323,6 +24656,8 @@ snapshots:
   fontace@0.4.1:
     dependencies:
       fontkitten: 1.0.3
+
+  fontfaceobserver@2.3.0: {}
 
   fontkitten@1.0.3:
     dependencies:
@@ -22379,6 +24714,8 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  freeport-async@2.0.0: {}
+
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
@@ -22402,6 +24739,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fs-extra@9.0.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 1.0.0
 
   fs-extra@9.1.0:
     dependencies:
@@ -22478,6 +24822,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@4.1.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -22487,6 +24835,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  getenv@1.0.0: {}
 
   giget@3.2.0: {}
 
@@ -22516,6 +24866,15 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@7.1.6:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:
@@ -22576,6 +24935,13 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  graphql-tag@2.12.6(graphql@15.8.0):
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.8.1
+
+  graphql@15.8.0: {}
 
   graphql@16.13.2: {}
 
@@ -22767,9 +25133,15 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  hermes-estree@0.19.1: {}
+
   hermes-estree@0.23.1: {}
 
   hermes-estree@0.25.1: {}
+
+  hermes-parser@0.19.1:
+    dependencies:
+      hermes-estree: 0.19.1
 
   hermes-parser@0.23.1:
     dependencies:
@@ -22779,9 +25151,21 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hermes-profile-transformer@0.0.6:
+    dependencies:
+      source-map: 0.7.6
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   hookable@5.5.3: {}
 
   hoopy@0.1.4: {}
+
+  hosted-git-info@3.0.8:
+    dependencies:
+      lru-cache: 6.0.0
 
   hosted-git-info@6.1.3:
     dependencies:
@@ -22867,6 +25251,14 @@ snapshots:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 1.5.0
+      toidentifier: 1.0.1
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
       toidentifier: 1.0.1
 
   http-errors@2.0.1:
@@ -23048,6 +25440,11 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  internal-ip@4.3.0:
+    dependencies:
+      default-gateway: 4.2.0
+      ipaddr.js: 1.9.1
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -23073,6 +25470,8 @@ snapshots:
       - supports-color
 
   ip-address@10.1.1: {}
+
+  ip-regex@2.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -23100,6 +25499,8 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-arrayish@0.3.4: {}
+
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -23120,6 +25521,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-buffer@2.0.5: {}
 
@@ -23150,11 +25553,15 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extglob@1.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -23167,6 +25574,10 @@ snapshots:
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
+
+  is-glob@2.0.1:
+    dependencies:
+      is-extglob: 1.0.0
 
   is-glob@4.0.3:
     dependencies:
@@ -23183,6 +25594,10 @@ snapshots:
       is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
+
+  is-invalid-path@0.1.0:
+    dependencies:
+      is-glob: 2.0.1
 
   is-lambda@1.0.1: {}
 
@@ -23202,6 +25617,10 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-path-cwd@2.2.0: {}
+
+  is-path-inside@3.0.3: {}
 
   is-path-inside@4.0.0: {}
 
@@ -23240,6 +25659,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@1.1.0: {}
+
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
@@ -23267,6 +25688,10 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
+  is-valid-path@0.1.1:
+    dependencies:
+      is-invalid-path: 0.1.0
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -23283,6 +25708,8 @@ snapshots:
   is-what@4.1.16: {}
 
   is-windows@1.0.2: {}
+
+  is-wsl@1.1.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -23862,9 +26289,21 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jimp-compact@0.16.1: {}
+
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
+
+  joi@17.13.3:
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.5
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+
+  join-component@1.1.0: {}
 
   joycon@3.1.1: {}
 
@@ -23984,6 +26423,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsesc@2.5.2: {}
+
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
@@ -23995,6 +26436,17 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
+
+  json-schema-deref-sync@0.13.0:
+    dependencies:
+      clone: 2.1.2
+      dag-map: 1.0.2
+      is-valid-path: 0.1.1
+      lodash: 4.18.1
+      md5: 2.2.1
+      memory-cache: 0.2.0
+      traverse: 0.6.11
+      valid-url: 1.0.9
 
   json-schema-traverse@0.4.1: {}
 
@@ -24130,7 +26582,13 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-darwin-arm64@1.19.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.19.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
@@ -24139,16 +26597,31 @@ snapshots:
   lightningcss-freebsd-x64@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.19.0:
+    optional: true
+
   lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.19.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.19.0:
+    optional: true
+
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-gnu@1.19.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.19.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
@@ -24157,8 +26630,24 @@ snapshots:
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-x64-msvc@1.19.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
     optional: true
+
+  lightningcss@1.19.0:
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.19.0
+      lightningcss-darwin-x64: 1.19.0
+      lightningcss-linux-arm-gnueabihf: 1.19.0
+      lightningcss-linux-arm64-gnu: 1.19.0
+      lightningcss-linux-arm64-musl: 1.19.0
+      lightningcss-linux-x64-gnu: 1.19.0
+      lightningcss-linux-x64-musl: 1.19.0
+      lightningcss-win32-x64-msvc: 1.19.0
 
   lightningcss@1.32.0:
     dependencies:
@@ -24264,10 +26753,20 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@2.2.0:
+    dependencies:
+      chalk: 2.4.2
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  logkitty@0.7.1:
+    dependencies:
+      ansi-fragments: 0.2.1
+      dayjs: 1.11.20
+      yargs: 15.4.1
 
   longest-streak@3.1.0: {}
 
@@ -24360,6 +26859,24 @@ snapshots:
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  md5-file@3.2.3:
+    dependencies:
+      buffer-alloc: 1.2.0
+
+  md5@2.2.1:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
+  md5hex@1.0.0: {}
 
   mdast-util-definitions@5.1.2:
     dependencies:
@@ -24608,6 +27125,8 @@ snapshots:
 
   memoize-one@5.2.1: {}
 
+  memory-cache@0.2.0: {}
+
   merge-anything@5.1.7:
     dependencies:
       is-what: 4.1.16
@@ -24620,6 +27139,15 @@ snapshots:
 
   methods@1.1.2: {}
 
+  metro-babel-transformer@0.80.12:
+    dependencies:
+      '@babel/core': 7.29.0
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.23.1
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-babel-transformer@0.81.5:
     dependencies:
       '@babel/core': 7.29.0
@@ -24629,15 +27157,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-cache-key@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   metro-cache-key@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
+
+  metro-cache@0.80.12:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      metro-core: 0.80.12
 
   metro-cache@0.81.5:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
       metro-core: 0.81.5
+
+  metro-config@0.80.12:
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.80.12
+      metro-cache: 0.80.12
+      metro-core: 0.80.12
+      metro-runtime: 0.80.12
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   metro-config@0.81.5:
     dependencies:
@@ -24654,11 +27207,35 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-core@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.80.12
+
   metro-core@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       lodash.throttle: 4.1.1
       metro-resolver: 0.81.5
+
+  metro-file-map@0.80.12:
+    dependencies:
+      anymatch: 3.1.3
+      debug: 2.6.9
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      node-abort-controller: 3.1.1
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   metro-file-map@0.81.5:
     dependencies:
@@ -24674,19 +27251,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-minify-terser@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.46.2
+
   metro-minify-terser@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
       terser: 5.46.2
 
+  metro-resolver@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
   metro-resolver@0.81.5:
     dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.80.12:
+    dependencies:
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.81.5:
     dependencies:
       '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
+
+  metro-source-map@0.80.12:
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.80.12
+      nullthrows: 1.1.1
+      ob1: 0.80.12
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   metro-source-map@0.81.5:
     dependencies:
@@ -24703,6 +27308,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-symbolicate@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.80.12
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      through2: 2.0.5
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   metro-symbolicate@0.81.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -24711,6 +27328,17 @@ snapshots:
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.80.12:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -24724,6 +27352,26 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
+
+  metro-transform-worker@0.80.12:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      flow-enums-runtime: 0.0.6
+      metro: 0.80.12
+      metro-babel-transformer: 0.80.12
+      metro-cache: 0.80.12
+      metro-cache-key: 0.80.12
+      metro-minify-terser: 0.80.12
+      metro-source-map: 0.80.12
+      metro-transform-plugins: 0.80.12
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   metro-transform-worker@0.81.5:
     dependencies:
@@ -24740,6 +27388,55 @@ snapshots:
       metro-source-map: 0.81.5
       metro-transform-plugins: 0.81.5
       nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.80.12:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 2.6.9
+      denodeify: 1.2.1
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.23.1
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.80.12
+      metro-cache: 0.80.12
+      metro-cache-key: 0.80.12
+      metro-config: 0.80.12
+      metro-core: 0.80.12
+      metro-file-map: 0.80.12
+      metro-resolver: 0.80.12
+      metro-runtime: 0.80.12
+      metro-source-map: 0.80.12
+      metro-symbolicate: 0.80.12
+      metro-transform-plugins: 0.80.12
+      metro-transform-worker: 0.80.12
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      strip-ansi: 6.0.1
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -25215,9 +27912,13 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@2.6.0: {}
+
   mime@3.0.0: {}
 
   mime@4.1.0: {}
+
+  mimic-fn@1.2.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -25410,6 +28111,8 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  nested-error-stacks@2.0.1: {}
+
   next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0):
     dependencies:
       '@next/env': 16.2.3
@@ -25472,6 +28175,8 @@ snapshots:
       node-addon-api: 3.2.1
       node-gyp-build: 4.8.4
     optional: true
+
+  nice-try@1.0.5: {}
 
   nitropack@2.13.4(encoding@0.1.13)(rolldown@1.0.0-rc.15):
     dependencies:
@@ -25586,6 +28291,10 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  nocache@3.0.4: {}
+
+  node-abort-controller@3.1.1: {}
+
   node-addon-api@3.2.1:
     optional: true
 
@@ -25634,6 +28343,8 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.38: {}
+
+  node-stream-zip@1.15.0: {}
 
   nopt@7.2.1:
     dependencies:
@@ -25686,6 +28397,13 @@ snapshots:
       semver: 7.7.4
       validate-npm-package-name: 5.0.1
 
+  npm-package-arg@7.0.0:
+    dependencies:
+      hosted-git-info: 3.0.8
+      osenv: 0.1.5
+      semver: 5.7.2
+      validate-npm-package-name: 3.0.0
+
   npm-packlist@8.0.2:
     dependencies:
       ignore-walk: 6.0.5
@@ -25717,6 +28435,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  npm-run-path@2.0.2:
+    dependencies:
+      path-key: 2.0.1
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -25736,6 +28458,10 @@ snapshots:
   nullthrows@1.1.1: {}
 
   nwsapi@2.2.23: {}
+
+  ob1@0.80.12:
+    dependencies:
+      flow-enums-runtime: 0.0.6
 
   ob1@0.81.5:
     dependencies:
@@ -25821,6 +28547,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@2.0.1:
+    dependencies:
+      mimic-fn: 1.2.0
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -25852,6 +28582,10 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  open@6.4.0:
+    dependencies:
+      is-wsl: 1.1.0
+
   open@7.4.2:
     dependencies:
       is-docker: 2.2.1
@@ -25872,6 +28606,15 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@3.4.0:
+    dependencies:
+      chalk: 2.4.2
+      cli-cursor: 2.1.0
+      cli-spinners: 2.9.2
+      log-symbols: 2.2.0
+      strip-ansi: 5.2.0
+      wcwidth: 1.0.1
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -25884,7 +28627,14 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  os-homedir@1.0.2: {}
+
   os-tmpdir@1.0.2: {}
+
+  osenv@0.1.5:
+    dependencies:
+      os-homedir: 1.0.2
+      os-tmpdir: 1.0.2
 
   outdent@0.5.0: {}
 
@@ -25901,6 +28651,8 @@ snapshots:
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
+
+  p-finally@1.0.0: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -26032,6 +28784,10 @@ snapshots:
 
   parse-node-version@1.0.1: {}
 
+  parse-png@2.1.0:
+    dependencies:
+      pngjs: 3.4.0
+
   parse5-html-rewriting-stream@7.0.0:
     dependencies:
       entities: 4.5.0
@@ -26064,6 +28820,8 @@ snapshots:
   path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
+
+  path-key@2.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -26115,6 +28873,8 @@ snapshots:
 
   picomatch@2.3.2: {}
 
+  picomatch@3.0.2: {}
+
   picomatch@4.0.1: {}
 
   picomatch@4.0.4: {}
@@ -26162,6 +28922,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  pngjs@3.4.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -26670,6 +29438,20 @@ snapshots:
       lodash: 4.18.1
       renderkid: 3.0.0
 
+  pretty-format@24.9.0:
+    dependencies:
+      '@jest/types': 24.9.0
+      ansi-regex: 4.1.1
+      ansi-styles: 3.2.1
+      react-is: 16.13.1
+
+  pretty-format@26.6.2:
+    dependencies:
+      '@jest/types': 26.6.2
+      ansi-regex: 5.0.1
+      ansi-styles: 4.3.0
+      react-is: 17.0.2
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -26709,12 +29491,18 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   promise-inflight@1.0.1: {}
 
   promise-retry@2.0.1:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
 
   promise@8.3.0:
     dependencies:
@@ -26776,6 +29564,8 @@ snapshots:
 
   q@1.5.1: {}
 
+  qrcode-terminal@0.11.0: {}
+
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
@@ -26785,6 +29575,15 @@ snapshots:
       side-channel: 1.1.0
 
   quansync@0.2.11: {}
+
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
+  querystring@0.2.1: {}
 
   querystringify@2.2.0: {}
 
@@ -26817,6 +29616,13 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-app-polyfill@3.0.0:
     dependencies:
@@ -26882,6 +29688,10 @@ snapshots:
 
   react-error-overlay@6.1.0: {}
 
+  react-freeze@1.0.4(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -26890,22 +29700,100 @@ snapshots:
 
   react-is@19.2.5: {}
 
-  react-native-view-shot@4.0.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5):
+  react-native-gesture-handler@2.16.2(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.18.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-safe-area-context@4.10.5(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-screens@3.31.1(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-freeze: 1.0.4(react@18.2.0)
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+      warn-once: 0.1.1
+
+  react-native-view-shot@3.8.0(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      html2canvas: 1.4.1
+      react: 18.2.0
+      react-native: 0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-view-shot@4.0.3(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5):
     dependencies:
       html2canvas: 1.4.1
       react: 19.2.5
-      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
+      react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5)
 
-  react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5):
+  react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.9(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.9(encoding@0.1.13)
+      '@react-native/assets-registry': 0.74.87
+      '@react-native/codegen': 0.74.87(@babel/preset-env@7.26.9(@babel/core@7.29.0))
+      '@react-native/community-cli-plugin': 0.74.87(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.74.87
+      '@react-native/js-polyfills': 0.74.87
+      '@react-native/normalize-colors': 0.74.87
+      '@react-native/virtualized-lists': 0.74.87(@types/react@19.2.14)(react-native@0.74.5(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.12
+      metro-source-map: 0.80.12
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 5.3.2
+      react-refresh: 0.14.2
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.76.9
       '@react-native/codegen': 0.76.9(@babel/preset-env@7.26.9(@babel/core@7.29.0))
-      '@react-native/community-cli-plugin': 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(encoding@0.1.13)
+      '@react-native/community-cli-plugin': 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.76.9
       '@react-native/js-polyfills': 0.76.9
       '@react-native/normalize-colors': 0.76.9
-      '@react-native/virtualized-lists': 0.76.9(@types/react@19.2.14)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)
+      '@react-native/virtualized-lists': 0.76.9(@types/react@19.2.14)(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.9(@babel/core@7.29.0))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@19.2.14)(encoding@0.1.13)(react@19.2.5))(react@19.2.5)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -27076,6 +29964,12 @@ snapshots:
       - webpack-plugin-serve
       - yaml
 
+  react-shallow-renderer@16.15.0(react@18.2.0):
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.2.0
+      react-is: 18.3.1
+
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       get-nonce: 1.0.1
@@ -27089,6 +29983,10 @@ snapshots:
       react: 19.2.5
       react-is: 19.2.5
       scheduler: 0.27.0
+
+  react@18.2.0:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@18.3.1:
     dependencies:
@@ -27359,6 +30257,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remove-trailing-slash@0.1.1: {}
+
   renderkid@3.0.0:
     dependencies:
       css-select: 4.3.0
@@ -27376,6 +30276,14 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-like@0.1.2: {}
+
+  require-main-filename@2.0.0: {}
+
+  requireg@0.2.2:
+    dependencies:
+      nested-error-stacks: 2.0.1
+      rc: 1.2.8
+      resolve: 1.7.1
 
   requires-port@1.0.0: {}
 
@@ -27405,6 +30313,8 @@ snapshots:
       postcss: 8.5.9
       source-map: 0.6.1
 
+  resolve-workspace-root@2.0.1: {}
+
   resolve.exports@1.1.1: {}
 
   resolve.exports@2.0.3: {}
@@ -27422,6 +30332,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  resolve@1.7.1:
+    dependencies:
+      path-parse: 1.0.7
+
   resolve@2.0.0-next.6:
     dependencies:
       es-errors: 1.3.0
@@ -27430,6 +30344,11 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@2.0.0:
+    dependencies:
+      onetime: 2.0.1
+      signal-exit: 3.0.7
 
   restore-cursor@3.1.0:
     dependencies:
@@ -27728,6 +30647,24 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@0.18.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -27814,6 +30751,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-blocking@2.0.0: {}
+
   set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
@@ -27839,6 +30778,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -27878,9 +30819,15 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
+
+  shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
 
@@ -27953,6 +30900,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-plist@1.3.1:
+    dependencies:
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.1
+      plist: 3.1.1
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -27976,6 +30933,14 @@ snapshots:
   slash@4.0.0: {}
 
   slash@5.1.0: {}
+
+  slice-ansi@2.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      astral-regex: 1.0.0
+      is-fullwidth-code-point: 2.0.0
+
+  slugify@1.6.9: {}
 
   smart-buffer@4.2.0: {}
 
@@ -28099,6 +31064,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  split-on-first@1.1.0: {}
+
   sprintf-js@1.0.3: {}
 
   ssri@10.0.6:
@@ -28127,6 +31094,8 @@ snapshots:
 
   statuses@1.5.0: {}
 
+  statuses@2.0.1: {}
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -28139,6 +31108,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-buffers@2.2.0: {}
 
   stream-shift@1.0.3: {}
 
@@ -28154,6 +31125,8 @@ snapshots:
       - react-native-b4a
 
   strict-event-emitter@0.5.1: {}
+
+  strict-uri-encode@2.0.0: {}
 
   string-hash@1.1.3: {}
 
@@ -28256,6 +31229,10 @@ snapshots:
       is-obj: 1.0.1
       is-regexp: 1.0.0
 
+  strip-ansi@5.2.0:
+    dependencies:
+      ansi-regex: 4.1.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -28270,6 +31247,8 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-eof@1.0.0: {}
+
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@3.0.0: {}
@@ -28278,11 +31257,17 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@1.1.2: {}
+
+  structured-headers@0.4.1: {}
 
   style-loader@3.3.4(webpack@5.94.0(esbuild@0.27.7)):
     dependencies:
@@ -28303,6 +31288,16 @@ snapshots:
       postcss: 8.5.9
       postcss-selector-parser: 6.1.2
 
+  sucrase@3.34.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      glob: 7.1.6
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      ts-interface-checker: 0.1.13
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -28312,6 +31307,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
+
+  sudo-prompt@9.2.1: {}
 
   supports-color@10.2.2: {}
 
@@ -28502,14 +31499,30 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  temp-dir@1.0.0: {}
+
   temp-dir@2.0.0: {}
 
   temp@0.8.4:
     dependencies:
       rimraf: 2.6.3
 
+  tempy@0.3.0:
+    dependencies:
+      temp-dir: 1.0.0
+      type-fest: 0.3.1
+      unique-string: 1.0.0
+
   tempy@0.6.0:
     dependencies:
+      is-stream: 2.0.1
+      temp-dir: 2.0.0
+      type-fest: 0.16.0
+      unique-string: 2.0.0
+
+  tempy@0.7.1:
+    dependencies:
+      del: 6.1.1
       is-stream: 2.0.1
       temp-dir: 2.0.0
       type-fest: 0.16.0
@@ -28674,9 +31687,17 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  traverse@0.6.11:
+    dependencies:
+      gopd: 1.2.0
+      typedarray.prototype.slice: 1.0.5
+      which-typed-array: 1.1.20
+
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
+
+  trim-right@1.0.1: {}
 
   trough@2.2.0: {}
 
@@ -28764,6 +31785,8 @@ snapshots:
 
   type-fest@0.21.3: {}
 
+  type-fest@0.3.1: {}
+
   type-fest@0.7.1: {}
 
   type-fest@4.41.0: {}
@@ -28816,6 +31839,17 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
+  typedarray.prototype.slice@1.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      math-intrinsics: 1.1.0
+      typed-array-buffer: 1.0.3
+      typed-array-byte-offset: 1.0.4
+
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.6:
@@ -28835,9 +31869,13 @@ snapshots:
 
   typescript@4.9.5: {}
 
+  typescript@5.3.3: {}
+
   typescript@5.4.5: {}
 
   typescript@5.9.3: {}
+
+  ua-parser-js@1.0.41: {}
 
   ufo@1.6.3: {}
 
@@ -28862,6 +31900,8 @@ snapshots:
       unplugin: 2.3.11
 
   underscore@1.13.6: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@5.28.4: {}
 
@@ -28947,6 +31987,10 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
 
+  unique-string@1.0.0:
+    dependencies:
+      crypto-random-string: 1.0.0
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
@@ -29031,6 +32075,8 @@ snapshots:
 
   universalify@0.2.0: {}
 
+  universalify@1.0.0: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -29108,6 +32154,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-join@4.0.0: {}
+
   url-parse@1.5.10:
     dependencies:
       querystringify: 2.2.0
@@ -29119,6 +32167,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-latest-callback@0.2.6(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -29153,6 +32205,8 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
+  uuid@7.0.3: {}
+
   uuid@8.3.2: {}
 
   uvu@0.5.6:
@@ -29172,10 +32226,16 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  valid-url@1.0.9: {}
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@3.0.0:
+    dependencies:
+      builtins: 1.0.3
 
   validate-npm-package-name@5.0.1: {}
 
@@ -29645,6 +32705,8 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  warn-once@0.1.1: {}
+
   watchpack@2.4.0:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -29829,6 +32891,12 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
+  whatwg-url-without-unicode@8.0.0-3:
+    dependencies:
+      buffer: 5.7.1
+      punycode: 2.3.1
+      webidl-conversions: 5.0.0
+
   whatwg-url@14.2.0:
     dependencies:
       tr46: 5.1.1
@@ -29882,6 +32950,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-pm-runs@1.1.0: {}
 
   which-typed-array@1.1.20:
@@ -29920,6 +32990,8 @@ snapshots:
       string-width: 7.2.0
 
   wildcard@2.0.1: {}
+
+  wonka@4.0.15: {}
 
   word-wrap@1.2.5: {}
 
@@ -30105,15 +33177,33 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xcode@3.0.1:
+    dependencies:
+      simple-plist: 1.3.1
+      uuid: 7.0.3
+
   xml-name-validator@3.0.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml2js@0.6.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
+  xmlbuilder@14.0.0: {}
+
+  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 
   xxhash-wasm@1.1.0: {}
+
+  y18n@4.0.3: {}
 
   y18n@5.0.8: {}
 
@@ -30143,11 +33233,30 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@16.2.0:
     dependencies:
@@ -30218,6 +33327,10 @@ snapshots:
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       typescript: 5.9.3
+      zod: 3.25.76
+
+  zod-validation-error@2.1.0(zod@3.25.76):
+    dependencies:
       zod: 3.25.76
 
   zod@3.25.76: {}


### PR DESCRIPTION
Closes #89
Closes #90

Minimal Expo example exercising provider, FAB, route ring, and four context streams; canonical README pulling its snippets from the example app so install instructions stay verifiable.

## Summary
- examples/react-native/ Expo app (Stack with Home + Details, four context-stream demo buttons)
- packages/react-native/README.md (Expo + bare RN quick-starts, peer-dep matrix, navigationRef wiring, Expo Go caveat, troubleshooting)
- Cross-links from root README.md and packages/react/README.md

## Test plan
- [ ] pnpm --filter brevwick-example-react-native type-check
- [ ] Manual submit from example produces all four context streams on staging dashboard
- [ ] README quick-start works in a fresh Expo SDK 51 app in < 10 min (SDD ship criterion)