### PR TITLE
test(sdk): real-Chromium Playwright regression for captureScreenshot (#104)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,100 @@
+name: Playwright e2e (real-browser screenshot)
+
+# Separate lane from `ci.yml` so the default test matrix stays fast and
+# the workflow only pays for Chromium binaries when something in the
+# capture path could plausibly be affected. The trigger filter below
+# scopes runs to changes in the SDK package (where the bug lives), the
+# Next example (which hosts the test page), and this workflow file
+# itself. Scoping by path means a docs-only PR doesn't burn a 90-second
+# Chromium download on every push.
+#
+# Closes the gap from issue #104: SDK unit tests run under happy-dom,
+# whose `<canvas>` has no 2D context, so `modern-screenshot` always
+# falls back to the placeholder there. Real Chromium rasterisation can
+# only be asserted via Playwright — that's what this lane locks in.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/sdk/**'
+      - 'examples/next/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/playwright.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/sdk/**'
+      - 'examples/next/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/playwright.yml'
+
+concurrency:
+  group: playwright-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      # Build the SDK + React workspaces so the Next example resolves
+      # `@tatlacas/brevwick-sdk` to a real `dist/`. The example imports
+      # the package via the workspace `exports` field, which points at
+      # `dist/index.js` — without these builds, Next's bundler would
+      # reach into an empty `dist/` and the page would 500 at runtime.
+      - run: pnpm --filter @tatlacas/brevwick-sdk build
+      - run: pnpm --filter @tatlacas/brevwick-react build
+
+      # `next build` runs as a separate step (rather than letting
+      # `playwright.config.ts`'s `webServer` do `next start`'s startup
+      # cold-build) so its log lands in its own collapsible group and
+      # build timing shows up in the job summary.
+      - run: pnpm --filter brevwick-example-next exec next build
+
+      # Cache the Playwright browsers across runs — the Chromium download
+      # is ~90 s on a cold runner and dominates the lane's wall time.
+      # Cache key is the lockfile hash so any version bump invalidates.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      # `--with-deps` was already handled in the previous step on cache
+      # miss; on cache hit we still need the system libs (xvfb, fonts,
+      # libnss3, libxkbcommon, etc.) installed because the cache only
+      # stores the browser binary, not apt packages.
+      - name: Install Chromium system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - run: pnpm test:e2e
+
+      # Always upload the Playwright report on failure so triagers can
+      # download the trace + screenshots from the workflow run summary
+      # without having to reproduce locally. Conditional on failure to
+      # keep the green-run artifact list tidy.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ build/
 
 # Local-only consumer sync scripts (tarball build + install into a sibling app).
 scripts/sync-*.sh
+
+# Playwright run artefacts — `test-results/` is per-spec failure dumps,
+# `playwright-report/` is the HTML reporter output. Both are reproducible
+# from a re-run and would just inflate diffs / repo size if committed.
+test-results/
+playwright-report/

--- a/e2e/screenshot.spec.ts
+++ b/e2e/screenshot.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * Real-browser regression suite for `captureScreenshot()` — issue #104.
+ *
+ * Why this exists
+ * ---------------
+ * The SDK unit tests run under happy-dom, whose `<canvas>` element has
+ * no 2D context. modern-screenshot's `imageToCanvas` step therefore
+ * always throws and the SDK falls back to its 26-byte placeholder WebP.
+ * That means the unit suite cannot prove that real Chromium actually
+ * paints non-blank pixels for the default-body capture path.
+ *
+ * `captureScreenshot()`'s default capture root has now flipped twice
+ * (PR #103, brevwick-web #254). Each fix landed against mock-only
+ * coverage and each one eventually regressed with a fresh "blank
+ * screenshot" report. This spec drives the live DOM against Chromium
+ * so the next regression breaks CI before it reaches a user.
+ *
+ * Test fixture lives in `examples/next/src/app/screenshot-test/page.tsx`
+ * — three solid coloured tiles (#ff0000, #00ff00, #0000ff) under a
+ * red-on-cream heading, plus a magenta `[data-brevwick-skip]` overlay.
+ * The page exposes `window.__brevwickCapture()` so we can call the SDK
+ * from the page context and shuttle the WebP back as a data URL.
+ */
+import { expect, test, type Page } from '@playwright/test';
+
+interface CaptureResult {
+  dataUrl: string;
+  size: number;
+  mime: string;
+}
+
+interface DecodedPixel {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+interface DecodedSample {
+  width: number;
+  height: number;
+  pixels: Record<string, DecodedPixel>;
+}
+
+/**
+ * Decode the data-URL'd WebP inside the browser context and pull a
+ * named set of pixel samples back out. Doing the decode on the page
+ * (rather than via a Node WebP decoder) keeps the dependency footprint
+ * small — Chromium already knows how to decode WebP via `<img>`.
+ *
+ * `samples` is name → {x,y}; values come back in the same shape so the
+ * spec can assert against meaningful labels rather than coordinate
+ * arithmetic at the call site.
+ */
+async function decodePixels(
+  page: Page,
+  dataUrl: string,
+  samples: Record<string, { x: number; y: number }>,
+): Promise<DecodedSample> {
+  return page.evaluate(
+    async ([dataUrlIn, samplesIn]) => {
+      const img = new Image();
+      img.src = dataUrlIn as string;
+      await img.decode();
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('2d context unavailable in test browser');
+      ctx.drawImage(img, 0, 0);
+      const out: Record<string, DecodedPixel> = {};
+      for (const [name, point] of Object.entries(
+        samplesIn as Record<string, { x: number; y: number }>,
+      )) {
+        const safeX = Math.min(
+          Math.max(0, Math.floor(point.x)),
+          canvas.width - 1,
+        );
+        const safeY = Math.min(
+          Math.max(0, Math.floor(point.y)),
+          canvas.height - 1,
+        );
+        const data = ctx.getImageData(safeX, safeY, 1, 1).data;
+        out[name] = {
+          r: data[0]!,
+          g: data[1]!,
+          b: data[2]!,
+          a: data[3]!,
+        };
+      }
+      return { width: canvas.width, height: canvas.height, pixels: out };
+    },
+    [dataUrl, samples] as const,
+  );
+}
+
+/**
+ * Size of the SDK's placeholder WebP. The placeholder is what the SDK
+ * returns when capture fails. The exact byte count comes from decoding
+ * the constant in `packages/sdk/src/screenshot.ts` —
+ * `atob('UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==')` is 26 raw
+ * bytes. We assert > placeholder so any real capture (which is at
+ * minimum a few hundred bytes for a non-empty viewport) clears it; a
+ * regression that silently returns the placeholder fails this gate.
+ */
+const PLACEHOLDER_BYTES = 26;
+
+test.describe('captureScreenshot — real Chromium', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/screenshot-test');
+    // The page sets `data-brevwick-ready=1` on body inside its useEffect —
+    // waiting on it guarantees `window.__brevwickCapture` is bound before
+    // the spec calls into it.
+    await page.waitForFunction(
+      () => document.body.dataset.brevwickReady === '1',
+    );
+    // Give the layout one rAF to settle. Without this, the very first
+    // capture in CI occasionally lands while the tiles are still painting
+    // their backgrounds, producing partially-transparent pixel samples.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
+  });
+
+  /**
+   * Query the live tile centres from the page rather than hard-coding
+   * pixel coordinates. The fixture's grid is laid out by CSS, so any
+   * font / line-height / browser-version drift would shift the centres
+   * a few pixels and silently invalidate hard-coded samples. Asking
+   * Chromium for the actual `getBoundingClientRect` is one round-trip
+   * and removes a whole class of drift flake.
+   */
+  async function tileCentres(
+    page: Page,
+  ): Promise<Record<'red' | 'green' | 'blue', { x: number; y: number }>> {
+    return page.evaluate(() => {
+      const centre = (sel: string): { x: number; y: number } => {
+        const el = document.querySelector(sel);
+        if (!el) throw new Error(`fixture missing: ${sel}`);
+        const r = el.getBoundingClientRect();
+        return {
+          x: Math.round(r.left + r.width / 2),
+          y: Math.round(r.top + r.height / 2),
+        };
+      };
+      return {
+        red: centre('[data-testid="tile-red"]'),
+        green: centre('[data-testid="tile-green"]'),
+        blue: centre('[data-testid="tile-blue"]'),
+      };
+    });
+  }
+
+  test('default body capture produces non-blank pixels in known regions', async ({
+    page,
+  }) => {
+    const centres = await tileCentres(page);
+    const result: CaptureResult = await page.evaluate(() =>
+      window.__brevwickCapture!('body'),
+    );
+
+    expect(result.mime).toBe('image/webp');
+    // Cleared the placeholder by a wide margin — typical real captures of
+    // this fixture land in the tens-of-kB range. The exact lower bound is
+    // intentionally loose so font / Chromium-version drift doesn't cause
+    // flake; the meaningful gate is "not the 26-byte placeholder".
+    expect(result.size).toBeGreaterThan(PLACEHOLDER_BYTES * 10);
+
+    const decoded = await decodePixels(page, result.dataUrl, centres);
+
+    // Bitmap should at least cover the blue tile's right edge — if the
+    // capture clipped or fell back to the placeholder, the rasterised
+    // size would not span the live layout we just measured.
+    expect(decoded.width).toBeGreaterThanOrEqual(centres.blue.x);
+    expect(decoded.height).toBeGreaterThanOrEqual(centres.blue.y);
+
+    // Each tile should be saturated in its named channel and near-zero
+    // in the other two. WebP is lossy so we tolerate a per-channel
+    // wobble, but the *dominance* must be unambiguous.
+    expect(decoded.pixels.red!.r).toBeGreaterThan(200);
+    expect(decoded.pixels.red!.g).toBeLessThan(80);
+    expect(decoded.pixels.red!.b).toBeLessThan(80);
+
+    expect(decoded.pixels.green!.g).toBeGreaterThan(200);
+    expect(decoded.pixels.green!.r).toBeLessThan(80);
+    expect(decoded.pixels.green!.b).toBeLessThan(80);
+
+    expect(decoded.pixels.blue!.b).toBeGreaterThan(200);
+    expect(decoded.pixels.blue!.r).toBeLessThan(80);
+    expect(decoded.pixels.blue!.g).toBeLessThan(80);
+
+    // Every captured pixel should be fully opaque — a transparent / 0-alpha
+    // bitmap is the most common "blank screenshot" failure mode.
+    expect(decoded.pixels.red!.a).toBe(255);
+    expect(decoded.pixels.green!.a).toBe(255);
+    expect(decoded.pixels.blue!.a).toBe(255);
+  });
+
+  test('[data-brevwick-skip] elements do not appear in the captured pixels', async ({
+    page,
+  }) => {
+    // The fixture stacks a magenta (#ff00ff) [data-brevwick-skip] overlay
+    // *exactly* over the green tile (it's a child of the green tile with
+    // `position:absolute; inset:0`). If the SDK's skip elision breaks,
+    // that magenta dominates the green tile's centre sample. Asserting
+    // "centre is still green-dominant after capture" therefore doubles
+    // as an elision regression guard without a separate sentinel pixel.
+    const centres = await tileCentres(page);
+    const result: CaptureResult = await page.evaluate(() =>
+      window.__brevwickCapture!('body'),
+    );
+
+    const decoded = await decodePixels(page, result.dataUrl, {
+      overlayCentre: centres.green,
+    });
+
+    const px = decoded.pixels.overlayCentre!;
+    // Green tile underneath is #00ff00. Magenta overlay would be #ff00ff.
+    // Either the overlay was elided (we see green) or our skip contract
+    // is broken (we see magenta). Encode the green-dominant assertion
+    // explicitly so the failure message is meaningful.
+    const sampledRgba = `rgba(${px.r},${px.g},${px.b},${px.a})`;
+    expect(
+      px.g,
+      `overlay pixel was not elided: got ${sampledRgba}`,
+    ).toBeGreaterThan(200);
+    expect(
+      px.r,
+      `overlay pixel was not elided: got ${sampledRgba}`,
+    ).toBeLessThan(80);
+  });
+
+  test('locks regression: documentElement capture differs from body capture', async ({
+    page,
+  }) => {
+    // Why this test
+    // -------------
+    // PR #103 flipped the default capture root from `documentElement` to
+    // `document.body` because some Chromium builds rasterise `<html>`
+    // through a `<foreignObject>` that drops flow-content. The cheapest
+    // honest regression guard is "the two roots produce demonstrably
+    // different output". If a future refactor silently flips the default
+    // back, the body capture will start matching the documentElement
+    // capture and this test fires. We assert on size as the proxy:
+    // body-rooted capture of this fixture is in the tens-of-kB; the
+    // documentElement-rooted capture is either the placeholder (26 B) or
+    // a meaningfully smaller / blank artefact in the affected Chromium
+    // builds. Either case fails `bodyResult.size === documentElementResult.size`.
+    const bodyResult: CaptureResult = await page.evaluate(() =>
+      window.__brevwickCapture!('body'),
+    );
+    const docElResult: CaptureResult = await page.evaluate(() =>
+      window.__brevwickCapture!('documentElement'),
+    );
+
+    expect(bodyResult.size).toBeGreaterThan(PLACEHOLDER_BYTES * 10);
+    expect(
+      bodyResult.size,
+      `body and documentElement captures produced byte-identical output (${bodyResult.size} B); the default-root regression guard is no longer effective`,
+    ).not.toBe(docElResult.size);
+  });
+});

--- a/examples/next/src/app/screenshot-test/page.tsx
+++ b/examples/next/src/app/screenshot-test/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+/**
+ * Real-browser test fixture for `captureScreenshot()` (issue #104). Mounts
+ * deterministic, paint-stable DOM and exposes the SDK's top-level
+ * `captureScreenshot` on `window` so a Playwright spec can drive it without
+ * routing through a `BrevwickProvider` (which would force the spec to
+ * stand up a valid project key + endpoint just to render a button).
+ *
+ * The page is intentionally _not_ linked from the example app's home page —
+ * it exists only to be hit by `examples/next/e2e/screenshot.spec.ts`. Test
+ * fixture, not a user-facing demo. Lives under the example app rather than
+ * a standalone Vite shell because brevwick-web's recurring "blank
+ * screenshot" reports all originated from a Next.js host, and reproducing
+ * the failure mode against the same framework + version is the only honest
+ * way to lock the regression.
+ */
+
+import { useEffect, type ReactElement } from 'react';
+import { captureScreenshot } from '@tatlacas/brevwick-sdk';
+
+declare global {
+  interface Window {
+    /**
+     * Test bridge: Playwright calls this from `page.evaluate()`. Returns a
+     * data-URL of the captured WebP so we can shuttle the bytes across the
+     * Playwright RPC boundary as a string (Blob isn't structured-cloneable
+     * in `evaluate` results).
+     */
+    __brevwickCapture?: (
+      target?: 'body' | 'documentElement',
+    ) => Promise<{ dataUrl: string; size: number; mime: string }>;
+  }
+}
+
+export default function ScreenshotTestPage(): ReactElement {
+  useEffect(() => {
+    window.__brevwickCapture = async (target = 'body') => {
+      const element =
+        target === 'documentElement' ? document.documentElement : document.body;
+      const blob = await captureScreenshot({ element });
+      const dataUrl: string = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (): void => resolve(reader.result as string);
+        reader.onerror = (): void =>
+          reject(reader.error ?? new Error('FileReader error'));
+        reader.readAsDataURL(blob);
+      });
+      return { dataUrl, size: blob.size, mime: blob.type };
+    };
+    // Marker the spec waits on before invoking the bridge — guarantees the
+    // useEffect has run and `window.__brevwickCapture` is bound. Plain
+    // dataset attribute, no React state, so it survives a hot-reload that
+    // would otherwise re-mount the component mid-spec.
+    document.body.dataset.brevwickReady = '1';
+    return () => {
+      delete window.__brevwickCapture;
+      delete document.body.dataset.brevwickReady;
+    };
+  }, []);
+
+  return (
+    <main
+      data-testid="capture-root"
+      style={
+        {
+          // `:root`-scoped CSS custom properties resolve via getComputedStyle
+          // on body descendants — modern-screenshot reads them when
+          // rendering. Locking a known set here lets the spec compare
+          // pixels in known regions.
+          '--brand': '#ff3366',
+          '--ink': '#102040',
+          '--paper': '#fefcf7',
+          minHeight: '100vh',
+          background: 'var(--paper)',
+          color: 'var(--ink)',
+          fontFamily:
+            'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+          padding: '2rem',
+          margin: 0,
+        } as React.CSSProperties
+      }
+    >
+      <h1
+        data-testid="capture-title"
+        style={{
+          color: 'var(--brand)',
+          margin: 0,
+          marginBottom: '1rem',
+          fontSize: '3rem',
+        }}
+      >
+        Brevwick screenshot test
+      </h1>
+      {/*
+        Three solid coloured tiles at fixed positions. The spec samples
+        one pixel inside each tile and asserts the channel that the tile
+        is supposed to dominate is fully saturated — that's how we prove
+        modern-screenshot actually rasterized the DOM and didn't fall
+        back to a blank canvas.
+      */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 200px)',
+          gap: '1rem',
+          marginTop: '2rem',
+        }}
+      >
+        <div
+          data-testid="tile-red"
+          style={{
+            width: 200,
+            height: 200,
+            background: '#ff0000',
+          }}
+        />
+        <div
+          data-testid="tile-green"
+          style={{
+            width: 200,
+            height: 200,
+            background: '#00ff00',
+            // `position: relative` so the magenta `[data-brevwick-skip]`
+            // child below positions itself against the tile, not the
+            // viewport — keeps the elision sentinel pinned to the
+            // sample point regardless of layout drift.
+            position: 'relative',
+          }}
+        >
+          <div
+            data-brevwick-skip
+            data-testid="skip-sentinel"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background: '#ff00ff',
+            }}
+          />
+        </div>
+        <div
+          data-testid="tile-blue"
+          style={{
+            width: 200,
+            height: 200,
+            background: '#0000ff',
+          }}
+        />
+      </div>
+
+      {/*
+        Sentinel for the data-brevwick-skip elision contract. Positioned
+        as a child of the green tile (via the wrapping `position:
+        relative` on the tile) so it sits *exactly* over the green tile's
+        full area — no font / line-height arithmetic to drift on. The
+        spec asks the green tile for its bounding rect at runtime and
+        samples the centre, so if the SDK fails to elide this overlay,
+        the sample will be #ff00ff (magenta) instead of #00ff00 (green)
+        and the test fails with an unmistakable colour delta.
+      */}
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev:examples": "pnpm --parallel --filter \"./examples/*\" dev",
     "build:examples": "pnpm --filter \"./examples/*\" build",
     "size": "size-limit",
