### PR TITLE
fix(sdk): default screenshot capture to document.body

### DIFF
--- a/.changeset/screenshot-default-body.md
+++ b/.changeset/screenshot-default-body.md
@@ -1,0 +1,38 @@
+---
+'@tatlacas/brevwick-sdk': patch
+---
+
+fix(sdk): default `captureScreenshot()` to `document.body`
+
+`captureScreenshot()` previously defaulted its capture root to
+`document.documentElement` (`<html>`). Empirically, the `<body>` default
+produces a non-blank capture in the brevwick-web reproduction reported in
+tatlacas-com/brevwick-web#254, where the previous default was returning a
+~2 KiB image with no visible content. The exact failure mode of the
+`documentElement` path is **not** yet root-caused — the change is a
+behaviour-improving switch matching `modern-screenshot`'s documented
+usage, not a verified upstream-bug fix. See JSDoc on
+`CaptureScreenshotOpts.element` for the provisional hypothesis (`<html>`
+inside an SVG `<foreignObject>` may not render as flow content) which is
+the leading suspicion but has not been pinned to a specific Chromium
+issue.
+
+Behavioural notes for adopters:
+
+- Callers that explicitly pass `opts.element` are unaffected.
+- Nodes portalled outside `<body>` (e.g. into `document.documentElement`
+  by browser extensions or atypical portal libraries) are now **outside**
+  the capture tree. Most React/Solid/Vue portal libraries portal into
+  `document.body` and are unaffected.
+- `:root` (i.e. `html`-scoped) CSS custom properties continue to be
+  inherited by the cloned `<body>` subtree at clone time because
+  `modern-screenshot` inlines computed styles before reparenting into
+  `<foreignObject>`.
+- Capture invoked before `<body>` parses (e.g. a `<head>` script) now
+  yields the placeholder + warn entry instead of attempting to rasterize
+  a `<body>`-less tree.
+- The `@tatlacas/brevwick-sdk` patch lockstep-bumps every adapter
+  (`-react`, `-vue`, `-solid`, `-svelte`, `-angular`, `-react-native`)
+  per the changesets `linked` config; consumers of any adapter who call
+  `bw.captureScreenshot()` (or top-level `captureScreenshot()`) inherit
+  the new default automatically.

--- a/.changeset/screenshot-default-body.md
+++ b/.changeset/screenshot-default-body.md
@@ -1,5 +1,5 @@
 ---
-'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-sdk': minor
 ---
 
 fix(sdk): default `captureScreenshot()` to `document.body`
@@ -31,7 +31,7 @@ Behavioural notes for adopters:
 - Capture invoked before `<body>` parses (e.g. a `<head>` script) now
   yields the placeholder + warn entry instead of attempting to rasterize
   a `<body>`-less tree.
-- The `@tatlacas/brevwick-sdk` patch lockstep-bumps every adapter
+- The `@tatlacas/brevwick-sdk` bump lockstep-bumps every adapter
   (`-react`, `-vue`, `-solid`, `-svelte`, `-angular`, `-react-native`)
   per the changesets `linked` config; consumers of any adapter who call
   `bw.captureScreenshot()` (or top-level `captureScreenshot()`) inherit

--- a/.claude/commands/brevwick.md
+++ b/.claude/commands/brevwick.md
@@ -1,12 +1,13 @@
 ---
 description: brevwick-sdk-js — fetch, assess, and implement a tracker issue end-to-end (pnpm workspace) with full CI gauntlet (+pnpm size for bundle-budgeted code), worktree, and auto-PR.
-argument-hint: "<issue-url — GitHub, Jira, or Linear>"
+argument-hint: '<issue-url — GitHub, Jira, or Linear>'
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*), Bash(gh:*), Bash(curl:*), Bash(jq:*), Bash(make:*), Bash(pnpm:*), Bash(npm:*), Bash(flutter:*), Bash(dart:*), Bash(go:*), Bash(test:*), Bash(grep:*), Bash(cat:*), Task, WebFetch, WebSearch
 ---
 
 You are landing a single issue end-to-end. Parse `$ARGUMENTS` as an issue URL. If empty, ask the user for one and stop.
 
 **Hard rules — do not violate, ever:**
+
 - No `Co-Authored-By` trailer in commits. No Claude attribution anywhere.
 - Never `git add -A` or `git add .` — stage specific paths only.
 - Never remove a worktree. The user manages worktree lifecycle.
@@ -20,12 +21,12 @@ You are landing a single issue end-to-end. Parse `$ARGUMENTS` as an issue URL. I
 
 Detect the tracker from `$ARGUMENTS`:
 
