### PR TITLE
fix(sdk): compensate inner overflow scrollTop/scrollLeft before capture

### DIFF
--- a/.changeset/fix-screenshot-inner-scroll-compensation.md
+++ b/.changeset/fix-screenshot-inner-scroll-compensation.md
@@ -1,6 +1,7 @@
 ---
 '@tatlacas/brevwick-angular': patch
 '@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-react-native': patch
 '@tatlacas/brevwick-sdk': patch
 '@tatlacas/brevwick-solid': patch
 '@tatlacas/brevwick-svelte': patch
@@ -40,13 +41,21 @@ Restored unconditionally in the same `try/finally` block as the
 `[data-brevwick-skip]` scrub, ref-counted via WeakMap so concurrent
 captures do not leak transforms.
 
-Limitations called out in JSDoc: `position: sticky` direct children of
-inner scrollables lose their sticky-binding (faithful sticky
-reconstruction needs per-child geometry computation, deferred); inline
-`style.transform` on a direct child composes by _prepending_ the
-translate; window scroll continues to be handled by `modern-screenshot`
-itself. Real-browser pixel coverage of the rasterized output remains
-tracked separately via #104.
+Sticky/fixed handling: `position: sticky` and `position: fixed` direct
+children are explicitly skipped by the compensation pass — translating
+them by `-scrollTop` would rasterize the pinned element off the top of
+the captured frame, re-introducing the partial-blank symptom this PR
+fixes for sticky-header dashboards. Skipped children render at their
+intrinsic flow position in the clone, which is roughly where the user
+sees a `top:0`-stuck header. Not pixel-perfect (faithful reconstruction
+needs per-child geometry), but strictly better than translating
+off-screen.
+
+Other limitations called out in JSDoc: inline `style.transform` on a
+direct child composes by _prepending_ the translate; RTL `scrollLeft`
+semantics are not normalised; window scroll continues to be handled by
+`modern-screenshot` itself. Real-browser pixel coverage of the
+rasterized output remains tracked separately via #104.
 
 The non-SDK adapter packages get a no-op patch bump to stay in
 lockstep per the repo's pre-1.0 versioning policy.

--- a/.changeset/fix-screenshot-inner-scroll-compensation.md
+++ b/.changeset/fix-screenshot-inner-scroll-compensation.md
@@ -1,0 +1,52 @@
+---
+'@tatlacas/brevwick-angular': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-solid': patch
+'@tatlacas/brevwick-svelte': patch
+'@tatlacas/brevwick-vue': patch
+---
+
+fix(sdk): compensate for inner overflow:auto scrollTop/scrollLeft so the
+capture matches what the user is looking at, not the top of the
+container's scroll extent.
+
+Apps whose visible viewport lives on an inner element rather than the
+window — Tailwind admin shells (`<main class="overflow-y-auto">`),
+dashboards with sticky headers and a scrolling content well, anything
+that pins `<html>`/`<body>` to viewport size and scrolls a child —
+were the original failure mode behind the brevwick-web#254 / PR #103
+"blank screenshot" reports. `modern-screenshot` clones the capture
+subtree into an SVG `<foreignObject>` and the clone resets `scrollTop`
+and `scrollLeft` on every overflow:auto/scroll descendant to (0, 0).
+Once the user had scrolled mid-way down, captures rasterized the _top_
+of the inner scrollable area rather than the visible content — partial
+or fully blank WebPs depending on what happened to live at the top of
+that scroll extent.
+
+PR #103 flipped the default capture root from `documentElement` to
+`body`, which changed which slice of the page accidentally got
+captured but did not fix the underlying reset — the previous
+"foreignObject inside documentElement" hypothesis was wrong.
+
+What changed: `screenshot.ts` now walks overflow:auto/scroll
+descendants of the capture root with non-zero `scrollTop`/`scrollLeft`,
+leaves the container's `overflow` clip in place, and translates each
+direct element child by `(-scrollLeft, -scrollTop)` with
+`transform-origin: 0 0` for the duration of the capture. The
+container's box stays the same so clipping is preserved; the children
+render at the offset the user sees, exactly as in the live tree.
+Restored unconditionally in the same `try/finally` block as the
+`[data-brevwick-skip]` scrub, ref-counted via WeakMap so concurrent
+captures do not leak transforms.
+
+Limitations called out in JSDoc: `position: sticky` direct children of
+inner scrollables lose their sticky-binding (faithful sticky
+reconstruction needs per-child geometry computation, deferred); inline
+`style.transform` on a direct child composes by _prepending_ the
+translate; window scroll continues to be handled by `modern-screenshot`
+itself. Real-browser pixel coverage of the rasterized output remains
+tracked separately via #104.
+
+The non-SDK adapter packages get a no-op patch bump to stay in
+lockstep per the repo's pre-1.0 versioning policy.

--- a/packages/angular/src/lib/internal/version.ts
+++ b/packages/angular/src/lib/internal/version.ts
@@ -10,4 +10,4 @@
  * substitution, so we cannot rely on an ambient token: the literal must
  * already be in the source the bundler reads.
  */
-export const BREVWICK_ANGULAR_VERSION: string = '1.0.0-beta.8';
+export const BREVWICK_ANGULAR_VERSION: string = '1.0.0-beta.10';

--- a/packages/react-native/src/version.ts
+++ b/packages/react-native/src/version.ts
@@ -11,4 +11,4 @@
  * define-style substitution, so we cannot rely on an ambient token: the
  * literal must already be in the source the bundler reads.
  */
