### PR TITLE
chore(release): @tatlacas/brevwick-react-native first beta

### DIFF
--- a/.changeset/react-native-first-beta.md
+++ b/.changeset/react-native-first-beta.md
@@ -1,0 +1,17 @@
+---
+'@tatlacas/brevwick-react-native': minor
+---
+
+chore(release): @tatlacas/brevwick-react-native first beta (#91)
+
+Initial React Native adapter package: BrevwickProvider, useFeedback hook,
+FeedbackButton + Modal, react-native-view-shot optional-peer screenshot,
+React Navigation route ring, device context, Expo example app, canonical
+README. Mirrors @tatlacas/brevwick-react with RN primitives. Wire format
+identical except `device_context.platform = react-native-{ios,android}`.
+
+Lockstep with the rest of the SDK suite via the `linked` group in
+`.changeset/config.json` — the package version syncs to the next
+`1.0.0-beta.x` when the Release PR runs. Ships with npm provenance
+(`publishConfig.provenance: true`) and the 25 kB gzip size-limit gate
+mirroring the React adapter.


### PR DESCRIPTION
Closes #91

Cuts the first npm beta of `@tatlacas/brevwick-react-native` via changesets. Lockstep with the rest of the SDK suite (`linked` group in `.changeset/config.json`) — the package version syncs from `1.0.0-beta.0` → next `1.0.0-beta.x` when the Release PR runs.

## Summary

- `.changeset/react-native-first-beta.md` — `@tatlacas/brevwick-react-native: minor` meta-entry that anchors `Closes #91` and gives the suite changelog a single comprehensive "first React Native beta" line alongside the per-PR entries from #93 / #95–#101.

## Already in place (verified)

- `publishConfig.access: public` + `publishConfig.provenance: true` in `packages/react-native/package.json` (set by #93 scaffold).
- Size-limit budgets in `.size-limit.js` for both ESM and CJS at 25 kB gzip (added by #100, mirroring the React adapter ceiling documented in `CLAUDE.md`). Current measured weight: ESM 6.01 kB, CJS 6.28 kB — well under budget.
- Per-PR changesets accumulated by #93–#101 already drive the linked-group bump; this PR adds only the meta-entry, no additional version impact.

## Verify post-merge

- `npm view @tatlacas/brevwick-react-native versions` lists the new `1.0.0-beta.x`.
- Provenance attestation visible on the npm page.
- Fresh Expo app: `npm i @tatlacas/brevwick-react-native@beta` resolves with the documented peer-dep matrix (`react >=18 <20`, `react-native >=0.72 <0.78`, optional `react-native-view-shot >=3.8.0 <5`).

## Out of scope

- Public announcement (separate launch-readiness effort, see `launch-readiness-worktree.md`).
- `brevwick-web` registry flip from coming-soon to live (companion follow-up; not gated here).
- A second size-limit entry for "core only" — the package ships a single `dist/index.js` entry-point, so a second budget against the same artefact would either duplicate or contradict the existing 25 kB cap. Tightening to a smaller ceiling is a separate budget decision and not blocking this release.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm build` (required so Angular can resolve `@tatlacas/brevwick-sdk` types)
- [x] `pnpm type-check` (all 18 workspace projects pass)
- [x] `pnpm test:cover` (595 tests passed across the suite, RN package = 102/102)
- [x] `pnpm size` (all budgets green; RN ESM 6.01 kB / CJS 6.28 kB vs 25 kB ceiling)
- [ ] CI green on this PR
- [ ] Release PR opened by changesets bot reflects the lockstep beta bump including `@tatlacas/brevwick-react-native`