-| URL contains | Tracker | Extract |
-|---|---|---|
-| `github.com/<owner>/<repo>/issues/<N>` | **github** | `OWNER`, `REPO`, `N` |
-| `*.atlassian.net/browse/<KEY>-<N>` or `/jira/...` | **jira** | `JIRA_KEY` (e.g. `ABC-123`) |
-| `linear.app/<workspace>/issue/<KEY>-<N>` | **linear** | `LINEAR_ID` (e.g. `ENG-456`) |
-| anything else | **generic** | full URL |
+| URL contains                                      | Tracker     | Extract                      |
+| ------------------------------------------------- | ----------- | ---------------------------- |
+| `github.com/<owner>/<repo>/issues/<N>`            | **github**  | `OWNER`, `REPO`, `N`         |
+| `*.atlassian.net/browse/<KEY>-<N>` or `/jira/...` | **jira**    | `JIRA_KEY` (e.g. `ABC-123`)  |
+| `linear.app/<workspace>/issue/<KEY>-<N>`          | **linear**  | `LINEAR_ID` (e.g. `ENG-456`) |
+| anything else                                     | **generic** | full URL                     |
 
 If the URL matches none of the above, abort and print: `Unsupported tracker. I support GitHub Issues, Jira, and Linear URLs.` Stop.
 
@@ -85,18 +86,19 @@ Read the current repo's `CLAUDE.md` (`git rev-parse --show-toplevel` → `CLAUDE
 
 Apply this decision matrix to the fetched issue:
 
-| Condition | Action |
-|---|---|
-| Issue body or comments name a **different** repo as the implementation site | Abort: `This issue belongs in <repo>, not here.` Stop. |
-| Issue is a question, support thread, or RFC discussion (no concrete change requested) | Abort: `This is a discussion, not an implementable change.` Stop. |
+| Condition                                                                                                                                                                                                   | Action                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Issue body or comments name a **different** repo as the implementation site                                                                                                                                 | Abort: `This issue belongs in <repo>, not here.` Stop.                                                                                |
+| Issue is a question, support thread, or RFC discussion (no concrete change requested)                                                                                                                       | Abort: `This is a discussion, not an implementable change.` Stop.                                                                     |
 | Issue body has < ~3 sentences AND no acceptance criteria, OR comments contradict the body, OR scope is undefined ("make it faster" with no metric), OR it references files/symbols not present in this repo | **Use AskUserQuestion** with 1–3 concrete scoping options. Append answers to `notes/issue-<N>-context.md`. Resume only after answers. |
-| Issue is real, scoped, clear | Proceed silently. |
+| Issue is real, scoped, clear                                                                                                                                                                                | Proceed silently.                                                                                                                     |
 
 Before any edit, print one paragraph: `Issue <id>: <title>. Plan: <2-3 sentences naming the files I will touch and the test approach>. Proceeding.`
 
 ## STEP 4 — Worktree + branch
 
 Determine the branch prefix from issue labels and `CLAUDE.md` conventional-commit rules:
+
 - Labels containing `bug` or `fix` → `fix/`
 - Labels containing `chore` → `chore/`
 - Labels containing `docs` → `docs/`
@@ -105,6 +107,7 @@ Determine the branch prefix from issue labels and `CLAUDE.md` conventional-commi
 Compute `SLUG` = first 5 words of the title, lowercased, kebab-cased, alphanumerics + hyphens only.
 
 Compute `ID`:
+
 - github → `${N}` (numeric)
 - jira → `${JIRA_KEY}` lowercased (e.g. `abc-123`)
 - linear → `${LINEAR_ID}` lowercased
@@ -132,13 +135,13 @@ Save any clarifications received in step 3 to `notes/issue-${ID}-context.md` so 
 
 Read the CI command from this repo's `CLAUDE.md`. Brevwick repos:
 
-| Repo | Command |
-|---|---|
-| `brevwick-api` | `make lint && make test` |
-| `brevwick-web` | `pnpm install --frozen-lockfile && pnpm format:check && pnpm lint && pnpm type-check && pnpm test:cover && pnpm build` |
-| `brevwick-sdk-js` | same as `-web` (add `pnpm size` if change touches bundle-budgeted code per CLAUDE.md § bundle budgets) |
-| `brevwick-sdk-flutter` | `flutter pub get && dart format --set-exit-if-changed . && dart analyze && flutter test --coverage` |
-| `brevwick-ops` | `/voice-check` on changed markdown |
+| Repo                   | Command                                                                                                                |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `brevwick-api`         | `make lint && make test`                                                                                               |
+| `brevwick-web`         | `pnpm install --frozen-lockfile && pnpm format:check && pnpm lint && pnpm type-check && pnpm test:cover && pnpm build` |
+| `brevwick-sdk-js`      | same as `-web` (add `pnpm size` if change touches bundle-budgeted code per CLAUDE.md § bundle budgets)                 |
+| `brevwick-sdk-flutter` | `flutter pub get && dart format --set-exit-if-changed . && dart analyze && flutter test --coverage`                    |
+| `brevwick-ops`         | `/voice-check` on changed markdown                                                                                     |
 
 For an unknown repo (customer install): `grep -E "CI gauntlet\|ci\.yml" CLAUDE.md`. If nothing usable, ask the user once via `AskUserQuestion`: which command mirrors `.github/workflows/ci.yml`? Save the answer to `notes/issue-${ID}-context.md` for future runs.
 
@@ -162,6 +165,7 @@ git push -u origin "${PREFIX}/issue-${ID}-${SLUG}"
 Open the PR. The body shape depends on tracker:
 
 **GitHub** (auto-close keyword fires):
+
 ```
 gh pr create --title "<commit subject>" --body "$(cat <<'PREOF'
 Closes #<N>
@@ -178,6 +182,7 @@ PREOF
 ```
 
 **Jira** (use Smart Commits keywords; branch name auto-links via Jira–GitHub integration):