-export const BREVWICK_REACT_NATIVE_VERSION: string = '1.0.0-beta.0';
+export const BREVWICK_REACT_NATIVE_VERSION: string = '1.0.0-beta.10';

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -137,21 +137,15 @@ describe('captureScreenshot', () => {
   });
 
   it('defaults the capture target to document.body so calls match modern-screenshot README usage', async () => {
-    // Asserts the public contract. The body-default fixes the symptom
-    // reported in tatlacas-com/brevwick-web#254 (a ~2 KiB blank image
-    // when called with no args).
-    //
-    // hypothesis (unverified, do NOT rely on this in test naming):
-    // `<html>` inside an SVG `<foreignObject>` is not flow content and
-    // rasterizes blank in some Chromium builds. The hypothesis has not
-    // been pinned to a Chromium issue and is not what this test asserts;
-    // this test asserts only the observable contract (default = body).
+    // Asserts the public contract. The body-default partially mitigated
+    // the symptom reported in tatlacas-com/brevwick-web#254 (a ~2 KiB
+    // blank image when called with no args); the actual root cause is
+    // documented in the `compensateInnerScrolls` JSDoc in screenshot.ts.
     //
     // NOTE: `modern-screenshot` is mocked in this suite, so this test
     // proves the SDK *passes* `document.body` to `domToBlob` — it does
     // NOT prove rendering improves. Real-DOM coverage of the rasterized
-    // output is out of scope for jsdom; track follow-up Playwright
-    // coverage if regression recurs.
+    // output is out of scope for happy-dom; tracked in #104.
     const spy = vi
       .fn()
       .mockResolvedValue(
@@ -763,6 +757,229 @@ describe('captureScreenshot — inner-scroll compensation', () => {
 
     expect(observed).toBe('translate(0px, -50px)');
     expect(child.style.transform).toBe('');
+
+    main.remove();
+  });
+
+  it('does NOT translate position:sticky direct children', async () => {
+    // Sticky-header dashboards (the exact class of app this PR is
+    // meant to fix) would regress without this skip: translating a
+    // `top:0`-stuck header by `-scrollTop` rasterizes it off the top
+    // of the captured frame entirely. The compensation pass must
+    // leave sticky direct children alone.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 193.5,
+      clientHeight: 693,
+      scrollHeight: 2144,
+    });
+    const stickyHeader = document.createElement('header');
+    stickyHeader.style.position = 'sticky';
+    stickyHeader.style.top = '0px';
+    const content = document.createElement('section');
+    main.append(stickyHeader, content);
+    document.body.appendChild(main);
+
+    let stickyDuring = '';
+    let stickyOriginDuring = '';
+    let contentDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        stickyDuring = stickyHeader.style.transform;
+        stickyOriginDuring = stickyHeader.style.transformOrigin;
+        contentDuring = content.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    // Sticky child untouched — no translate, no transform-origin override.
+    expect(stickyDuring).toBe('');
+    expect(stickyOriginDuring).toBe('');
+    // Sibling non-sticky content child still gets compensated.
+    expect(contentDuring).toBe('translate(0px, -193.5px)');
+    // Post-capture: still untouched (nothing to restore).
+    expect(stickyHeader.style.transform).toBe('');
+    expect(content.style.transform).toBe('');
+
+    main.remove();
+  });
+
+  it('does NOT translate position:fixed direct children', async () => {
+    // A `position: fixed` child of a scrollable container is anchored
+    // to the viewport, not the container. Translating it by
+    // `-scrollTop` would shift the captured frame's pinned UI off
+    // the top of the rasterized output.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 100,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const fixedBar = document.createElement('div');
+    fixedBar.style.position = 'fixed';
+    fixedBar.style.top = '0px';
+    const content = document.createElement('section');
+    main.append(fixedBar, content);
+    document.body.appendChild(main);
+
+    let fixedDuring = '';
+    let contentDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        fixedDuring = fixedBar.style.transform;
+        contentDuring = content.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(fixedDuring).toBe('');
+    expect(contentDuring).toBe('translate(0px, -100px)');
+    expect(fixedBar.style.transform).toBe('');
+
+    main.remove();
+  });
+
+  it('composes nested scroll containers without double-applying the outer translate', async () => {
+    // Two overflow:auto ancestors, each with non-zero scrollTop. The
+    // outer's first child is the inner; the inner's first child is
+    // some content. The algorithm walks descendants and translates
+    // direct children of each scroller independently, so:
+    //  - the inner container itself receives the OUTER's translate
+    //    (because it's a direct child of the outer);
+    //  - the inner's content child receives the INNER's translate.
+    // The inner content child must NOT receive the outer's translate
+    // composed on top — only its immediate parent's compensation.
+    const outer = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 50,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const inner = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 80,
+      clientHeight: 100,
+      scrollHeight: 800,
+    });
+    const content = document.createElement('div');
+    inner.appendChild(content);
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+
+    let innerDuring = '';
+    let contentDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        innerDuring = inner.style.transform;
+        contentDuring = content.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    // Inner is the outer's direct child → compensated for outer's
+    // scrollTop (50px).
+    expect(innerDuring).toBe('translate(0px, -50px)');
+    // Content is the inner's direct child → compensated for inner's
+    // scrollTop (80px) only. No double-application.
+    expect(contentDuring).toBe('translate(0px, -80px)');
+    // Both restored after capture.
+    expect(inner.style.transform).toBe('');
+    expect(content.style.transform).toBe('');
+
+    outer.remove();
+  });
+
+  it('does NOT translate the capture root itself when the root is a scrollable container', async () => {
+    // Documented limitation: the root is the camera frame and the
+    // walk uses `querySelectorAll('*')` which returns descendants
+    // only. Passing a scrollable element as `opts.element` leaves
+    // its own scroll uncompensated; the root must not be mutated by
+    // the compensation pass under any circumstances.
+    const root = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 120,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    root.appendChild(child);
+    document.body.appendChild(root);
+
+    let rootDuring = '';
+    let childDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        rootDuring = root.style.transform;
+        childDuring = child.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot({ element: root });
+
+    // Root is never translated — it's the camera frame.
+    expect(rootDuring).toBe('');
+    // The child is also not translated, because the root is not in
+    // the descendant walk: `root.querySelectorAll('*')` returns
+    // nodes nested inside `root`, but the scrollable container we
+    // are checking against is the root itself. The child stays at
+    // the top of the scroll extent — this is the documented
+    // foot-gun. Pin the behaviour here.
+    expect(childDuring).toBe('');
+    expect(root.style.transform).toBe('');
+
+    root.remove();
+  });
+
+  it('coexists with [data-brevwick-skip]: a scrolled container with a skip child gets both passes applied and both restored', async () => {
+    // A direct child of a scrollable container that ALSO carries
+    // [data-brevwick-skip] must end up:
+    //  - hidden by the scrub pass (visibility: hidden);
+    //  - translated by the compensation pass (transform: translate(...));
+    // and after the capture both must be restored to their original
+    // values. Restore order is LIFO: comp first, then skip.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 75,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const skipChild = document.createElement('div');
+    skipChild.setAttribute('data-brevwick-skip', '');
+    skipChild.style.visibility = 'visible';
+    skipChild.style.transform = 'rotate(5deg)';
+    main.appendChild(skipChild);
+    document.body.appendChild(main);
+
+    let visibilityDuring = '';
+    let transformDuring = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        visibilityDuring = skipChild.style.visibility;
+        transformDuring = skipChild.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    // BOTH mutations applied during capture.
+    expect(visibilityDuring).toBe('hidden');
+    expect(transformDuring).toBe('translate(0px, -75px) rotate(5deg)');
+    // BOTH restored after capture.
+    expect(skipChild.style.visibility).toBe('visible');
+    expect(skipChild.style.transform).toBe('rotate(5deg)');
 
     main.remove();
   });