+    "test:e2e": "playwright test",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only",
     "release": "pnpm build && changeset publish"
@@ -26,6 +27,7 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@size-limit/file": "^12.1.0",
     "@size-limit/preset-small-lib": "^12.1.0",
     "@types/node": "^25.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,57 @@
+/**
+ * Playwright config for the real-browser screenshot regression suite
+ * (issue #104). Drives `examples/next` against Chromium and asserts that
+ * `captureScreenshot()` actually rasterises pixels from the live DOM —
+ * the property the happy-dom-based unit tests cannot prove because
+ * happy-dom's `<canvas>` returns no 2D context.
+ *
+ * Wired only into the `e2e` script in this repo's root `package.json`,
+ * not into `pnpm test:cover`, so the default test matrix stays fast and
+ * does not require Chromium binaries.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 3100;
+
+export default defineConfig({
+  testDir: './e2e',
+  // Single project — the regression we're locking is purely a Chromium
+  // rasterisation bug. Adding WebKit / Firefox here would test
+  // modern-screenshot, not our consumption of it, and would force the
+  // CI lane to install three browser engines for ~zero additional signal.
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  // Build + start the example, NOT `next dev`. Two reasons:
+  //  1) The bug under test is a Chromium rasterisation issue against the
+  //     compiled bundle the user actually ships — the dev bundle goes
+  //     through Turbopack's HMR runtime, which adds layers (suspense
+  //     boundaries, error overlays) that are NOT present in production.
+  //     A "passes in dev / fails in prod" outcome is the exact failure
+  //     mode this suite exists to prevent.
+  //  2) Next 16 + Turbopack dev mode currently does not hydrate cleanly
+  //     in CI-style headless Chromium runs (HMR websocket handshake
+  //     fails, `useEffect` never runs, `window.__brevwickCapture` never
+  //     binds). `next build && next start` sidesteps the whole HMR layer.
+  // Port 3100 chosen to dodge the example app's default 3000 in case a
+  // contributor has it running.
+  webServer: {
+    command: `pnpm --filter brevwick-example-next exec next start --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}/screenshot-test`,
+    reuseExistingServer: !process.env.CI,
+    // The build is the slow step; `next start` itself is sub-second once
+    // the build is cached. CI runs `next build` separately before the
+    // suite (see `.github/workflows/playwright.yml`), so this timeout
+    // only covers `next start`'s socket warmup.
+    timeout: 60_000,
+  },
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    // No traces in green CI — only on retry. Failed runs upload to the
+    // workflow artifact bundle for triage.
+    trace: 'on-first-retry',
+  },
+  reporter: process.env.CI ? 'github' : 'list',
+  // Two retries on CI, none locally — local failures should be debugged,
+  // not papered over. CI flake is usually Chromium / dev-server cold-start
+  // jitter, both of which actually retry-clear.
+  retries: process.env.CI ? 2 : 0,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.39.4(jiti@2.6.1))
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@size-limit/file':
         specifier: ^12.1.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
@@ -199,7 +202,7 @@ importers:
         version: link:../../packages/sdk
       next:
         specifier: ^16.0.0
-        version: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0)
+        version: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0)
       react:
         specifier: ^19.2.4
         version: 19.2.5
@@ -2952,7 +2955,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -3770,6 +3773,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
@@ -8256,6 +8264,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -11247,6 +11260,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -19033,6 +19056,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@4.15.1(webpack@5.94.0(esbuild@0.27.7)))(webpack@5.94.0(esbuild@0.27.7))':
     dependencies:
       ansi-html: 0.0.9
@@ -24766,6 +24793,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -28113,7 +28143,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0):
+  next@16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.99.0):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -28132,6 +28162,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.3
       '@next/swc-win32-arm64-msvc': 16.2.3
       '@next/swc-win32-x64-msvc': 16.2.3
+      '@playwright/test': 1.59.1
       sass: 1.99.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -28922,6 +28953,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:


### PR DESCRIPTION
Closes #104.

## Summary

The SDK unit suite runs under happy-dom, whose `<canvas>` returns no 2D context. `modern-screenshot`'s rasterisation step always throws there and the SDK falls back to its 26-byte placeholder WebP. That means the unit tests cannot prove that real Chromium paints non-blank pixels for the default body capture path — the exact failure mode that drove PR #103 (default-root flip from `documentElement` → `body`) and the third "blank screenshot" report in brevwick-web #254.

This PR adds a Playwright lane that drives the live DOM against Chromium and asserts:

1. **Non-blank capture.** `captureScreenshot()` (default `body`) returns a > 26-byte WebP whose decoded bitmap is dominantly red / green / blue at the centres of three solid-colour test tiles. Centres are queried from the live `getBoundingClientRect()` so font / layout drift can't silently invalidate hard-coded samples.
2. **Skip elision.** A magenta `[data-brevwick-skip]` overlay sitting *exactly* over the green tile (absolute child of the tile, `inset: 0`) is elided — the green sample remains green-dominant. If the SDK fails to elide, the sample comes back magenta and the test fails with an unmistakable colour delta.
3. **Default-root regression lock.** `{ element: document.documentElement }` capture is asserted to differ in size from the `body` capture. If a future refactor silently flips the default back to `documentElement`, body-rooted output will start matching docElement-rooted output and this test fires.

## Notes

- **`next start`, not `next dev`.** Two reasons captured in `playwright.config.ts`: (a) the bug under test is a Chromium rasterisation issue against the bundle users actually ship — dev mode adds Turbopack HMR layers that aren't present in production, so a "passes in dev / fails in prod" outcome is the failure mode this lane exists to prevent. (b) Next 16 + Turbopack dev mode currently does not hydrate cleanly in headless Chromium runs (HMR websocket handshake fails, `useEffect` never runs, `window.__brevwickCapture` never binds). `next build && next start` sidesteps the whole HMR layer.
- **Test fixture is unlinked.** `examples/next/src/app/screenshot-test/page.tsx` exists only for the spec. It exposes `window.__brevwickCapture(target)` so the spec can call the SDK from page context without standing up a `BrevwickProvider` (which would force the spec to ship a valid project key + endpoint).
- **CI lane is separate from `ci.yml`.** New `.github/workflows/playwright.yml` is path-filtered to `packages/sdk/**`, `examples/next/**`, `e2e/**`, and the workflow / config files themselves — no Chromium download on a docs-only PR. Playwright browsers are cached across runs.
- **No published-package impact.** `@playwright/test` is a devDependency at the workspace root only; no `packages/**` files change in this PR (so `changeset-check` correctly stays silent — no version bump required).

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check` (clean after building `@tatlacas/brevwick-react-native` for the example app — pre-existing dep, unrelated)
- [x] `pnpm --filter @tatlacas/brevwick-sdk build && pnpm --filter @tatlacas/brevwick-react build && pnpm --filter brevwick-example-next exec next build`
- [x] `pnpm test:e2e` — 3/3 passing in 3.1 s wall time against real Chromium (after build)