+
 ```
 gh pr create --title "[<JIRA_KEY>] <commit subject>" --body "$(cat <<'PREOF'
 Refs <JIRA_KEY> — <JIRA_BASE_URL>/browse/<JIRA_KEY>
@@ -192,6 +197,7 @@ PREOF
 ```
 
 **Linear** (magic words `Closes <ID>` auto-close when PR merges):
+
 ```
 gh pr create --title "<commit subject>" --body "$(cat <<'PREOF'
 Closes <LINEAR_ID>
@@ -216,6 +222,7 @@ Do not remove the worktree. Do not switch back to the main checkout. Stop here.
 ## Ambiguity policy (governs step 3)
 
 Ask the user via `AskUserQuestion` **only** in step 3, **only** with concrete options (no free-form questions), and **only** if one of these holds:
+
 - Body has < 3 sentences and no acceptance criteria.
 - Body and comments contradict each other.
 - Scope is undefined ("improve performance" with no metric).

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -307,12 +307,12 @@ own README captures against `<body>`. The exact failure mode of the
 a behaviour-improving change rather than a verified upstream fix. Two
 behaviour changes worth knowing:
 
-- **`:root` CSS custom properties** (e.g. `--brw-accent` declared on
-  `html`) are still inherited by the cloned `<body>` subtree because
+- **CSS custom properties declared on `:root` (`html`) or `<body>`** are
+  still inherited by the cloned `<body>` subtree because
   `modern-screenshot` inlines computed styles before reparenting under
-  `<foreignObject>`. If your design system relies on a token that is
-  declared on `<body>` (rare) or on a `<head>`-level container outside
-  `<body>` (rarer still), pass `opts.element` to widen the capture root.
+  `<foreignObject>`, and `getComputedStyle(body)` already resolves
+  ancestor-declared tokens. No action needed for typical design-system
+  setups (Tailwind, CSS variables on `:root`, theme classes on `body`).
 - **Portals into `<html>`** (browser extensions, atypical portal
   libraries) are no longer inside the capture tree. Most React/Solid/Vue
   portals land in `document.body` and continue to be captured. To

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -293,10 +293,10 @@ const blob = await bw.captureScreenshot({
 
 **Options:**
 
-| Field     | Type           | Default                    | Description                                                                                                                     |
-| --------- | -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `element` | `HTMLElement`  | `document.documentElement` | Sub-tree to capture. Only _descendants_ with `[data-brevwick-skip]` are scrubbed — a skip marker on the root itself is ignored. |
-| `quality` | `number` (0–1) | `0.85`                     | WebP encoder quality, forwarded to `modern-screenshot`'s `domToBlob`.                                                           |
+| Field     | Type           | Default         | Description                                                                                                                     |
+| --------- | -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `element` | `HTMLElement`  | `document.body` | Sub-tree to capture. Only _descendants_ with `[data-brevwick-skip]` are scrubbed — a skip marker on the root itself is ignored. |
+| `quality` | `number` (0–1) | `0.85`          | WebP encoder quality, forwarded to `modern-screenshot`'s `domToBlob`.                                                           |
 
 **Screenshot privacy:** any element marked `data-brevwick-skip` is hidden before capture and restored afterwards, even on failure. Use it on password fields, PII, card numbers, anything that should never land in a bug report:
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -298,6 +298,27 @@ const blob = await bw.captureScreenshot({
 | `element` | `HTMLElement`  | `document.body` | Sub-tree to capture. Only _descendants_ with `[data-brevwick-skip]` are scrubbed — a skip marker on the root itself is ignored. |
 | `quality` | `number` (0–1) | `0.85`          | WebP encoder quality, forwarded to `modern-screenshot`'s `domToBlob`.                                                           |
 
+**About the `document.body` default:** prior to this version the default
+was `document.documentElement`. We changed it because the
+`documentElement` default reproduced as a ~2 KiB blank image in at least
+one consumer (tatlacas-com/brevwick-web#254) and `modern-screenshot`'s
+own README captures against `<body>`. The exact failure mode of the
+`documentElement` path is not yet root-caused — treat the new default as
+a behaviour-improving change rather than a verified upstream fix. Two
+behaviour changes worth knowing:
+
+- **`:root` CSS custom properties** (e.g. `--brw-accent` declared on
+  `html`) are still inherited by the cloned `<body>` subtree because
+  `modern-screenshot` inlines computed styles before reparenting under
+  `<foreignObject>`. If your design system relies on a token that is
+  declared on `<body>` (rare) or on a `<head>`-level container outside
+  `<body>` (rarer still), pass `opts.element` to widen the capture root.
+- **Portals into `<html>`** (browser extensions, atypical portal
+  libraries) are no longer inside the capture tree. Most React/Solid/Vue
+  portals land in `document.body` and continue to be captured. To
+  preserve the previous behaviour, pass
+  `opts.element: document.documentElement` explicitly.
+
 **Screenshot privacy:** any element marked `data-brevwick-skip` is hidden before capture and restored afterwards, even on failure. Use it on password fields, PII, card numbers, anything that should never land in a bug report:
 
 ```html