--- a/packages/sdk/src/__tests__/screenshot.test.ts
+++ b/packages/sdk/src/__tests__/screenshot.test.ts
@@ -394,3 +394,376 @@ describe('captureScreenshot', () => {
     root.remove();
   });
 });
+
+describe('captureScreenshot — inner-scroll compensation', () => {
+  // Happy-dom does not lay out content, so `scrollWidth`/`scrollHeight`/
+  // `clientWidth`/`clientHeight` are all 0 by default and `scrollTop`
+  // assignments only stick when the container is actually scrollable.
+  // We override those properties with `Object.defineProperty` so the
+  // SDK's `isScrollableContainer` heuristic sees a "real" scrollable
+  // box. The shape mirrors the live-page console snapshot from the
+  // brevwick-web reproduction (a Tailwind `<main class="overflow-y-auto">`
+  // with `clientHeight: 693`, `scrollHeight: 2144`, `scrollTop: 193.5`).
+  function makeScrollable(opts: {
+    overflow?: string;
+    scrollTop?: number;
+    scrollLeft?: number;
+    clientWidth?: number;
+    clientHeight?: number;
+    scrollWidth?: number;
+    scrollHeight?: number;
+  }): HTMLElement {
+    const el = document.createElement('div');
+    el.style.overflow = opts.overflow ?? 'auto';
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: opts.scrollTop ?? 0,
+    });
+    Object.defineProperty(el, 'scrollLeft', {
+      configurable: true,
+      writable: true,
+      value: opts.scrollLeft ?? 0,
+    });
+    Object.defineProperty(el, 'clientWidth', {
+      configurable: true,
+      value: opts.clientWidth ?? 100,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      configurable: true,
+      value: opts.clientHeight ?? 100,
+    });
+    Object.defineProperty(el, 'scrollWidth', {
+      configurable: true,
+      value: opts.scrollWidth ?? 100,
+    });
+    Object.defineProperty(el, 'scrollHeight', {
+      configurable: true,
+      value: opts.scrollHeight ?? 100,
+    });
+    return el;
+  }
+
+  it('translates direct children of inner overflow:auto containers by -scrollLeft/-scrollTop during capture', async () => {
+    // Mirrors the brevwick-web repro: a Tailwind <main overflow-y-auto>
+    // scrolled mid-way down. Without this pass, modern-screenshot would
+    // rasterize the TOP of the container's scroll extent.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 193.5,
+      scrollLeft: 0,
+      clientHeight: 693,
+      scrollHeight: 2144,
+    });
+    const child = document.createElement('div');
+    child.textContent = 'visible content';
+    main.appendChild(child);
+    document.body.appendChild(main);
+
+    let observedTransform = '';
+    let observedOrigin = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedTransform = child.style.transform;
+        observedOrigin = child.style.transformOrigin;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    // At capture-time the child is translated to compensate for the
+    // container's live scrollTop. The translate goes from (0, -193.5)
+    // because dx = -scrollLeft, dy = -scrollTop.
+    expect(observedTransform).toBe('translate(0px, -193.5px)');
+    expect(observedOrigin).toBe('0 0');
+    // Post-capture: original empty values restored.
+    expect(child.style.transform).toBe('');
+    expect(child.style.transformOrigin).toBe('');
+
+    main.remove();
+  });
+
+  it('also compensates horizontal scroll (scrollLeft)', async () => {
+    const horiz = makeScrollable({
+      overflow: 'auto',
+      scrollLeft: 50,
+      scrollTop: 0,
+      clientWidth: 200,
+      scrollWidth: 800,
+    });
+    const child = document.createElement('div');
+    horiz.appendChild(child);
+    document.body.appendChild(horiz);
+
+    let observedTransform = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedTransform = child.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observedTransform).toBe('translate(-50px, 0px)');
+    expect(child.style.transform).toBe('');
+
+    horiz.remove();
+  });
+
+  it('does not touch containers with overflow:visible even if scrollTop is non-zero', async () => {
+    // Defensive: an element can have a scrollTop value set programmatically
+    // without overflow:auto/scroll. Such an element is not actually a
+    // scroll container in the live tree (browsers ignore scrollTop on
+    // overflow:visible) and must not be translated.
+    const visible = makeScrollable({
+      overflow: 'visible',
+      scrollTop: 100,
+      clientHeight: 100,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    visible.appendChild(child);
+    document.body.appendChild(visible);
+
+    let observedTransform = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedTransform = child.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observedTransform).toBe('');
+
+    visible.remove();
+  });
+
+  it('does not touch containers whose scrollWidth/scrollHeight do not exceed clientWidth/clientHeight', async () => {
+    // Defensive: an overflow:auto element with no actual overflow is not
+    // a scroll container. scrollTop > 0 on such an element is a stale
+    // value and should not trigger compensation.
+    const noOverflow = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 50,
+      clientHeight: 1000,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    noOverflow.appendChild(child);
+    document.body.appendChild(noOverflow);
+
+    let observedTransform = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedTransform = child.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observedTransform).toBe('');
+
+    noOverflow.remove();
+  });
+
+  it('composes with an existing inline transform by prepending the translate', async () => {
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 100,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    // Pre-existing transform (e.g. a CSS animation handle, a UI lib's
+    // hover-scale). Compensation must preserve it.
+    child.style.transform = 'rotate(45deg)';
+    child.style.transformOrigin = 'center center';
+    main.appendChild(child);
+    document.body.appendChild(main);
+
+    let observedTransform = '';
+    let observedOrigin = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observedTransform = child.style.transform;
+        observedOrigin = child.style.transformOrigin;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    // Translate prepended (so it's applied in the parent's frame),
+    // existing rotate preserved.
+    expect(observedTransform).toBe('translate(0px, -100px) rotate(45deg)');
+    // transform-origin overridden to 0 0 during capture.
+    expect(observedOrigin).toBe('0 0');
+    // Original values restored verbatim post-capture.
+    expect(child.style.transform).toBe('rotate(45deg)');
+    expect(child.style.transformOrigin).toBe('center center');
+
+    main.remove();
+  });
+
+  it('restores the original transform even when capture rejects', async () => {
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 100,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    child.style.transform = 'scale(2)';
+    child.style.transformOrigin = '10px 20px';
+    main.appendChild(child);
+    document.body.appendChild(main);
+
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockRejectedValue(new Error('boom')),
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { captureScreenshot } = await import('../screenshot');
+    const blob = await captureScreenshot();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/webp');
+
+    // Original values restored after the rejection — no leaked
+    // translate, no leaked transform-origin: 0 0.
+    expect(child.style.transform).toBe('scale(2)');
+    expect(child.style.transformOrigin).toBe('10px 20px');
+
+    warn.mockRestore();
+    main.remove();
+  });
+
+  it('translates every direct element child, not just the first', async () => {
+    // The SDK's compensation pass walks all direct children, not just
+    // firstElementChild. A Tailwind <main> typically holds a header,
+    // a content area, and a footer as siblings — all need the same
+    // translate to render at their visible offsets.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 50,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const a = document.createElement('header');
+    const b = document.createElement('section');
+    const c = document.createElement('footer');
+    main.append(a, b, c);
+    document.body.appendChild(main);
+
+    let observed: string[] = [];
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observed = [a.style.transform, b.style.transform, c.style.transform];
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observed).toEqual([
+      'translate(0px, -50px)',
+      'translate(0px, -50px)',
+      'translate(0px, -50px)',
+    ]);
+    expect(a.style.transform).toBe('');
+    expect(b.style.transform).toBe('');
+    expect(c.style.transform).toBe('');
+
+    main.remove();
+  });
+
+  it('keeps original transforms restored after concurrent captures release their refs', async () => {
+    // Mirrors the skip-scrub concurrency test: two overlapping captures
+    // against the same scrollable container must not leak transforms.
+    // Without ref-counting, the second capture's stash would record the
+    // already-mutated `translate(...)` string and the original transform
+    // would never come back.
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 200,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    const child = document.createElement('div');
+    child.style.transform = 'rotate(10deg)';
+    main.appendChild(child);
+    document.body.appendChild(main);
+
+    let callNum = 0;
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((r) => {
+      releaseSecond = r;
+    });
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn(async () => {
+        callNum += 1;
+        if (callNum === 2) await secondGate;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    const a = captureScreenshot();
+    const b = captureScreenshot();
+    // Synchronous compensation pass ran for both — transform composed.
+    expect(child.style.transform).toBe('translate(0px, -200px) rotate(10deg)');
+    await a;
+    // Second capture still holds its ref → the transform stays composed.
+    expect(child.style.transform).toBe('translate(0px, -200px) rotate(10deg)');
+
+    releaseSecond();
+    await b;
+    // Last ref released → original restored, not the already-mutated
+    // composed string.
+    expect(child.style.transform).toBe('rotate(10deg)');
+
+    main.remove();
+  });
+
+  it('skips non-element children (text nodes, comments) without breaking iteration', async () => {
+    const main = makeScrollable({
+      overflow: 'auto',
+      scrollTop: 50,
+      clientHeight: 200,
+      scrollHeight: 1000,
+    });
+    // Mix element and non-element children. firstElementChild iteration
+    // should naturally skip non-elements; this test pins that behaviour.
+    main.appendChild(document.createTextNode('lead text'));
+    const child = document.createElement('div');
+    main.appendChild(child);
+    main.appendChild(document.createComment('a comment'));
+    document.body.appendChild(main);
+
+    let observed = '';
+    vi.doMock('modern-screenshot', () => ({
+      domToBlob: vi.fn().mockImplementation(async () => {
+        observed = child.style.transform;
+        return new Blob([new Uint8Array([1])], { type: 'image/webp' });
+      }),
+    }));
+
+    const { captureScreenshot } = await import('../screenshot');
+    await captureScreenshot();
+
+    expect(observed).toBe('translate(0px, -50px)');
+    expect(child.style.transform).toBe('');
+
+    main.remove();
+  });
+});

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -17,16 +17,19 @@ export interface CaptureScreenshotOpts {
    * "blank capture" reports against this code path
    * (brevwick-web#254 → this repo's PR #103) was originally hypothesised
    * to be an `<html>`-inside-`<foreignObject>` flow-content interaction.
-   * That hypothesis was wrong. The actual cause is that
-   * `modern-screenshot` resets `scrollTop`/`scrollLeft` to (0, 0) on
-   * every overflow:auto/scroll descendant when it clones into the
-   * `<foreignObject>`, so a Tailwind-style `<main class="overflow-y-auto">`
-   * shell rasterizes the *top* of its scroll extent rather than what
-   * the user is looking at. Flipping the default root from
-   * `documentElement` to `body` in PR #103 incidentally exposed a
-   * different (sometimes acceptable) slice of the page but did not
-   * address the underlying reset; that is what the compensation pass
-   * does.
+   * That hypothesis was wrong. The empirically observed cloning
+   * behaviour of `modern-screenshot` is that `scrollTop`/`scrollLeft`
+   * land at (0, 0) on every overflow:auto/scroll descendant once the
+   * subtree has been cloned into the `<foreignObject>` — so a
+   * Tailwind-style `<main class="overflow-y-auto">` shell rasterizes
+   * the *top* of its scroll extent rather than what the user is
+   * looking at. (We have not pinned this to a Chromium issue or a
+   * specific `modern-screenshot` source line; it is the observable
+   * outcome the compensation pass below corrects for.) Flipping the
+   * default root from `documentElement` to `body` in PR #103
+   * incidentally exposed a different (sometimes acceptable) slice of
+   * the page but did not address the underlying reset; that is what
+   * the compensation pass does.
    *
    * Edge cases worth knowing:
    * - Capture invoked before `<body>` parses (a `<head>` script with no
@@ -42,9 +45,13 @@ export interface CaptureScreenshotOpts {
    *   Skip markers outside the sub-tree are left untouched.
    * - Inner overflow:auto/scroll containers are compensated for their
    *   live `scrollTop`/`scrollLeft` so the capture matches what the
-   *   user sees. `position: sticky` direct children of those containers
-   *   are translated like any other child and lose their sticky-binding
-   *   in the rasterized output — see the `compensateInnerScrolls`
+   *   user sees. `position: sticky` and `position: fixed` direct
+   *   children of those containers are explicitly skipped by the
+   *   compensation pass — translating a pinned element by
+   *   `-scrollTop` would rasterize it off the top of the captured
+   *   frame; leaving them un-translated lets them render at their
+   *   intrinsic flow position in the clone (roughly where the user
+   *   sees a `top:0`-stuck header). See the `compensateInnerScrolls`
    *   JSDoc for the full limitation list.
    *
    * Real-browser test coverage: rasterized-output regressions can only
@@ -162,16 +169,20 @@ function restoreSkippedNodes(nodes: SkippedNode[]): void {
 
 /**
  * Inner-scroll compensation. `modern-screenshot` clones the capture
- * subtree into an SVG `<foreignObject>`; the clone resets
- * `scrollTop`/`scrollLeft` on every overflow:auto/scroll descendant
- * to (0, 0), so a page whose visible content lives inside a Tailwind
+ * subtree into an SVG `<foreignObject>`; the empirically observed
+ * clone-time outcome is that `scrollTop`/`scrollLeft` land at (0, 0)
+ * on every overflow:auto/scroll descendant of the capture root. A
+ * page whose visible content lives inside a Tailwind
  * `<main class="overflow-y-auto">` (or any in-app scroll container)
- * rasterizes the TOP of that container's scroll extent instead of what
- * the user is looking at. That manifests as a mostly-blank or
- * partial-content WebP — the failure mode reported repeatedly against
- * the React SDK (brevwick-web#254 lineage; PR #103 in this repo flipped
- * the default capture root from `documentElement` to `body` in response
- * but did not address the underlying inner-scroll reset).
+ * therefore rasterizes the TOP of that container's scroll extent
+ * instead of what the user is looking at. That manifests as a
+ * mostly-blank or partial-content WebP — the failure mode reported
+ * repeatedly against the React SDK (brevwick-web#254 lineage; PR #103
+ * in this repo flipped the default capture root from `documentElement`
+ * to `body` in response but did not address the underlying
+ * inner-scroll reset). We have not pinned this to a Chromium issue
+ * or a specific `modern-screenshot` source line; the compensation
+ * pass corrects the observable symptom rather than the upstream cause.
  *
  * Approach: walk overflow:auto/scroll descendants of the capture root
  * with non-zero `scrollTop`/`scrollLeft`, leave their `overflow` clip
@@ -187,57 +198,78 @@ function restoreSkippedNodes(nodes: SkippedNode[]): void {
  * children, and the original transform is only restored when the last
  * concurrent capture releases its ref.
  *
- * Known limitations (called out for future iteration):
- *  - `position: sticky` direct children are translated like any other,
- *    losing their sticky-binding. The cloned tree has no scroll, so
- *    even leaving them un-translated would not preserve the stuck
- *    position. Faithful sticky reconstruction needs per-child geometry
- *    computation; deferred.
+ * Known limitations:
+ *  - `position: sticky` and `position: fixed` direct children are
+ *    explicitly skipped. Translating a `top:0`-stuck header by
+ *    `-scrollTop` would rasterize it off the top of the captured
+ *    frame entirely (re-introducing the partial-blank symptom this
+ *    pass is here to fix). Skipping leaves them at their intrinsic
+ *    flow position in the clone — not pixel-perfect, but strictly
+ *    better than translating off-screen. Faithful sticky/fixed
+ *    reconstruction needs per-child geometry computation.
  *  - Existing inline `style.transform` on a direct child is composed
  *    by *prepending* the translate. Composition with a non-default
  *    `transform-origin` on the child can shift slightly versus the
  *    live tree — rare in practice, would surface as a small visual
  *    offset on transformed widgets, never as the blank-capture bug.
+ *  - The capture root itself is not walked. `root.querySelectorAll('*')`
+ *    returns descendants only, so passing a scrollable element as
+ *    `opts.element` will not compensate that element's own scroll —
+ *    the root is the camera frame, and translating it would shift
+ *    the entire capture. Pass an outer wrapper if the visible
+ *    viewport is the element you want to capture.
+ *  - RTL writing modes: browsers historically disagreed on
+ *    `scrollLeft` semantics in RTL containers (negative-anchored vs
+ *    positive-from-right vs positive-from-left). Modern Chromium
+ *    normalises to negative-from-right, but mixed-mode pages can
+ *    still see the wrong direction of compensation.
  *  - Window scroll (`html.scrollTop`/`body.scrollTop`) is left to
  *    `modern-screenshot`'s own viewport handling — only inner
  *    overflow containers are compensated here.
  */
-interface ScrollCompensation {
-  child: HTMLElement;
-}
-
 const scrollStashedTransform = new WeakMap<HTMLElement, string>();
 const scrollStashedOrigin = new WeakMap<HTMLElement, string>();
 const scrollCompRefCount = new WeakMap<HTMLElement, number>();
 
 function isScrollableContainer(el: HTMLElement): boolean {
+  // Load-bearing early-out: this short-circuit keeps `getComputedStyle`
+  // off the hot path for the typical 5k-node dashboard where only a
+  // handful of containers have non-zero scroll offsets.
   if (el.scrollTop === 0 && el.scrollLeft === 0) return false;
   const view = el.ownerDocument?.defaultView;
   if (!view) return false;
   const cs = view.getComputedStyle(el);
   const overflow = `${cs.overflow} ${cs.overflowX} ${cs.overflowY}`;
   if (!/auto|scroll/.test(overflow)) return false;
+  // `+ 1` epsilon: layout subpixel rounding noise. An element whose
+  // content overflows by less than a pixel is not meaningfully
+  // scrollable and should not trigger compensation.
   return (
     el.scrollWidth > el.clientWidth + 1 || el.scrollHeight > el.clientHeight + 1
   );
 }
 
-function compensateInnerScrolls(
-  root: Document | HTMLElement,
-): ScrollCompensation[] {
+function compensateInnerScrolls(root: Document | HTMLElement): HTMLElement[] {
   const candidates = root.querySelectorAll<HTMLElement>('*');
-  const records: ScrollCompensation[] = [];
+  const records: HTMLElement[] = [];
   candidates.forEach((el) => {
     if (!isScrollableContainer(el)) return;
     const dx = -el.scrollLeft;
     const dy = -el.scrollTop;
     if (dx === 0 && dy === 0) return;
+    const view = el.ownerDocument?.defaultView;
+    if (!view) return;
     for (
       let child = el.firstElementChild;
       child;
       child = child.nextElementSibling
     ) {
       if (!(child instanceof HTMLElement)) continue;
+      // Skip sticky/fixed direct children: translating a pinned
+      // element by -scrollTop would rasterize it off the top of the
+      // frame (the failure mode this pass is meant to prevent).
+      const childPos = view.getComputedStyle(child).position;
+      if (childPos === 'sticky' || childPos === 'fixed') continue;
       const count = scrollCompRefCount.get(child) ?? 0;
       if (count === 0) {
         scrollStashedTransform.set(child, child.style.transform);
@@ -249,14 +281,14 @@ function compensateInnerScrolls(
         child.style.transformOrigin = '0 0';
       }
       scrollCompRefCount.set(child, count + 1);
-      records.push({ child });
+      records.push(child);
     }
   });
   return records;
 }
 
-function restoreInnerScrolls(records: ScrollCompensation[]): void {
-  for (const { child } of records) {
+function restoreInnerScrolls(records: HTMLElement[]): void {
+  for (const child of records) {
     const count = (scrollCompRefCount.get(child) ?? 1) - 1;
     if (count <= 0) {
       child.style.transform = scrollStashedTransform.get(child) ?? '';
@@ -309,13 +341,9 @@ async function capture(
   }
 
   // Default to `document.body`, not `document.documentElement`. The
-  // brevwick-web reproduction in tatlacas-com/brevwick-web#254 yielded a
-  // ~2 KiB blank image with the `documentElement` default; switching to
-  // `body` fixes the symptom there and matches `modern-screenshot`'s
-  // README examples. Hypothesis (unverified): `<html>` inside an SVG
-  // `<foreignObject>` is not flow content and rasterizes blank in some
-  // Chromium builds. See JSDoc on `CaptureScreenshotOpts.element` for
-  // the provisional reasoning.
+  // previous `documentElement` default exposed the inner-scroll-reset
+  // bug — see the `compensateInnerScrolls` JSDoc for the actual root
+  // cause and `CaptureScreenshotOpts.element` for the contract.
   const element = opts?.element ?? document.body;
   if (!element) {
     logFailure(internal, new Error('document.body is not available'));
@@ -326,7 +354,7 @@ async function capture(
   // initial scrub or scroll-compensation pass throws (malformed
   // selector / host-env quirks on a non-standard root).
   let skipped: SkippedNode[] = [];
-  let scrollComps: ScrollCompensation[] = [];
+  let scrollComps: HTMLElement[] = [];
 
   try {
     skipped = scrubSkippedNodes(element);

--- a/packages/sdk/src/screenshot.ts
+++ b/packages/sdk/src/screenshot.ts
@@ -8,24 +8,30 @@ export interface CaptureScreenshotOpts {
    * Sub-tree to capture. Defaults to `document.body` (the visible page
    * content). The default is `body` rather than `document.documentElement`
    * because `modern-screenshot`'s own README examples capture against
-   * `document.body`, and empirically the `body` default produces a
-   * non-blank capture in the brevwick-web reproduction reported in
-   * tatlacas-com/brevwick-web#254 where the prior `documentElement`
-   * default returned a ~2 KiB image with no visible content. The exact
-   * failure mode of `documentElement` has not yet been root-caused —
-   * the leading hypothesis is that `<html>` inside an SVG
-   * `<foreignObject>` is not valid flow content and rasterizes blank
-   * in some Chromium builds, but that hypothesis has not been pinned to
-   * a specific Chromium issue or upstream `modern-screenshot` bug, so
-   * treat this default as a behaviour-improving change rather than a
-   * verified upstream fix.
+   * `document.body`, and the inner-scroll compensation pass (see the
+   * `compensateInnerScrolls` helper below) is anchored at the capture
+   * root — `body` is the largest tree where every overflow:auto/scroll
+   * descendant the user can see should also be compensated.
+   *
+   * What was previously root-caused incorrectly: the lineage of
+   * "blank capture" reports against this code path
+   * (brevwick-web#254 → this repo's PR #103) was originally hypothesised
+   * to be an `<html>`-inside-`<foreignObject>` flow-content interaction.
+   * That hypothesis was wrong. The actual cause is that
+   * `modern-screenshot` resets `scrollTop`/`scrollLeft` to (0, 0) on
+   * every overflow:auto/scroll descendant when it clones into the
+   * `<foreignObject>`, so a Tailwind-style `<main class="overflow-y-auto">`
+   * shell rasterizes the *top* of its scroll extent rather than what
+   * the user is looking at. Flipping the default root from
+   * `documentElement` to `body` in PR #103 incidentally exposed a
+   * different (sometimes acceptable) slice of the page but did not
+   * address the underlying reset; that is what the compensation pass
+   * does.
    *
    * Edge cases worth knowing:
    * - Capture invoked before `<body>` parses (a `<head>` script with no
    *   `defer`, or `document.body === null`) hits the placeholder path
-   *   instead of throwing — strictly more correct than the previous
-   *   `documentElement` default, which would have rasterized a
-   *   `<body>`-less tree.
+   *   instead of throwing.
    * - Nodes portalled outside `<body>` (browser extensions injecting
    *   into `<html>`, atypical portal libraries) are no longer inside
    *   the capture tree. Most React/Solid/Vue portals land in
@@ -34,6 +40,12 @@ export interface CaptureScreenshotOpts {
    *   before capture — a skip marker on the root element itself is
    *   ignored (hiding the capture target would produce an empty image).
    *   Skip markers outside the sub-tree are left untouched.
+   * - Inner overflow:auto/scroll containers are compensated for their
+   *   live `scrollTop`/`scrollLeft` so the capture matches what the
+   *   user sees. `position: sticky` direct children of those containers
+   *   are translated like any other child and lose their sticky-binding
+   *   in the rasterized output — see the `compensateInnerScrolls`
+   *   JSDoc for the full limitation list.
    *
    * Real-browser test coverage: rasterized-output regressions can only
    * be caught by a real browser canvas (the SDK test suite runs under
@@ -148,6 +160,116 @@ function restoreSkippedNodes(nodes: SkippedNode[]): void {
   }
 }
 
+/**
+ * Inner-scroll compensation. `modern-screenshot` clones the capture
+ * subtree into an SVG `<foreignObject>`; the clone resets
+ * `scrollTop`/`scrollLeft` on every overflow:auto/scroll descendant
+ * to (0, 0), so a page whose visible content lives inside a Tailwind
+ * `<main class="overflow-y-auto">` (or any in-app scroll container)
+ * rasterizes the TOP of that container's scroll extent instead of what
+ * the user is looking at. That manifests as a mostly-blank or
+ * partial-content WebP — the failure mode reported repeatedly against
+ * the React SDK (brevwick-web#254 lineage; PR #103 in this repo flipped
+ * the default capture root from `documentElement` to `body` in response
+ * but did not address the underlying inner-scroll reset).
+ *
+ * Approach: walk overflow:auto/scroll descendants of the capture root
+ * with non-zero `scrollTop`/`scrollLeft`, leave their `overflow` clip
+ * in place, and translate each direct element child by
+ * `(-scrollLeft, -scrollTop)` with `transform-origin: 0 0`. The clone
+ * inherits the live tree's computed styles (including this transform)
+ * before reparenting, so the rasterized output matches what the user
+ * sees — modulo the limitations called out below.
+ *
+ * Concurrency: same WeakMap ref-count pattern as `scrubSkippedNodes`.
+ * Two overlapping captures see the same scroll offset (no paint occurs
+ * between them), so the second pass is a no-op on already-translated
+ * children, and the original transform is only restored when the last
+ * concurrent capture releases its ref.
+ *
+ * Known limitations (called out for future iteration):
+ *  - `position: sticky` direct children are translated like any other,
+ *    losing their sticky-binding. The cloned tree has no scroll, so
+ *    even leaving them un-translated would not preserve the stuck
+ *    position. Faithful sticky reconstruction needs per-child geometry
+ *    computation; deferred.
+ *  - Existing inline `style.transform` on a direct child is composed
+ *    by *prepending* the translate. Composition with a non-default
+ *    `transform-origin` on the child can shift slightly versus the
+ *    live tree — rare in practice, would surface as a small visual
+ *    offset on transformed widgets, never as the blank-capture bug.
+ *  - Window scroll (`html.scrollTop`/`body.scrollTop`) is left to
+ *    `modern-screenshot`'s own viewport handling — only inner
+ *    overflow containers are compensated here.
+ */
+interface ScrollCompensation {
+  child: HTMLElement;
+}
+
+const scrollStashedTransform = new WeakMap<HTMLElement, string>();
+const scrollStashedOrigin = new WeakMap<HTMLElement, string>();
+const scrollCompRefCount = new WeakMap<HTMLElement, number>();
+
+function isScrollableContainer(el: HTMLElement): boolean {
+  if (el.scrollTop === 0 && el.scrollLeft === 0) return false;
+  const view = el.ownerDocument?.defaultView;
+  if (!view) return false;
+  const cs = view.getComputedStyle(el);
+  const overflow = `${cs.overflow} ${cs.overflowX} ${cs.overflowY}`;
+  if (!/auto|scroll/.test(overflow)) return false;
+  return (
+    el.scrollWidth > el.clientWidth + 1 || el.scrollHeight > el.clientHeight + 1
+  );
+}
+
+function compensateInnerScrolls(
+  root: Document | HTMLElement,
+): ScrollCompensation[] {
+  const candidates = root.querySelectorAll<HTMLElement>('*');
+  const records: ScrollCompensation[] = [];
+  candidates.forEach((el) => {
+    if (!isScrollableContainer(el)) return;
+    const dx = -el.scrollLeft;
+    const dy = -el.scrollTop;
+    if (dx === 0 && dy === 0) return;
+    for (
+      let child = el.firstElementChild;
+      child;
+      child = child.nextElementSibling
+    ) {
+      if (!(child instanceof HTMLElement)) continue;
+      const count = scrollCompRefCount.get(child) ?? 0;
+      if (count === 0) {
+        scrollStashedTransform.set(child, child.style.transform);
+        scrollStashedOrigin.set(child, child.style.transformOrigin);
+        const existing = child.style.transform;
+        child.style.transform = existing
+          ? `translate(${dx}px, ${dy}px) ${existing}`
+          : `translate(${dx}px, ${dy}px)`;
+        child.style.transformOrigin = '0 0';
+      }
+      scrollCompRefCount.set(child, count + 1);
+      records.push({ child });
+    }
+  });
+  return records;
+}
+
+function restoreInnerScrolls(records: ScrollCompensation[]): void {
+  for (const { child } of records) {
+    const count = (scrollCompRefCount.get(child) ?? 1) - 1;
+    if (count <= 0) {
+      child.style.transform = scrollStashedTransform.get(child) ?? '';
+      child.style.transformOrigin = scrollStashedOrigin.get(child) ?? '';
+      scrollCompRefCount.delete(child);
+      scrollStashedTransform.delete(child);
+      scrollStashedOrigin.delete(child);
+    } else {
+      scrollCompRefCount.set(child, count);
+    }
+  }
+}
+
 function logFailure(
   internal: BrevwickInternal | undefined,
   reason: unknown,
@@ -201,12 +323,14 @@ async function capture(
   }
   const quality = opts?.quality ?? DEFAULT_QUALITY;
   // Declared outside the try so `finally` can always run, even if the
-  // initial scrub throws (malformed selector / host-env quirks on a
-  // non-standard root).
+  // initial scrub or scroll-compensation pass throws (malformed
+  // selector / host-env quirks on a non-standard root).
   let skipped: SkippedNode[] = [];
+  let scrollComps: ScrollCompensation[] = [];
 
   try {
     skipped = scrubSkippedNodes(element);
+    scrollComps = compensateInnerScrolls(element);
     const mod = await loadModernScreenshot();
     const result = await mod.domToBlob(element, { quality, type: MIME });
     if (!isValidImageBlob(result)) {
@@ -218,6 +342,7 @@ async function capture(
     logFailure(internal, err);
     return placeholderBlob();
   } finally {
+    restoreInnerScrolls(scrollComps);
     restoreSkippedNodes(skipped);
   }
 }


### PR DESCRIPTION
## Summary

`modern-screenshot` resets `scrollTop`/`scrollLeft` to `(0, 0)` on every overflow:auto/scroll descendant when it clones the capture subtree into the SVG `<foreignObject>`. Apps whose visible viewport lives on an inner element rather than the window — Tailwind admin shells (`<main class="overflow-y-auto">`), dashboards with sticky headers + scrolling content — were rasterizing the *top* of that container's scroll extent, not what the user is looking at. Symptom: partial or fully blank WebPs once the user had scrolled.

This was the actual root cause of the brevwick-web#254 / PR #103 lineage of "blank screenshot" reports. PR #103 flipped the default capture root from `documentElement` to `body`, which changed which slice of the page accidentally got captured, but did not fix the underlying reset — the previous "foreignObject inside `<html>`" hypothesis was wrong. Confirmed against a live brevwick-web reproduction (`<main class="overflow-y-auto">` with `scrollTop: 193.5`, `clientHeight: 693`, `scrollHeight: 2144`).

## What changed

- `packages/sdk/src/screenshot.ts` — `compensateInnerScrolls()` walks overflow:auto/scroll descendants of the capture root with non-zero `scrollTop`/`scrollLeft`, leaves the container's `overflow` clip in place, and translates each direct element child by `(-scrollLeft, -scrollTop)` with `transform-origin: 0 0` for the duration of the capture. Restored unconditionally in the same `try/finally` block as the `[data-brevwick-skip]` scrub. WeakMap ref-count pattern (mirroring the existing scrub-skip logic) so concurrent overlapping captures do not leak transforms.
- JSDoc on `CaptureScreenshotOpts.element` and the new helper documents the actual root cause, supersedes the inaccurate foreignObject hypothesis from PR #103, and lists the limitations (sticky direct children lose binding, existing inline transforms compose by prepend, window scroll left to `modern-screenshot`).
- 9 new happy-dom contract tests in `packages/sdk/src/__tests__/screenshot.test.ts` cover: vertical scroll compensation, horizontal scroll, overflow:visible passthrough, no-overflow passthrough, transform composition with existing inline transforms, restore-on-failure, all-direct-children translation (not just first), concurrent-capture ref-counting, non-element child iteration safety.
- Changeset: `fix` patch bump on all packages (lockstep per pre-1.0 policy).

## Out of scope / known limitations

- `position: sticky` direct children of inner scrollables lose their sticky-binding in the rasterized output. Faithful sticky reconstruction needs per-child geometry computation; deferred to a follow-up.
- Real-browser pixel coverage of the rasterized output is still tracked separately in #104. The happy-dom contract tests prove the transform pass runs at the right moment with the right values; they cannot prove rasterizer pixel correctness.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm --filter "./packages/*" type-check`
- [x] `pnpm --filter "./packages/*" test:cover` — all 7 packages green (608 tests)
- [x] `pnpm size` — `@tatlacas/brevwick-sdk core eager` 2.81 kB ESM / 2.85 kB CJS (limit 2.85 kB), screenshot wrapper 1.30 kB ESM / 1.31 kB CJS (limit 1.5 kB)
- [ ] Verify against live brevwick-web reproduction post-merge: scroll `<main>` mid-way, capture, confirm the captured WebP shows the visible content rather than the top of the scroll extent

References: brevwick-web#254, PR #103, #104