--- a/packages/sdk/src/__tests__/integration/screenshot-real-dom.test.ts
+++ b/packages/sdk/src/__tests__/integration/screenshot-real-dom.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Real-DOM contract test for `captureScreenshot()` — addresses the
+ * "all our coverage is mock-only" gap raised in PR #103 review.
+ *
+ * Why this file exists separately from `../screenshot.test.ts`:
+ *   `screenshot.test.ts` mocks `modern-screenshot` everywhere because most
+ *   of its assertions are about *SDK-side* behaviour (skip-scrub ref
+ *   counting, placeholder fallback shape, `internal.push` wiring, quality
+ *   forwarding). Mocking is correct for those — they're testing the SDK,
+ *   not the renderer. But it leaves a gap: if a future refactor breaks
+ *   the live integration with `modern-screenshot` (wrong import shape,
+ *   element passed by stale reference, scrub mutations not visible to
+ *   the renderer because we accidentally cloned the subtree first), no
+ *   existing test catches it. This file exercises the un-mocked dynamic
+ *   import end-to-end against a real happy-dom subtree so any such
+ *   regression fails here loudly.
+ *
+ * What this file CAN assert (under happy-dom):
+ *   - The `import('modern-screenshot')` dynamic import resolves to the
+ *     real published package (i.e. peer-dep wiring is correct end-to-end
+ *     in the test runtime, not just at the bundle-graph level the
+ *     `chunk-split.test.ts` covers). The mock factory composes
+ *     `await vi.importActual('modern-screenshot')` rather than
+ *     hand-rolling a stub, so an ABI break (renamed export, removed
+ *     `domToBlob`, signature change) fails the import call itself —
+ *     not a mock that "passes" because the contract drifted.
+ *   - The SDK passes the LIVE `document.body` element (not a detached
+ *     clone) to `domToBlob`, so when `modern-screenshot` walks ancestor
+ *     stylesheets and inlines computed styles, the `:root`-scoped CSS
+ *     custom properties brevwick-web ships are reachable. Asserted by
+ *     reading `getComputedStyle` on a body descendant from inside a
+ *     wrapper that lets the call proceed otherwise un-mocked.
+ *   - The `[data-brevwick-skip]` scrub runs against the live tree before
+ *     `modern-screenshot` is invoked (so the renderer sees the hidden
+ *     state) and is restored afterwards even when the renderer fails.
+ *   - When `modern-screenshot` fails (which it will under happy-dom —
+ *     see below) the SDK's catch handler produces a valid `image/webp`
+ *     Blob without throwing.
+ *
+ * What this file CANNOT assert (and why it's tracked separately):
+ *   happy-dom's `<canvas>` element returns `null` from `getContext('2d')`
+ *   and the empty string from `toDataURL()`. modern-screenshot's
+ *   `imageToCanvas` step calls `context2d.drawImage`, which throws on
+ *   the missing 2D context. So the un-mocked rasterization path always
+ *   fails under happy-dom and the SDK falls back to the placeholder.
+ *   That means we cannot, in this test environment, assert that the
+ *   returned Blob's bytes differ from the 34-byte placeholder — because
+ *   the bytes WILL match the placeholder, every time. Worse, the real
+ *   `domToBlob` call hangs (waiting for `Image.onload` on the SVG data
+ *   URL, which happy-dom does not synthesise) so a fully-un-mocked
+ *   "let it fail naturally" test deadlocks. The wrapper below resolves
+ *   that by tapping the call, asserting the live arguments, and
+ *   short-circuiting the renderer.
+ *
+ *   Asserting "blob bytes differ from placeholder" requires a real
+ *   browser canvas (Playwright/Puppeteer against `examples/next/`).
+ *   That work is tracked in:
+ *     https://github.com/tatlacas-com/brevwick-sdk-js/issues/104
+ *   and is referenced from the JSDoc on `CaptureScreenshotOpts.element`
+ *   and the PR #103 body so the next reporter of a blank-screenshot
+ *   regression is linked to an existing ticket instead of opening a
+ *   duplicate. Switching this test environment to a node-canvas
+ *   binding would itself require cross-platform native-bindings work
+ *   that belongs in a separate PR.
+ *
+ * Why these assertions are still load-bearing despite the rasterization
+ * gap:
+ *   The bug PR #103 fixes is "the SDK passed the wrong root element to
+ *   modern-screenshot". The fix is a default-value flip. The mock-based
+ *   tests prove the new default value is forwarded, but they cannot
+ *   prove the renderer is actually reachable, that the imported module
+ *   has the expected shape, or that the live element survives the
+ *   scrub→capture handoff. If any of those break, every mock-based
+ *   test in `screenshot.test.ts` still passes (the SDK still calls a
+ *   mock function with the right argument) and the bug ships again.
+ *   This file fails loudly in that scenario.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  // Each test installs into a clean module graph so the cached
+  // `modernScreenshotPromise` from a sibling test does not satisfy
+  // the dynamic import before this file's wrapper is in place.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.doUnmock('modern-screenshot');
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('integration — captureScreenshot() against a real DOM subtree', () => {
+  it('resolves the un-mocked modern-screenshot import and reaches domToBlob with the live document.body', async () => {
+    // Real subtree. No content is mocked.
+    const styleEl = document.createElement('style');
+    styleEl.textContent = `
+      :root { --brw-real-dom-token: rgb(11, 22, 33); }
+      .brw-real-dom-sample { color: var(--brw-real-dom-token); }
+    `;
+    document.head.appendChild(styleEl);
+    const sample = document.createElement('div');
+    sample.className = 'brw-real-dom-sample';
+    sample.textContent = 'real dom subtree';
+    document.body.appendChild(sample);
+    const skip = document.createElement('div');
+    skip.setAttribute('data-brevwick-skip', '');
+    skip.style.visibility = 'visible';
+    document.body.appendChild(skip);
+
+    // Wrap the real `modern-screenshot` module: pull the actual exports
+    // via `vi.importActual` (not a hand-rolled stub) so the wrapper
+    // factory itself fails if the package's export shape regresses.
+    // Then override only `domToBlob` to record live arguments and
+    // re-throw, mirroring the canvas-unavailable failure that would
+    // happen anyway under happy-dom — without the deadlock that the
+    // un-tapped real call produces (modern-screenshot's
+    // `imageToCanvas` waits for `Image.onload` on an SVG data URL,
+    // which happy-dom does not synthesise).
+    let receivedTarget: unknown;
+    let observedSkipDuringCapture = '';
+    let observedTokenColor = '';
+    let calls = 0;
+    vi.doMock('modern-screenshot', async () => {
+      const actual =
+        await vi.importActual<typeof import('modern-screenshot')>(
+          'modern-screenshot',
+        );
+      // Sanity: the real module must still expose `domToBlob`. If a
+      // future major rename happened, this assertion fires inside the
+      // mock factory and the test surfaces it instead of silently
+      // passing against a stubbed shape.
+      if (typeof actual.domToBlob !== 'function') {
+        throw new Error(
+          'modern-screenshot ABI regression: domToBlob is not a function',
+        );
+      }
+      return {
+        ...actual,
+        domToBlob: async (target: HTMLElement) => {
+          calls += 1;
+          receivedTarget = target;
+          // The scrub MUST already have hidden the skip node before the
+          // renderer is called, because the renderer rasterizes
+          // whatever it sees at this instant.
+          observedSkipDuringCapture = skip.style.visibility;
+          // The :root-scoped token MUST be resolvable on a body
+          // descendant through getComputedStyle — modern-screenshot
+          // relies on this when it inlines computed styles into the
+          // cloned subtree before reparenting under <foreignObject>.
+          observedTokenColor = window.getComputedStyle(sample).color;
+          // Re-throw so the SDK's catch handler runs (mirroring the
+          // happy-dom canvas-unavailable failure that would happen
+          // anyway if we let the real call proceed end-to-end).
+          throw new Error('test: tapped real domToBlob and re-threw');
+        },
+      };
+    });
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { captureScreenshot } = await import('../../screenshot');
+    const blob = await captureScreenshot();
+
+    // End-to-end un-mocked wiring works: the dynamic import resolved
+    // to the real package (the wrapper factory's `vi.importActual`
+    // would have failed otherwise) and `domToBlob` was actually
+    // reached with live arguments.
+    expect(calls).toBe(1);
+    // The SDK passed the LIVE document.body, not a clone or
+    // documentElement.
+    expect(receivedTarget).toBe(document.body);
+    // Scrub ran against the live tree before the renderer was invoked.
+    expect(observedSkipDuringCapture).toBe('hidden');
+    // :root CSS-var inheritance survives at capture time on the live
+    // subtree (the invariant brevwick-web's design tokens depend on).
+    expect(observedTokenColor).toBe('rgb(11, 22, 33)');
+    // Renderer failure was caught and produced a valid placeholder.
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+    // Placeholder size is exactly 34 bytes (decoded from the
+    // hard-coded VP8L base64 in screenshot.ts). Asserting the exact
+    // size pins the contract: when rasterization fails, callers get
+    // the placeholder, not a partial render or a zero-byte blob.
+    expect(blob.size).toBe(34);
+    // Restore-after-failure path ran on the live tree.
+    expect(skip.style.visibility).toBe('visible');
+    expect(warn).toHaveBeenCalled();
+
+    sample.remove();
+    skip.remove();
+    styleEl.remove();
+  });
+});

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -136,10 +136,22 @@ describe('captureScreenshot', () => {
     );
   });
 
-  it('defaults capture target to document.body, not document.documentElement', async () => {
-    // Regression: putting `<html>` inside an SVG `<foreignObject>` is malformed
-    // flow content and produces a blank canvas in recent Chromium builds, so
-    // the implicit target must be `body`. (tatlacas-com/brevwick-web#254)
+  it('defaults the capture target to document.body so calls match modern-screenshot README usage', async () => {
+    // Asserts the public contract. The body-default fixes the symptom
+    // reported in tatlacas-com/brevwick-web#254 (a ~2 KiB blank image
+    // when called with no args).
+    //
+    // hypothesis (unverified, do NOT rely on this in test naming):
+    // `<html>` inside an SVG `<foreignObject>` is not flow content and
+    // rasterizes blank in some Chromium builds. The hypothesis has not
+    // been pinned to a Chromium issue and is not what this test asserts;
+    // this test asserts only the observable contract (default = body).
+    //
+    // NOTE: `modern-screenshot` is mocked in this suite, so this test
+    // proves the SDK *passes* `document.body` to `domToBlob` — it does
+    // NOT prove rendering improves. Real-DOM coverage of the rasterized
+    // output is out of scope for jsdom; track follow-up Playwright
+    // coverage if regression recurs.
     const spy = vi
       .fn()
       .mockResolvedValue(
@@ -222,6 +234,11 @@ describe('captureScreenshot', () => {
   });
 
   it('defaults quality to 0.85', async () => {
+    // Note: this test references `document.body` only because `body` is
+    // the default capture target (asserted by the dedicated body-default
+    // test above). Do NOT collapse this test into that one — they cover
+    // separate contracts (quality default vs target default) and the
+    // body reference here is incidental.
     const spy = vi
       .fn()
       .mockResolvedValue(
@@ -285,6 +302,64 @@ describe('captureScreenshot', () => {
       vi.unstubAllGlobals();
       warn.mockRestore();
     }
+  });
+
+  it('preserves :root CSS custom properties on body subtree at capture time', async () => {
+    // Regression guard for the CSS-variable inheritance concern raised
+    // in PR #103 review: brevwick-web defines `--brw-*` design tokens on
+    // `:root` (i.e. `<html>`). When the capture root is `document.body`
+    // (the new default), a body descendant must STILL be able to resolve
+    // those tokens via `getComputedStyle` at the moment `domToBlob` is
+    // invoked — otherwise the rasterized subtree would render with
+    // unresolved `var()` colours.
+    //
+    // jsdom does not actually rasterize, so this test cannot assert
+    // pixel output. What it CAN assert is the consumer-side invariant
+    // that `modern-screenshot` relies on: the live element passed to
+    // `domToBlob` already resolves :root tokens via `getComputedStyle`,
+    // which is what `modern-screenshot` inlines into its cloned tree
+    // before reparenting under `<foreignObject>`. If this invariant
+    // ever broke (e.g. because we started passing a detached clone
+    // instead of the live body) the rasterized output would lose the
+    // tokens.
+    const styleEl = document.createElement('style');
+    styleEl.textContent = `
+      :root {
+        --brw-test-token: rgb(7, 13, 29);
+      }
+      .brw-uses-token {
+        color: var(--brw-test-token);
+      }
+    `;
+    document.head.appendChild(styleEl);
+    const sample = document.createElement('div');
+    sample.className = 'brw-uses-token';
+    document.body.appendChild(sample);
+
+    let observedColor = '';
+    let receivedTarget: unknown;
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async (target: HTMLElement) => {
+        receivedTarget = target;
+        // At capture time, the body descendant must resolve the
+        // :root-scoped token. If this returns the empty string or the
+        // literal `var(--brw-test-token)`, modern-screenshot would
+        // inline a broken style.
+        observedColor = window.getComputedStyle(sample).color;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(receivedTarget).toBe(document.body);
+    // jsdom's CSS engine resolves the var; assert the computed value
+    // matches the :root declaration.
+    expect(observedColor).toBe('rgb(7, 13, 29)');
+
+    sample.remove();
+    styleEl.remove();
   });
 
   it('does not hide the root element itself when the root carries data-brevwick-skip', async () => {

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -131,9 +131,26 @@ describe('captureScreenshot', () => {
     const { captureScreenshot } = await import('../screenshot');
     await captureScreenshot({ quality: 0.5 });
     expect(spy).toHaveBeenCalledWith(
-      document.documentElement,
+      document.body,
       expect.objectContaining({ quality: 0.5, type: 'image/webp' }),
     );
+  });
+
+  it('defaults capture target to document.body, not document.documentElement', async () => {
+    // Regression: putting `<html>` inside an SVG `<foreignObject>` is malformed
+    // flow content and produces a blank canvas in recent Chromium builds, so
+    // the implicit target must be `body`. (tatlacas-com/brevwick-web#254)
+    const spy = vi
+      .fn()
+      .mockResolvedValue(
+        new Blob([new Uint8Array([1])], { type: 'image/webp' }),
+      );
+    vi.doMock('modern-screenshot', () => ({ domToBlob: spy }));
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]).toBe(document.body);
+    expect(spy.mock.calls[0]?.[0]).not.toBe(document.documentElement);
   });
 
   it('restores [data-brevwick-skip] visibility after concurrent captures that overlap', async () => {
@@ -214,9 +231,40 @@ describe('captureScreenshot', () => {
     const { captureScreenshot } = await import('../screenshot');
     await captureScreenshot();
     expect(spy).toHaveBeenCalledWith(
-      document.documentElement,
+      document.body,
       expect.objectContaining({ quality: 0.85, type: 'image/webp' }),
     );
+  });
+
+  it('returns a placeholder without invoking modern-screenshot when document.body is null', async () => {
+    // Defends the `document.body ?? null` fallback: capture invoked before
+    // body parsing finishes (or against a stub document with no body) must
+    // yield the placeholder rather than throwing.
+    const domToBlob = vi.fn();
+    vi.doMock('modern-screenshot', () => ({ domToBlob }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const originalBody = document.body;
+    Object.defineProperty(document, 'body', {
+      configurable: true,
+      get: () => null,
+    });
+    try {
+      const { captureScreenshot } = await import('../screenshot');
+      const blob = await captureScreenshot();
+      expect(blob).toBeInstanceOf(Blob);
+      expect(blob.type).toBe('image/webp');
+      expect(domToBlob).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalled();
+      const msg = String(warn.mock.calls[0]?.[0] ?? '');
+      expect(msg).toMatch(/document\.body is not available/);
+    } finally {
+      Object.defineProperty(document, 'body', {
+        configurable: true,
+        value: originalBody,
+        writable: true,
+      });
+      warn.mockRestore();
+    }
   });
 
   it('returns a placeholder without invoking modern-screenshot when document is undefined (SSR)', async () => {

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -5,11 +5,15 @@ import type { BrevwickInternal } from './core/internal';
  */
 export interface CaptureScreenshotOpts {
   /**
-   * Sub-tree to capture. Defaults to `document.documentElement` (the full
-   * page). Only *descendants* marked with `[data-brevwick-skip]` are scrubbed
-   * before capture — a skip marker on the root element itself is ignored
-   * (hiding the capture target would produce an empty image). Skip markers
-   * outside the sub-tree are left untouched.
+   * Sub-tree to capture. Defaults to `document.body` (the visible page
+   * content). The default is `body` rather than `document.documentElement`
+   * because `modern-screenshot` rasterizes the target inside an SVG
+   * `<foreignObject>`, where `<html>` is not valid flow content and recent
+   * Chromium builds render it as a blank canvas (~2 KiB transparent encode).
+   * Only *descendants* marked with `[data-brevwick-skip]` are scrubbed before
+   * capture — a skip marker on the root element itself is ignored (hiding the
+   * capture target would produce an empty image). Skip markers outside the
+   * sub-tree are left untouched.
    */
   element?: HTMLElement;
   /**
@@ -156,7 +160,15 @@ async function capture(
     return placeholderBlob();
   }
 
-  const element = opts?.element ?? document.documentElement;
+  // Default to `document.body`, not `document.documentElement`: putting
+  // `<html>` inside an SVG `<foreignObject>` is malformed flow content and
+  // produces a blank canvas in recent Chromium. See JSDoc on
+  // `CaptureScreenshotOpts.element` for the full rationale.
+  const element = opts?.element ?? document.body;
+  if (!element) {
+    logFailure(internal, new Error('document.body is not available'));
+    return placeholderBlob();
+  }
   const quality = opts?.quality ?? DEFAULT_QUALITY;
   // Declared outside the try so `finally` can always run, even if the
   // initial scrub throws (malformed selector / host-env quirks on a

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -34,6 +34,12 @@ export interface CaptureScreenshotOpts {
    *   before capture — a skip marker on the root element itself is
    *   ignored (hiding the capture target would produce an empty image).
    *   Skip markers outside the sub-tree are left untouched.
+   *
+   * Real-browser test coverage: rasterized-output regressions can only
+   * be caught by a real browser canvas (the SDK test suite runs under
+   * happy-dom, which has no functional 2D context). Tracked in
+   * https://github.com/tatlacas-com/brevwick-sdk-js/issues/104 — link
+   * any new "blank screenshot" report there before opening a duplicate.
    */
   element?: HTMLElement;
   /**

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -7,13 +7,33 @@ export interface CaptureScreenshotOpts {
   /**
    * Sub-tree to capture. Defaults to `document.body` (the visible page
    * content). The default is `body` rather than `document.documentElement`
-   * because `modern-screenshot` rasterizes the target inside an SVG
-   * `<foreignObject>`, where `<html>` is not valid flow content and recent
-   * Chromium builds render it as a blank canvas (~2 KiB transparent encode).
-   * Only *descendants* marked with `[data-brevwick-skip]` are scrubbed before
-   * capture — a skip marker on the root element itself is ignored (hiding the
-   * capture target would produce an empty image). Skip markers outside the
-   * sub-tree are left untouched.
+   * because `modern-screenshot`'s own README examples capture against
+   * `document.body`, and empirically the `body` default produces a
+   * non-blank capture in the brevwick-web reproduction reported in
+   * tatlacas-com/brevwick-web#254 where the prior `documentElement`
+   * default returned a ~2 KiB image with no visible content. The exact
+   * failure mode of `documentElement` has not yet been root-caused —
+   * the leading hypothesis is that `<html>` inside an SVG
+   * `<foreignObject>` is not valid flow content and rasterizes blank
+   * in some Chromium builds, but that hypothesis has not been pinned to
+   * a specific Chromium issue or upstream `modern-screenshot` bug, so
+   * treat this default as a behaviour-improving change rather than a
+   * verified upstream fix.
+   *
+   * Edge cases worth knowing:
+   * - Capture invoked before `<body>` parses (a `<head>` script with no
+   *   `defer`, or `document.body === null`) hits the placeholder path
+   *   instead of throwing — strictly more correct than the previous
+   *   `documentElement` default, which would have rasterized a
+   *   `<body>`-less tree.
+   * - Nodes portalled outside `<body>` (browser extensions injecting
+   *   into `<html>`, atypical portal libraries) are no longer inside
+   *   the capture tree. Most React/Solid/Vue portals land in
+   *   `document.body` and are unaffected.
+   * - Only *descendants* marked with `[data-brevwick-skip]` are scrubbed
+   *   before capture — a skip marker on the root element itself is
+   *   ignored (hiding the capture target would produce an empty image).
+   *   Skip markers outside the sub-tree are left untouched.
    */
   element?: HTMLElement;
   /**
@@ -160,10 +180,14 @@ async function capture(
     return placeholderBlob();
   }
 
-  // Default to `document.body`, not `document.documentElement`: putting
-  // `<html>` inside an SVG `<foreignObject>` is malformed flow content and
-  // produces a blank canvas in recent Chromium. See JSDoc on
-  // `CaptureScreenshotOpts.element` for the full rationale.
+  // Default to `document.body`, not `document.documentElement`. The
+  // brevwick-web reproduction in tatlacas-com/brevwick-web#254 yielded a
+  // ~2 KiB blank image with the `documentElement` default; switching to
+  // `body` fixes the symptom there and matches `modern-screenshot`'s
+  // README examples. Hypothesis (unverified): `<html>` inside an SVG
+  // `<foreignObject>` is not flow content and rasterizes blank in some
+  // Chromium builds. See JSDoc on `CaptureScreenshotOpts.element` for
+  // the provisional reasoning.
   const element = opts?.element ?? document.body;
   if (!element) {
     logFailure(internal, new Error('document.body is not available'));


### PR DESCRIPTION
Closes tatlacas-com/brevwick-web#254

## Summary

- `captureScreenshot()` defaulted its capture root to
  `document.documentElement` (the `<html>` element). The brevwick-web
  reproduction in tatlacas-com/brevwick-web#254 returned a ~2 KiB blank
  image with that default. This PR flips the default to `document.body`,
  matching `modern-screenshot`'s own README usage.
- The exact failure mode of the `documentElement` path is **not** yet
  root-caused. The leading hypothesis (unverified) is that `<html>`
  inside an SVG `<foreignObject>` is not valid flow content and
  rasterizes blank in some Chromium builds, but that hypothesis has not
  been pinned to a specific Chromium issue or upstream
  `modern-screenshot` bug. Treat this PR as a **behaviour-improving
  change** that matches documented upstream usage, not a verified
  upstream-bug fix. The hypothesis is preserved as a hypothesis (not
  asserted as fact) in the JSDoc, in-source comment, and changeset
  body.
- Element-override option is unchanged, so callers passing an explicit
  `opts.element` are unaffected.
- Added regression test asserting the implicit target is `document.body`,
  and a placeholder-fallback test for the rare case where
  `document.body` is null (e.g. capture fired before body parse). The
  body-default test names the observable contract only; the hypothesis
  lives in a `// hypothesis (unverified)` comment block. **Note:**
  `modern-screenshot` is mocked across the suite, so the unit tests
  prove the SDK passes `document.body` to `domToBlob` — they do **not**
  prove rendering improves. A real-browser screenshot test rig
  (Playwright in `examples/next/`) is the right remediation if this
  surface regresses again; not blocking this PR.
- Added CSS-variable inheritance test
  (`preserves :root CSS custom properties on body subtree at capture
  time`) guarding against the design-token regression risk raised in
  review: brevwick-web's `--brw-*` tokens are declared on `:root`, and
  the test asserts that a body descendant resolves them via
  `getComputedStyle` at the moment `domToBlob` is invoked — i.e. the
  consumer-side invariant `modern-screenshot` relies on at clone time
  is intact.
- Updated SDK README and JSDoc to reflect the new default, document the
  `:root` CSS-var caveat, the portal-tree behaviour change (nodes
  portalled into `<html>` are now outside the capture tree), and the
  document-ordering edge case.
- Added `.changeset/screenshot-default-body.md` (patch on
  `@tatlacas/brevwick-sdk`; the `linked` config in
  `.changeset/config.json` lockstep-bumps every adapter) — unblocks the
  changeset-required CI gate.

## Out of scope

- The first commit (`chore: format .claude/commands/brevwick.md with
  prettier`) is a tiny drive-by to unblock `pnpm format:check` on
  `main` (introduced in 3848ddd) — without it this branch's CI cannot
  turn green. Splitting it into its own PR after the fact would
  require rewriting branch history; flagged for next time, kept as-is
  here for hygiene.
- A real-browser (Playwright) screenshot test rig that would actually
  exercise the rasterizer. That is a multi-day initiative on its own
  and not the right scope for a one-line default flip; it is the
  remediation path the next time this surface regresses.

## Test plan

- [x] `pnpm install --frozen-lockfile && pnpm format:check && pnpm lint && pnpm type-check && pnpm test:cover && pnpm build && pnpm size` — all pass locally.
- [x] New test `defaults the capture target to document.body so calls match modern-screenshot README usage` — observable contract.
- [x] New test `preserves :root CSS custom properties on body subtree at capture time` — guards the `--brw-*` regression risk raised in review.
- [x] New test `returns a placeholder without invoking modern-screenshot when document.body is null` — null-body fallback.
- [x] `pnpm size`: SDK on widget open chunk = 10.92 kB, well under the 25 kB budget.
- [x] No real-DOM Playwright verification possible from this worktree; documented above as the next-regression remediation rather than a paper-trail follow-up issue. Treat this PR as a behaviour-improving change rather than a verified fix.