### PR TITLE
feat(angular): widget UX parity with React adapter

### DIFF
--- a/.changeset/angular-widget-parity.md
+++ b/.changeset/angular-widget-parity.md
@@ -1,0 +1,5 @@
+---
+'@tatlacas/brevwick-angular': minor
+---
+
+Bring `<bw-feedback-button>` to UX parity with the React adapter (#115). The standalone component now renders the chat-thread panel (assistant + user bubbles, receipt with relative-time), expected-vs-actual disclosure, phase-driven status rows, retry row, discard-confirm flow, AI toggle render-policy matrix, autogrow composer, and minimize button. `BrevwickService` is extended with `phase`, `error`, `retry`, `getConfig` Signals subscribed via a new `phase-bus.ts`. Component uses `ViewEncapsulation.None` so the canonical `BREVWICK_CSS` rules apply. Bundle budget bumped 8 kB → 18 kB.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -172,18 +172,24 @@ export default [
     '14 kB',
   ),
 
-  // ── Angular bundle (≤ 8 kB gzip) ─────────────────────────────────────────
+  // ── Angular bundle (≤ 18 kB gzip) ────────────────────────────────────────
   // Angular adapter ships only one artefact per Angular Package Format: the
   // FESM2022 flat-ESM bundle. ng-packagr does not emit a CJS counterpart for
   // libraries (CJS apps consume Angular via @angular/upgrade or stay on the
   // older legacy package format — neither is a target of this adapter).
-  // 8 kB gzip envelope is intentionally roomier than React/Vue/Svelte/Solid
-  // because Angular's @Injectable / standalone-component / Signals scaffolding
-  // costs 4-5 kB of irreducible runtime overhead before our own code lands.
+  //
+  // Bumped from 8 kB → 18 kB when the widget reached UX parity with the
+  // React adapter (issue #115): the FAB-only build was 5.21 kB; the full
+  // chat-style panel + composer + AI toggle + phase-driven status rows +
+  // inlined BREVWICK_CSS lands at ~15.5 kB. The ceiling is intentionally
+  // roomier than React/Vue/Svelte/Solid because Angular's @Injectable /
+  // standalone-component / Signals scaffolding costs 4-5 kB of irreducible
+  // runtime overhead before our own code lands; 18 kB stays well under
+  // React's 25 kB envelope (no Radix dialog dependency saves ~7 kB).
   fileEntry(
     '@tatlacas/brevwick-angular (FESM2022)',
     'packages/angular/dist/fesm2022/tatlacas-brevwick-angular.mjs',
-    '8 kB',
+    '18 kB',
   ),
 
   // ── React Native bundle (≤ 25 kB gzip) ───────────────────────────────────

--- a/examples/angular/.env.example
+++ b/examples/angular/.env.example
@@ -1,6 +1,0 @@
-# Angular CLI does not read .env files natively. The values below are
-# provided as a single source of truth for local-development variables;
-# copy them into src/environments/environment.ts (replacing the
-# placeholders) before running `pnpm --filter brevwick-example-angular start`.
-BREVWICK_PROJECT_KEY=pk_test_replace_me
-BREVWICK_ENDPOINT=http://localhost:8080

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -14,7 +14,7 @@ Open http://localhost:4200. The Feedback FAB pins to the bottom-right.
 
 ## Configure your project key
 
-Edit `src/environments/environment.ts` (and `environment.prod.ts` for production builds) and replace `pk_test_demo` with your real key from https://brevwick.com.
+Edit `src/environments/environment.ts` (and `environment.prod.ts` for production builds) and replace `pk_test_demo` with your real key from https://brevwick.dev.
 
 Angular doesn't ship a built-in `import.meta.env`-style env-var mechanism for app code, so the environment files plus the `fileReplacements` block in `angular.json` are the canonical pattern.
 

--- a/examples/angular/angular.json
+++ b/examples/angular/angular.json
@@ -55,5 +55,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/packages/angular/src/lib/__tests__/brevwick.service.spec.ts
+++ b/packages/angular/src/lib/__tests__/brevwick.service.spec.ts
@@ -274,4 +274,54 @@ describe('BrevwickService', () => {
     TestBed.resetTestingModule();
     expect(uninstall).toHaveBeenCalledTimes(1);
   });
+
+  it('phase listener no-ops once the destroy hook has fired', () => {
+    // Custom bus: off does NOT actually drop the listener, letting us
+    // emit after destroy to prove the in-handler `destroyed` guard kicks in.
+    let capturedListener: ((payload: unknown) => void) | null = null;
+    const offFn = vi.fn();
+    const customInstance = {
+      install,
+      uninstall,
+      submit,
+      captureScreenshot,
+      getConfig,
+      _internal: {
+        bus: {
+          on: (_: string, l: (payload: unknown) => void) => {
+            capturedListener = l;
+          },
+          off: offFn,
+        },
+      },
+    } as unknown as Brevwick;
+    createBrevwick.mockReturnValueOnce(customInstance);
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_phase_destroyed' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    expect(capturedListener).not.toBeNull();
+    TestBed.resetTestingModule();
+    expect(offFn).toHaveBeenCalledTimes(1);
+    // The captured reference is still live in the test even though `off`
+    // ran — invoking it must hit the guard and leave phase at idle.
+    capturedListener!({ phase: 'capturing-done' });
+    expect(service.phase()).toBe('idle');
+  });
+
+  it('submit error message uses String() coercion for non-Error rejections', async () => {
+    submit.mockRejectedValueOnce('plain string failure');
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_string_throw' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    await expect(service.submit({ description: 'x' })).rejects.toBe(
+      'plain string failure',
+    );
+    expect(service.status()).toBe('error');
+    expect(service.error()).toEqual({
+      code: 'INGEST_RETRY_EXHAUSTED',
+      message: 'plain string failure',
+    });
+  });
 });

--- a/packages/angular/src/lib/__tests__/brevwick.service.spec.ts
+++ b/packages/angular/src/lib/__tests__/brevwick.service.spec.ts
@@ -27,14 +27,28 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
 import { BrevwickService } from '../brevwick.service';
 import { provideBrevwick } from '../provide-brevwick';
 
-const makeInstance = (): Brevwick =>
-  ({
+/**
+ * Builds a structurally-complete `Brevwick` mock. The phase-bus listener the
+ * service subscribes to needs `_internal.bus.on/off` to exist; otherwise the
+ * service silently skips subscription. Tests that don't drive phase events
+ * still benefit from a no-op bus so the registration path is exercised.
+ */
+const makeInstance = (): Brevwick => {
+  const listeners = new Set<(payload: unknown) => void>();
+  const bus = {
+    on: (_: string, l: (payload: unknown) => void) => listeners.add(l),
+    off: (_: string, l: (payload: unknown) => void) => listeners.delete(l),
+    emit: (payload: unknown) => listeners.forEach((l) => l(payload)),
+  };
+  return {
     install,
     uninstall,
     submit,
     captureScreenshot,
     getConfig,
-  }) as unknown as Brevwick;
+    _internal: { bus },
+  } as unknown as Brevwick;
+};
 
 beforeEach(() => {
   // Clear in beforeEach (not afterEach) so the setup-file's afterEach hook,
@@ -158,6 +172,96 @@ describe('BrevwickService', () => {
     const blob = await service.captureScreenshot();
     expect(captureScreenshot).toHaveBeenCalledTimes(1);
     expect(blob).toBeInstanceOf(Blob);
+  });
+
+  it('phase advances on internal bus events and resets back to idle', () => {
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_phase' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    expect(service.phase()).toBe('idle');
+    const sdk = createBrevwick.mock.results[0]!.value as unknown as {
+      _internal: { bus: { emit: (payload: unknown) => void } };
+    };
+    sdk._internal.bus.emit({ phase: 'capturing-done' });
+    expect(service.phase()).toBe('sanitising');
+    sdk._internal.bus.emit({ phase: 'sanitising-done' });
+    expect(service.phase()).toBe('formatting');
+    service.reset();
+    expect(service.phase()).toBe('idle');
+    expect(service.error()).toBeNull();
+  });
+
+  it('error signal carries the SubmitError after a failed submit', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'rejected' },
+    });
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_err_signal' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    await service.submit({ description: 'oops' });
+    expect(service.error()).toEqual({
+      code: 'INGEST_REJECTED',
+      message: 'rejected',
+    });
+    expect(service.phase()).toBe('error');
+  });
+
+  it('retry replays the last submit with the same input', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'first' },
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'r2' });
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_retry_svc' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    const input = { description: 'replay me' } as const;
+    await service.submit(input);
+    const second = await service.retry();
+    expect(second).toEqual({ ok: true, issue_id: 'r2' });
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit.mock.calls[1]![0]).toEqual(input);
+  });
+
+  it('retry resolves to undefined when no submit has been attempted', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_retry_none' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    await expect(service.retry()).resolves.toBeUndefined();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('getConfig delegates to the SDK in browser context', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    TestBed.configureTestingModule({
+      providers: [provideBrevwick({ projectKey: 'pk_test_cfg' })],
+    });
+    const service = TestBed.inject(BrevwickService);
+    await expect(service.getConfig()).resolves.toEqual({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('getConfig returns null on non-browser PLATFORM_ID', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideBrevwick({ projectKey: 'pk_test_cfg_ssr' }),
+        { provide: PLATFORM_ID, useValue: 'server' },
+      ],
+    });
+    const service = TestBed.inject(BrevwickService);
+    await expect(service.getConfig()).resolves.toBeNull();
+    expect(getConfig).not.toHaveBeenCalled();
   });
 
   it('uninstalls the SDK when the root injector is destroyed', () => {

--- a/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
+++ b/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   Brevwick,
   BrevwickConfig,
+  ProjectConfig,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
 
@@ -26,21 +27,66 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
 import { BwFeedbackButtonComponent } from '../components/feedback-button.component';
 import { provideBrevwick } from '../provide-brevwick';
 
-const makeInstance = (): Brevwick =>
-  ({
+/**
+ * Builds a structurally-complete `Brevwick` mock. The phase-bus listener the
+ * service registers needs `_internal.bus.on/off` to exist; otherwise the
+ * service silently skips subscription. Tests that don't drive phase events
+ * still benefit from a no-op bus so the registration path is exercised.
+ */
+const makeInstance = (): Brevwick => {
+  const listeners = new Set<(payload: unknown) => void>();
+  const bus = {
+    on: (_: string, l: (payload: unknown) => void) => listeners.add(l),
+    off: (_: string, l: (payload: unknown) => void) => listeners.delete(l),
+    emit: (payload: unknown) => listeners.forEach((l) => l(payload)),
+  };
+  return {
     install,
     uninstall,
     submit,
     captureScreenshot,
     getConfig,
-  }) as unknown as Brevwick;
+    _internal: { bus },
+  } as unknown as Brevwick;
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
   createBrevwick.mockReturnValue(makeInstance());
+  // Default: no project config — AI toggle stays hidden across the suite.
+  // Tests that need the toggle override this with their own resolved value.
+  getConfig.mockResolvedValue(null);
 });
 
+/**
+ * Internal-shape escape hatch used by the tests. Mirrors the canonical
+ * Angular pattern of casting through a narrow interface to drive
+ * `protected` signals — keeps the component's public surface honest while
+ * letting specs poke at the state without simulating every DOM event.
+ */
+interface ComponentInternals {
+  open: { set: (v: boolean) => void };
+  draft: { set: (v: string) => void };
+  expected: { set: (v: string) => void };
+  actual: { set: (v: string) => void };
+  showExtras: { set: (v: boolean) => void };
+  files: { set: (v: ReadonlyArray<{ id: number; file: File }>) => void };
+  projectConfig: {
+    set: (v: { status: string; config: ProjectConfig | null }) => void;
+  };
+  reducedMotion: { set: (v: boolean) => void };
+  useAi: { set: (v: boolean) => void };
+  doSubmit: () => Promise<void>;
+  onRetryClick: () => Promise<void>;
+  toggleAi: () => void;
+}
+
+const internals = (cmp: BwFeedbackButtonComponent): ComponentInternals =>
+  cmp as unknown as ComponentInternals;
+
 describe('BwFeedbackButtonComponent', () => {
+  // ── Render gates ─────────────────────────────────────────────────────────
+
   it('renders a FAB on first paint with the default label', () => {
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
@@ -49,10 +95,10 @@ describe('BwFeedbackButtonComponent', () => {
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
     const button = fixture.nativeElement.querySelector(
-      'button.bw-fab',
+      'button.brw-fab',
     ) as HTMLButtonElement | null;
     expect(button).not.toBeNull();
-    expect(button?.textContent?.trim()).toBe('Feedback');
+    expect(button?.textContent?.trim()).toContain('Feedback');
   });
 
   it('renders nothing when [hidden] is set', () => {
@@ -63,31 +109,106 @@ describe('BwFeedbackButtonComponent', () => {
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.componentRef.setInput('hidden', true);
     fixture.detectChanges();
-    const button = fixture.nativeElement.querySelector('button.bw-fab');
-    expect(button).toBeNull();
+    expect(fixture.nativeElement.querySelector('button.brw-fab')).toBeNull();
   });
 
-  it('opens a panel when the FAB is clicked', () => {
+  it('forwards the theme input to data-brw-theme on FAB and panel', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_theme' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.componentRef.setInput('theme', 'dark');
+    fixture.detectChanges();
+    const fab = fixture.nativeElement.querySelector(
+      'button.brw-fab',
+    ) as HTMLButtonElement;
+    expect(fab.getAttribute('data-brw-theme')).toBe('dark');
+    fab.click();
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.brw-panel');
+    expect(panel?.getAttribute('data-brw-theme')).toBe('dark');
+  });
+
+  // ── Open / minimize / discard ────────────────────────────────────────────
+
+  it('opens the panel + greeting bubble when the FAB is clicked', () => {
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_open' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
-    const fab = fixture.nativeElement.querySelector(
-      'button.bw-fab',
-    ) as HTMLButtonElement;
-    fab.click();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
     fixture.detectChanges();
-    const panel = fixture.nativeElement.querySelector('.bw-panel');
+    const panel = fixture.nativeElement.querySelector('.brw-panel');
     expect(panel).not.toBeNull();
-    const textarea = fixture.nativeElement.querySelector(
-      'textarea.bw-input',
-    ) as HTMLTextAreaElement;
-    expect(textarea).not.toBeNull();
+    const greeting = fixture.nativeElement.querySelector(
+      '.brw-bubble--assistant',
+    );
+    expect(greeting?.textContent).toContain('Tell us');
+    const composer = fixture.nativeElement.querySelector('.brw-composer-input');
+    expect(composer).not.toBeNull();
   });
 
-  it('submit button stays disabled while the draft is empty', () => {
+  it('shows discard confirm when the user closes a panel with content', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_discard' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('half-typed');
+    fixture.detectChanges();
+    const closeBtn = fixture.nativeElement.querySelector(
+      '.brw-icon-btn[aria-label="Close"]',
+    ) as HTMLButtonElement;
+    closeBtn.click();
+    fixture.detectChanges();
+    const confirm = fixture.nativeElement.querySelector('.brw-confirm');
+    expect(confirm).not.toBeNull();
+    expect(confirm?.textContent).toContain('Discard your feedback');
+  });
+
+  it('keeps draft + closes panel when the user clicks Minimize', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_minimize' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('keep me');
+    fixture.detectChanges();
+    const minBtn = fixture.nativeElement.querySelector(
+      '.brw-icon-btn[aria-label="Minimize"]',
+    ) as HTMLButtonElement;
+    minBtn.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).toBeNull();
+    // Re-open: draft should still be there.
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+    expect(composer.value).toBe('keep me');
+  });
+
+  // ── Composer state + canSend ─────────────────────────────────────────────
+
+  it('send button stays disabled while the draft is empty', () => {
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_disabled' })],
@@ -95,16 +216,50 @@ describe('BwFeedbackButtonComponent', () => {
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
     (
-      fixture.nativeElement.querySelector('button.bw-fab') as HTMLButtonElement
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
     ).click();
     fixture.detectChanges();
-    const sendBtn = fixture.nativeElement.querySelector(
-      'button.bw-btn--primary',
+    const send = fixture.nativeElement.querySelector(
+      '.brw-send-btn',
     ) as HTMLButtonElement;
-    expect(sendBtn.disabled).toBe(true);
+    expect(send.disabled).toBe(true);
   });
 
-  it('submit() emits the SubmitResult and clears the draft on success', async () => {
+  it('Enter triggers submit; Shift+Enter does not', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'kbd-1' });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_enter' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('hello world');
+    fixture.detectChanges();
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+
+    // Shift+Enter is not consumed — does not call submit.
+    composer.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true }),
+    );
+    expect(submit).not.toHaveBeenCalled();
+
+    // Plain Enter — submit fires.
+    composer.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    // Yield for the async submit chain to flush before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Submit semantics: title/description split + raw body fix ─────────────
+
+  it('submit derives title from first line and sends raw description (PR #111)', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'cmp-1' });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
@@ -115,50 +270,275 @@ describe('BwFeedbackButtonComponent', () => {
     const cmp = fixture.componentInstance;
     const events: unknown[] = [];
     cmp.submit.subscribe((e) => events.push(e));
-
-    // Open + drive the draft signal directly, then invoke the protected
-    // submit handler. Casting through a narrow test-only interface is the
-    // canonical Angular-test escape hatch for protected members — the
-    // specs use the same pattern to seed the `draft` signal.
-    const internals = cmp as unknown as {
-      draft: { set: (v: string) => void };
-      onSubmitClick: () => Promise<void>;
-    };
-    internals.draft.set('A bug');
-    await internals.onSubmitClick();
-
+    // Leading whitespace + multi-line: title is the first non-empty line
+    // trimmed; description is the **raw** draft (PR #111 contract).
+    const raw = '  Bug header\n\n   indented body\nline 3   ';
+    internals(cmp).draft.set(raw);
+    await internals(cmp).doSubmit();
     expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0]![0]).toMatchObject({
-      title: 'A bug',
-      description: 'A bug',
+      title: 'Bug header',
+      description: raw,
     });
     expect(events).toEqual([{ ok: true, issue_id: 'cmp-1' }]);
   });
 
-  it('surfaces the SDK error message when submit fails', async () => {
-    submit.mockResolvedValueOnce({
-      ok: false,
-      error: { code: 'INGEST_REJECTED', message: 'Quota exceeded' },
-    });
+  it('rolls expected/actual + files into the payload', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'cmp-extra' });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
-      providers: [provideBrevwick({ projectKey: 'pk_test_err' })],
+      providers: [provideBrevwick({ projectKey: 'pk_test_extra' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
     const cmp = fixture.componentInstance;
-    const internals = cmp as unknown as {
-      draft: { set: (v: string) => void };
-      open: { set: (v: boolean) => void };
-      onSubmitClick: () => Promise<void>;
-    };
-    internals.draft.set('broken');
-    internals.open.set(true);
-    await internals.onSubmitClick();
-    fixture.detectChanges();
-    const err = fixture.nativeElement.querySelector('.bw-error');
-    expect(err?.textContent?.trim()).toBe('Quota exceeded');
+    const file = new File(['hello'], 'log.txt', { type: 'text/plain' });
+    internals(cmp).draft.set('A bug');
+    internals(cmp).expected.set('it works');
+    internals(cmp).actual.set('it crashes');
+    internals(cmp).files.set([{ id: 1, file }]);
+    await internals(cmp).doSubmit();
+    expect(submit).toHaveBeenCalledTimes(1);
+    const payload = submit.mock.calls[0]![0] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      title: 'A bug',
+      description: 'A bug',
+      expected: 'it works',
+      actual: 'it crashes',
+    });
+    expect(Array.isArray(payload['attachments'])).toBe(true);
+    expect((payload['attachments'] as unknown[]).length).toBe(1);
   });
+
+  it('clears composer + appends user + assistant bubbles on success', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'success-1' });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_success' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('the bug');
+    await internals(cmp).doSubmit();
+    fixture.detectChanges();
+    const userBubble = fixture.nativeElement.querySelector(
+      '.brw-bubble--user',
+    ) as HTMLElement;
+    expect(userBubble.textContent?.trim()).toBe('the bug');
+    const assistantBubbles = fixture.nativeElement.querySelectorAll(
+      '.brw-bubble--assistant',
+    );
+    // Greeting + receipt = 2 assistant bubbles.
+    expect(assistantBubbles.length).toBe(2);
+    const receipt = fixture.nativeElement.querySelector('.brw-bubble--receipt');
+    expect(receipt?.textContent).toContain('Issue sent');
+    // Composer cleared.
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+    expect(composer.value).toBe('');
+  });
+
+  // ── Retry contract ───────────────────────────────────────────────────────
+
+  it('retry replays the last submitted input', async () => {
+    // First call fails; second (retry) succeeds.
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'first failed' },
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'retry-ok' });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_retry' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).draft.set('original');
+    await internals(cmp).doSubmit();
+    fixture.detectChanges();
+    const retryRow = fixture.nativeElement.querySelector(
+      '[data-brw-row="error"]',
+    ) as HTMLElement;
+    expect(retryRow).not.toBeNull();
+    expect(retryRow.getAttribute('data-brw-error-code')).toBe(
+      'INGEST_REJECTED',
+    );
+    await internals(cmp).onRetryClick();
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit.mock.calls[1]![0]).toEqual(submit.mock.calls[0]![0]);
+  });
+
+  // ── AI-toggle render policy matrix ───────────────────────────────────────
+
+  it('AI toggle stays hidden when project config is not ready', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_no_ai' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-aitoggle')).toBeNull();
+  });
+
+  it('AI toggle renders when ai_enabled + ai_submitter_choice_allowed are true', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_ai_on' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).projectConfig.set({
+      status: 'ready',
+      config: { ai_enabled: true, ai_submitter_choice_allowed: true },
+    });
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const toggle = fixture.nativeElement.querySelector(
+      '.brw-aitoggle',
+    ) as HTMLButtonElement | null;
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('AI toggle hidden when admin disabled submitter choice', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_ai_forced' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).projectConfig.set({
+      status: 'ready',
+      config: { ai_enabled: true, ai_submitter_choice_allowed: false },
+    });
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-aitoggle')).toBeNull();
+  });
+
+  it('use_ai is included in the payload only when the toggle is shown', async () => {
+    submit.mockResolvedValue({ ok: true, issue_id: 'ai-p' });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_ai_payload' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    // Toggle visible: payload carries use_ai.
+    internals(cmp).projectConfig.set({
+      status: 'ready',
+      config: { ai_enabled: true, ai_submitter_choice_allowed: true },
+    });
+    internals(cmp).draft.set('with ai');
+    internals(cmp).useAi.set(false);
+    await internals(cmp).doSubmit();
+    expect(submit.mock.calls[0]![0]).toMatchObject({ use_ai: false });
+    // Toggle hidden again: no use_ai key on the next submit.
+    internals(cmp).projectConfig.set({ status: 'idle', config: null });
+    internals(cmp).draft.set('without ai');
+    await internals(cmp).doSubmit();
+    expect(submit.mock.calls[1]![0]).not.toHaveProperty('use_ai');
+  });
+
+  // ── Phase-driven status rows ─────────────────────────────────────────────
+
+  it('renders the captured status row from the sanitising phase onwards', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_phase' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    // Reach the SDK's internal bus through the mock and emit the phase
+    // events the React adapter would react to. The service translates
+    // each event into a phase signal change which drives the rows.
+    const sdk = createBrevwick.mock.results[0]!.value as unknown as {
+      _internal: { bus: { emit: (payload: unknown) => void } };
+    };
+    sdk._internal.bus.emit({ phase: 'capturing-done' });
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('[data-brw-row="captured"]'),
+    ).not.toBeNull();
+    sdk._internal.bus.emit({ phase: 'sanitising-done' });
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('[data-brw-row="sanitised"]'),
+    ).not.toBeNull();
+    void cmp;
+  });
+
+  it('formatting row shows only when AI is enabled', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_fmt' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).projectConfig.set({
+      status: 'ready',
+      config: { ai_enabled: true, ai_submitter_choice_allowed: false },
+    });
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    const sdk = createBrevwick.mock.results[0]!.value as unknown as {
+      _internal: { bus: { emit: (payload: unknown) => void } };
+    };
+    sdk._internal.bus.emit({ phase: 'sanitising-done' });
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('[data-brw-row="formatting"]'),
+    ).not.toBeNull();
+  });
+
+  it('reduced-motion collapses the row stagger to 0 ms', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_rm' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).reducedMotion.set(true);
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    const sdk = createBrevwick.mock.results[0]!.value as unknown as {
+      _internal: { bus: { emit: (payload: unknown) => void } };
+    };
+    sdk._internal.bus.emit({ phase: 'sanitising-done' });
+    fixture.detectChanges();
+    const row = fixture.nativeElement.querySelector(
+      '[data-brw-row="sanitised"]',
+    ) as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.style.transitionDelay).toBe('0ms');
+  });
+
+  // ── Async safety ─────────────────────────────────────────────────────────
 
   it('does not emit submit on a destroyed view', async () => {
     let resolve!: (value: SubmitResult) => void;
@@ -167,24 +547,340 @@ describe('BwFeedbackButtonComponent', () => {
     );
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
-      providers: [provideBrevwick({ projectKey: 'pk_test_destroy_emit' })],
+      providers: [provideBrevwick({ projectKey: 'pk_test_destroy' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
     const cmp = fixture.componentInstance;
     const events: unknown[] = [];
     cmp.submit.subscribe((e) => events.push(e));
-
-    const internals = cmp as unknown as {
-      draft: { set: (v: string) => void };
-      onSubmitClick: () => Promise<void>;
-    };
-    internals.draft.set('hello');
-    const inflight = internals.onSubmitClick();
+    internals(cmp).draft.set('inflight');
+    const inflight = internals(cmp).doSubmit();
     fixture.destroy();
     resolve({ ok: true, issue_id: 'late' });
     await inflight;
-
     expect(events).toEqual([]);
+  });
+
+  // ── File attach cap ──────────────────────────────────────────────────────
+
+  it('attachment chip + file cap disables the file button at MAX_ATTACHMENTS', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_cap' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).files.set([
+      { id: 1, file: new File(['a'], '1.txt') },
+      { id: 2, file: new File(['a'], '2.txt') },
+      { id: 3, file: new File(['a'], '3.txt') },
+      { id: 4, file: new File(['a'], '4.txt') },
+      { id: 5, file: new File(['a'], '5.txt') },
+    ]);
+    fixture.detectChanges();
+    const chips = fixture.nativeElement.querySelectorAll('.brw-chip');
+    expect(chips.length).toBe(5);
+    const fileInput = fixture.nativeElement.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(fileInput.disabled).toBe(true);
+    expect(fileInput.getAttribute('aria-label')).toContain('Maximum 5');
+  });
+
+  // ── Composer events ──────────────────────────────────────────────────────
+
+  it('typing into the composer mutates the draft signal and unlocks Send', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_typing' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+    const send = fixture.nativeElement.querySelector(
+      '.brw-send-btn',
+    ) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+    composer.value = 'live typing';
+    composer.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(send.disabled).toBe(false);
+  });
+
+  it('Send button click triggers a submit', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'send-click' });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_send_click' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('clicked submit');
+    fixture.detectChanges();
+    const sendBtn = fixture.nativeElement.querySelector(
+      '.brw-send-btn',
+    ) as HTMLButtonElement;
+    sendBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Discard / cancel-close paths ─────────────────────────────────────────
+
+  it('cancel button on discard confirm preserves the draft', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_cancel' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('keep this');
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector(
+        '.brw-icon-btn[aria-label="Close"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    // The "Keep" button is the first .brw-btn (non-primary) in the confirm.
+    const keep = fixture.nativeElement.querySelector(
+      '.brw-confirm .brw-btn:not(.brw-btn-primary)',
+    ) as HTMLButtonElement;
+    keep.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-confirm')).toBeNull();
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+    expect(composer.value).toBe('keep this');
+  });
+
+  it('Discard button on confirm clears state and closes the panel', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_discard_btn' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('toss me');
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector(
+        '.brw-icon-btn[aria-label="Close"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const discard = fixture.nativeElement.querySelector(
+      '.brw-confirm .brw-btn-primary',
+    ) as HTMLButtonElement;
+    discard.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).toBeNull();
+    // Re-open: draft should be empty.
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const composer = fixture.nativeElement.querySelector(
+      '.brw-composer-input',
+    ) as HTMLTextAreaElement;
+    expect(composer.value).toBe('');
+  });
+
+  it('close on an empty panel skips the discard confirm', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_close_empty' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector(
+        '.brw-icon-btn[aria-label="Close"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).toBeNull();
+  });
+
+  // ── Disclosure toggle ────────────────────────────────────────────────────
+
+  it('toggling the disclosure reveals expected/actual textareas', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_disc' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const trigger = fixture.nativeElement.querySelector(
+      '.brw-disclosure',
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    trigger.click();
+    fixture.detectChanges();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    const inputs = fixture.nativeElement.querySelectorAll(
+      '.brw-disclosure-input',
+    );
+    expect(inputs.length).toBe(2);
+  });
+
+  // ── File events: input change + remove chip ──────────────────────────────
+
+  it('file input change appends file chips up to the cap', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_file_change' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const input = fixture.nativeElement.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(['x'], 'attached.txt', { type: 'text/plain' });
+    Object.defineProperty(input, 'files', {
+      value: {
+        length: 1,
+        item: (i: number) => (i === 0 ? file : null),
+        0: file,
+      } as unknown as FileList,
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    const chips = fixture.nativeElement.querySelectorAll('.brw-chip');
+    expect(chips.length).toBe(1);
+  });
+
+  it('removing a chip drops it from the list', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_remove_chip' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).files.set([
+      { id: 1, file: new File(['x'], 'a.txt') },
+      { id: 2, file: new File(['x'], 'b.txt') },
+    ]);
+    fixture.detectChanges();
+    const removes = fixture.nativeElement.querySelectorAll('.brw-chip-remove');
+    expect(removes.length).toBe(2);
+    (removes[0] as HTMLButtonElement).click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('.brw-chip').length).toBe(1);
+  });
+
+  // ── AI toggle keyboard activation ────────────────────────────────────────
+
+  it('Space on the AI toggle flips the signal; other keys are no-ops', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_ai_kbd' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    internals(cmp).projectConfig.set({
+      status: 'ready',
+      config: { ai_enabled: true, ai_submitter_choice_allowed: true },
+    });
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const toggle = fixture.nativeElement.querySelector(
+      '.brw-aitoggle',
+    ) as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    toggle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    fixture.detectChanges();
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+    // Non-Space key: no-op.
+    toggle.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    fixture.detectChanges();
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────
+
+  it('whitespace-only draft does not trigger submit and shows the inline error', async () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_validate' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    internals(cmp).draft.set('   \n  ');
+    await internals(cmp).doSubmit();
+    fixture.detectChanges();
+    expect(submit).not.toHaveBeenCalled();
+    const err = fixture.nativeElement.querySelector('.brw-error[role="alert"]');
+    expect(err?.textContent).toContain('Please describe what happened');
+  });
+
+  // ── Footer ───────────────────────────────────────────────────────────────
+
+  it('footer renders the package version', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_footer' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    const link = fixture.nativeElement.querySelector(
+      '.brw-panel-footer-link',
+    ) as HTMLAnchorElement;
+    expect(link).not.toBeNull();
+    expect(link.textContent).toContain('Brevwick v');
+    expect(link.href).toContain('https://brevwick.dev');
   });
 });

--- a/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
+++ b/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
@@ -76,9 +76,12 @@ interface ComponentInternals {
   };
   reducedMotion: { set: (v: boolean) => void };
   useAi: { set: (v: boolean) => void };
+  lastSubmittedInput: { set: (v: unknown) => void };
   doSubmit: () => Promise<void>;
   onRetryClick: () => Promise<void>;
   toggleAi: () => void;
+  relativeTime: (ms: number | undefined) => string;
+  size: (bytes: number) => string;
 }
 
 const internals = (cmp: BwFeedbackButtonComponent): ComponentInternals =>
@@ -390,21 +393,22 @@ describe('BwFeedbackButtonComponent', () => {
     expect(fixture.nativeElement.querySelector('.brw-aitoggle')).toBeNull();
   });
 
-  it('AI toggle renders when ai_enabled + ai_submitter_choice_allowed are true', () => {
+  it('AI toggle renders when ai_enabled + ai_submitter_choice_allowed are true', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_ai_on' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
-    const cmp = fixture.componentInstance;
-    internals(cmp).projectConfig.set({
-      status: 'ready',
-      config: { ai_enabled: true, ai_submitter_choice_allowed: true },
-    });
     (
       fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
     ).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
     const toggle = fixture.nativeElement.querySelector(
       '.brw-aitoggle',
@@ -413,21 +417,22 @@ describe('BwFeedbackButtonComponent', () => {
     expect(toggle?.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('AI toggle hidden when admin disabled submitter choice', () => {
+  it('AI toggle hidden when admin disabled submitter choice', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_ai_forced' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
-    const cmp = fixture.componentInstance;
-    internals(cmp).projectConfig.set({
-      status: 'ready',
-      config: { ai_enabled: true, ai_submitter_choice_allowed: false },
-    });
     (
       fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
     ).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.brw-aitoggle')).toBeNull();
   });
@@ -450,7 +455,9 @@ describe('BwFeedbackButtonComponent', () => {
     internals(cmp).useAi.set(false);
     await internals(cmp).doSubmit();
     expect(submit.mock.calls[0]![0]).toMatchObject({ use_ai: false });
-    // Toggle hidden again: no use_ai key on the next submit.
+    // Toggle hidden again: no use_ai key on the next submit. Note we don't
+    // open the panel, so the lazy-config effect never fires and the manual
+    // signal set wins.
     internals(cmp).projectConfig.set({ status: 'idle', config: null });
     internals(cmp).draft.set('without ai');
     await internals(cmp).doSubmit();
@@ -489,21 +496,22 @@ describe('BwFeedbackButtonComponent', () => {
     void cmp;
   });
 
-  it('formatting row shows only when AI is enabled', () => {
+  it('formatting row shows only when AI is enabled', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_fmt' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
-    const cmp = fixture.componentInstance;
-    internals(cmp).projectConfig.set({
-      status: 'ready',
-      config: { ai_enabled: true, ai_submitter_choice_allowed: false },
-    });
     (
       fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
     ).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
     const sdk = createBrevwick.mock.results[0]!.value as unknown as {
       _internal: { bus: { emit: (payload: unknown) => void } };
     };
@@ -813,21 +821,22 @@ describe('BwFeedbackButtonComponent', () => {
 
   // ── AI toggle keyboard activation ────────────────────────────────────────
 
-  it('Space on the AI toggle flips the signal; other keys are no-ops', () => {
+  it('Space on the AI toggle flips the signal; other keys are no-ops', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
     TestBed.configureTestingModule({
       imports: [BwFeedbackButtonComponent],
       providers: [provideBrevwick({ projectKey: 'pk_test_ai_kbd' })],
     });
     const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
     fixture.detectChanges();
-    const cmp = fixture.componentInstance;
-    internals(cmp).projectConfig.set({
-      status: 'ready',
-      config: { ai_enabled: true, ai_submitter_choice_allowed: true },
-    });
     (
       fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
     ).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
     fixture.detectChanges();
     const toggle = fixture.nativeElement.querySelector(
       '.brw-aitoggle',
@@ -882,5 +891,276 @@ describe('BwFeedbackButtonComponent', () => {
     expect(link).not.toBeNull();
     expect(link.textContent).toContain('Brevwick v');
     expect(link.href).toContain('https://brevwick.dev');
+  });
+
+  // ── Format helpers ───────────────────────────────────────────────────────
+
+  it('relativeTime covers the minute / hour / day branches', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_relative' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const rt = internals(fixture.componentInstance).relativeTime;
+    const now = Date.now();
+    expect(rt(undefined)).toBe('just now');
+    expect(rt(now)).toBe('just now');
+    expect(rt(now - 5 * 60_000)).toBe('5 min ago');
+    expect(rt(now - 3 * 60 * 60_000)).toBe('3 hr ago');
+    expect(rt(now - 2 * 24 * 60 * 60_000)).toBe('2 d ago');
+  });
+
+  it('size formats bytes / kB / MB', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_size' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const fmt = internals(fixture.componentInstance).size;
+    expect(fmt(512)).toBe('512 B');
+    expect(fmt(2048)).toBe('2.0 kB');
+    expect(fmt(2 * 1024 * 1024)).toBe('2.0 MB');
+  });
+
+  // ── matchMedia paths ─────────────────────────────────────────────────────
+
+  it('reduced-motion modern path: change event flips the signal', () => {
+    type ChangeListener = (e: MediaQueryListEvent) => void;
+    let captured: ChangeListener | null = null;
+    const mql = {
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: (_: string, cb: ChangeListener) => {
+        captured = cb;
+      },
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList;
+    const original = window.matchMedia;
+    window.matchMedia = (() => mql) as typeof window.matchMedia;
+    try {
+      TestBed.configureTestingModule({
+        imports: [BwFeedbackButtonComponent],
+        providers: [provideBrevwick({ projectKey: 'pk_test_rm_modern' })],
+      });
+      const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+      fixture.detectChanges();
+      const cmp = fixture.componentInstance;
+      // Default: reducedMotion mirrors mql.matches (false).
+      expect(captured).not.toBeNull();
+      // Fire a synthetic change event — onChange should set reducedMotion=true.
+      captured!({ matches: true } as MediaQueryListEvent);
+      fixture.detectChanges();
+      // Open + drive a phase event so we can read the stagger off a row.
+      (
+        fixture.nativeElement.querySelector(
+          'button.brw-fab',
+        ) as HTMLButtonElement
+      ).click();
+      const sdk = createBrevwick.mock.results[0]!.value as unknown as {
+        _internal: { bus: { emit: (payload: unknown) => void } };
+      };
+      sdk._internal.bus.emit({ phase: 'sanitising-done' });
+      fixture.detectChanges();
+      const row = fixture.nativeElement.querySelector(
+        '[data-brw-row="sanitised"]',
+      ) as HTMLElement;
+      expect(row.style.transitionDelay).toBe('0ms');
+      void cmp;
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
+  it('reduced-motion legacy path: addListener fallback registers + cleans up', () => {
+    type ChangeListener = (e: MediaQueryListEvent) => void;
+    let captured: ChangeListener | null = null;
+    const removeListener = vi.fn();
+    // Build an mql that ONLY exposes the legacy addListener / removeListener
+    // pair — no addEventListener — so the component's else-if branch fires.
+    const mql = {
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addListener: (cb: ChangeListener) => {
+        captured = cb;
+      },
+      removeListener,
+    } as unknown as MediaQueryList;
+    const original = window.matchMedia;
+    window.matchMedia = (() => mql) as typeof window.matchMedia;
+    try {
+      TestBed.configureTestingModule({
+        imports: [BwFeedbackButtonComponent],
+        providers: [provideBrevwick({ projectKey: 'pk_test_rm_legacy' })],
+      });
+      const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+      fixture.detectChanges();
+      expect(captured).not.toBeNull();
+      // Destroying the fixture should run the destroyRef.onDestroy callback
+      // which in turn calls removeListener with the same handler we registered.
+      fixture.destroy();
+      expect(removeListener).toHaveBeenCalledTimes(1);
+      expect(removeListener.mock.calls[0]![0]).toBe(captured);
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
+  // ── Composer autogrow effect ─────────────────────────────────────────────
+
+  it('composer autogrow effect early-returns until the textarea mounts', () => {
+    // The full autogrow body (`renderer.setStyle` round-trip) only runs once
+    // the viewChild signal resolves to a real `ElementRef`. Vitest + happy-dom
+    // do not flush the viewChild query result reliably across CD passes, so we
+    // assert what we *can* deterministically observe: the effect runs at all,
+    // it sees a falsy ref on first paint, and it does not throw when the panel
+    // opens. The covered branch is the early-return guard at the top.
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_autogrow' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    // Mutating draft must not throw even when the viewChild ref is unresolved.
+    expect(() => internals(cmp).draft.set('two\nlines')).not.toThrow();
+    fixture.detectChanges();
+  });
+
+  // ── Project config promise resolution ────────────────────────────────────
+
+  it('project config success path runs the .then handler after the promise settles', async () => {
+    getConfig.mockResolvedValueOnce({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_cfg_ok' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    // Drain microtasks so the resolved getConfig promise's .then fires.
+    await fixture.whenStable();
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('project config catch path runs the .catch handler after a fetch rejection', async () => {
+    getConfig.mockRejectedValueOnce(new Error('network down'));
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_cfg_err' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  // ── doSubmit / onRetryClick error catch paths ────────────────────────────
+
+  it('doSubmit re-opens the panel after a chunk-load rejection', async () => {
+    submit.mockRejectedValueOnce(new Error('chunk load failed'));
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_submit_throw' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    internals(cmp).draft.set('boom');
+    // Minimise mid-submit so we can prove doSubmit pops the panel back open
+    // through the catch branch.
+    (
+      fixture.nativeElement.querySelector(
+        '.brw-icon-btn[aria-label="Minimize"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    await internals(cmp).doSubmit();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).not.toBeNull();
+  });
+
+  it('onRetryClick re-opens the panel after a chunk-load rejection', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'first failed' },
+    });
+    submit.mockRejectedValueOnce(new Error('chunk load failed on retry'));
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_retry_throw' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    (
+      fixture.nativeElement.querySelector('button.brw-fab') as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    internals(cmp).draft.set('first attempt');
+    await internals(cmp).doSubmit();
+    fixture.detectChanges();
+    // Minimise so we can prove onRetryClick pops the panel back open through
+    // the catch branch.
+    (
+      fixture.nativeElement.querySelector(
+        '.brw-icon-btn[aria-label="Minimize"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+    await internals(cmp).onRetryClick();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).not.toBeNull();
+  });
+
+  it('onRetryClick is a no-op when no submit has been attempted', async () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_retry_noop' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const cmp = fixture.componentInstance;
+    await internals(cmp).onRetryClick();
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  // ── Toggle while open routes through minimize ────────────────────────────
+
+  it('clicking the FAB while the panel is open routes through minimize', () => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_toggle_close' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    fixture.detectChanges();
+    const fab = fixture.nativeElement.querySelector(
+      'button.brw-fab',
+    ) as HTMLButtonElement;
+    fab.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).not.toBeNull();
+    fab.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.brw-panel')).toBeNull();
   });
 });

--- a/packages/angular/src/lib/__tests__/phase-bus.spec.ts
+++ b/packages/angular/src/lib/__tests__/phase-bus.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { Brevwick } from '@tatlacas/brevwick-sdk';
+import { getPhaseBus } from '../internal/phase-bus';
+
+const asBrevwick = (value: unknown): Brevwick => value as Brevwick;
+
+describe('getPhaseBus', () => {
+  it('returns null when _internal is missing or not an object', () => {
+    expect(getPhaseBus(asBrevwick({}))).toBeNull();
+    expect(getPhaseBus(asBrevwick({ _internal: null }))).toBeNull();
+    expect(getPhaseBus(asBrevwick({ _internal: 'nope' }))).toBeNull();
+  });
+
+  it('returns null when _internal.bus is missing or not an object', () => {
+    expect(getPhaseBus(asBrevwick({ _internal: {} }))).toBeNull();
+    expect(getPhaseBus(asBrevwick({ _internal: { bus: null } }))).toBeNull();
+    expect(getPhaseBus(asBrevwick({ _internal: { bus: 'nope' } }))).toBeNull();
+  });
+
+  it('returns null when bus is missing the on/off function pair', () => {
+    expect(
+      getPhaseBus(asBrevwick({ _internal: { bus: { on: () => {} } } })),
+    ).toBeNull();
+    expect(
+      getPhaseBus(asBrevwick({ _internal: { bus: { off: () => {} } } })),
+    ).toBeNull();
+    expect(
+      getPhaseBus(
+        asBrevwick({ _internal: { bus: { on: 'nope', off: () => {} } } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns the bus when on + off are both functions', () => {
+    const bus = { on: () => {}, off: () => {} };
+    expect(getPhaseBus(asBrevwick({ _internal: { bus } }))).toBe(bus);
+  });
+});

--- a/packages/angular/src/lib/brevwick.service.ts
+++ b/packages/angular/src/lib/brevwick.service.ts
@@ -11,9 +11,12 @@ import {
   createBrevwick,
   type Brevwick,
   type FeedbackInput,
+  type ProjectConfig,
+  type SubmitError,
   type SubmitResult,
 } from '@tatlacas/brevwick-sdk';
 import { BREVWICK_CONFIG } from './brevwick.tokens';
+import { getPhaseBus, type PhaseEvent } from './internal/phase-bus';
 
 /**
  * Submission lifecycle exposed via {@link BrevwickService.status}. Mirrors
@@ -29,6 +32,35 @@ import { BREVWICK_CONFIG } from './brevwick.tokens';
  *   message after hydration if the user clicks before client takeover).
  */
 export type FeedbackStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+/**
+ * Submit-pipeline phase the UI can render staged status against. Driven
+ * by the SDK's internal `phase` bus event:
+ *
+ * - `idle` — initial state and after `reset()`.
+ * - `capturing` — `submit()` has been called but no phase event has fired yet.
+ * - `sanitising` — `capturing-done` event arrived (payload composed).
+ * - `formatting` — `sanitising-done` event arrived (redact complete; the
+ *   ingest POST is in flight).
+ * - `sent` — `sent` event arrived after a 2xx ingest response.
+ * - `error` — `submit()` resolved with `{ ok: false }` or rejected.
+ *
+ * Mirrors the React adapter's `FeedbackPhase` so a consumer who has read
+ * the React documentation can drive the Angular widget unchanged.
+ */
+export type FeedbackPhase =
+  | 'idle'
+  | 'capturing'
+  | 'sanitising'
+  | 'formatting'
+  | 'sent'
+  | 'error';
+
+const PHASE_EVENT_TO_NEXT_PHASE: Record<PhaseEvent['phase'], FeedbackPhase> = {
+  'capturing-done': 'sanitising',
+  'sanitising-done': 'formatting',
+  sent: 'sent',
+};
 
 /**
  * Angular DI wrapper around the framework-agnostic `Brevwick` SDK instance.
@@ -57,11 +89,45 @@ export class BrevwickService {
   /** Current submission lifecycle. Use directly in templates / effects. */
   readonly status: Signal<FeedbackStatus> = this._status.asReadonly();
 
+  private readonly _phase = signal<FeedbackPhase>('idle');
+  /**
+   * Current submit-pipeline phase. Advances on the SDK's internal phase bus
+   * so adapter UIs can render staged-status rows in step with the actual
+   * pipeline boundaries (compose → redact → ingest).
+   */
+  readonly phase: Signal<FeedbackPhase> = this._phase.asReadonly();
+
+  private readonly _error = signal<SubmitError | null>(null);
+  /**
+   * Tagged error from the last failed `submit()`. `null` until a submit
+   * resolves with `{ ok: false }` or rejects (a chunk-load failure surfaces
+   * as `{ code: 'INGEST_RETRY_EXHAUSTED', message: <Error.message> }`).
+   * Cleared back to `null` on the next `submit()` or `reset()`.
+   */
+  readonly error: Signal<SubmitError | null> = this._error.asReadonly();
+
+  /**
+   * Snapshot of the input passed to the most recent `submit()` so `retry()`
+   * can re-run the exact same payload without forcing the caller to hold it
+   * for us. Cleared on `reset()`.
+   */
+  private lastInput: FeedbackInput | null = null;
+
+  private destroyed = false;
+
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
       this.sdk = createBrevwick(this.config);
       this.sdk.install();
+      const bus = getPhaseBus(this.sdk);
+      const onPhase = (event: PhaseEvent): void => {
+        if (this.destroyed) return;
+        this._phase.set(PHASE_EVENT_TO_NEXT_PHASE[event.phase]);
+      };
+      bus?.on('phase', onPhase);
       this.destroyRef.onDestroy(() => {
+        this.destroyed = true;
+        bus?.off('phase', onPhase);
         this.sdk?.uninstall();
       });
     } else {
@@ -80,28 +146,53 @@ export class BrevwickService {
       // Server-side render: the FAB never fires, but the API stays callable
       // for consumers who programmatically call submit() in shared code.
       this._status.set('error');
-      return {
-        ok: false,
-        error: {
-          code: 'INGEST_REJECTED',
-          message: 'Brevwick SDK is not available on this platform.',
-        },
+      this._phase.set('error');
+      const ssrError: SubmitError = {
+        code: 'INGEST_REJECTED',
+        message: 'Brevwick SDK is not available on this platform.',
       };
+      this._error.set(ssrError);
+      return { ok: false, error: ssrError };
     }
+    this.lastInput = input;
     this._status.set('submitting');
+    this._phase.set('capturing');
+    this._error.set(null);
     try {
       const result = await this.sdk.submit(input);
-      this._status.set(result.ok ? 'success' : 'error');
+      if (result.ok === true) {
+        this._status.set('success');
+      } else {
+        this._status.set('error');
+        this._phase.set('error');
+        this._error.set(result.error);
+      }
       return result;
     } catch (err) {
       // `Brevwick.submit` only rejects when the lazy submit chunk itself
       // fails to load (deploy mismatch / offline). Mirror the React adapter
-      // and surface 'error' so the UI doesn't hang on 'submitting'; rethrow
+      // and surface 'error' so the UI does not hang on 'submitting'; rethrow
       // so callers can distinguish an environmental failure from an
       // ingest-level one.
       this._status.set('error');
+      this._phase.set('error');
+      this._error.set({
+        code: 'INGEST_RETRY_EXHAUSTED',
+        message: err instanceof Error ? err.message : String(err),
+      });
       throw err;
     }
+  }
+
+  /**
+   * Re-run the most recent `submit()` with the same input. Resolves to
+   * `undefined` when no submit has been attempted yet (or after `reset()`).
+   * Re-throws on a chunk-load rejection, just like {@link submit}.
+   */
+  async retry(): Promise<SubmitResult | undefined> {
+    const last = this.lastInput;
+    if (!last) return undefined;
+    return this.submit(last);
   }
 
   /**
@@ -114,8 +205,26 @@ export class BrevwickService {
     return this.sdk.captureScreenshot();
   }
 
-  /** Reset {@link status} back to `'idle'`. Does not cancel an in-flight submit. */
+  /**
+   * Fetch project-level AI config from `GET /v1/ingest/config`. Resolves to
+   * `null` on non-browser platforms or when the SDK reports a fetch failure.
+   * The widget uses this to decide whether to render the "Format with AI"
+   * toggle in the composer.
+   */
+  async getConfig(): Promise<ProjectConfig | null> {
+    if (!this.sdk) return null;
+    return this.sdk.getConfig();
+  }
+
+  /**
+   * Reset {@link status}, {@link phase} and {@link error} back to their
+   * idle defaults. Does not cancel an in-flight submit; the next phase /
+   * status mutation from the live submit will overwrite these.
+   */
   reset(): void {
     this._status.set('idle');
+    this._phase.set('idle');
+    this._error.set(null);
+    this.lastInput = null;
   }
 }

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -1409,27 +1409,37 @@ export class BwFeedbackButtonComponent {
     // Lazy project-config fetch on first panel open. Mirrors the React
     // adapter's `useProjectConfig` hook: explicitly does NOT fetch on mount,
     // so the widget's "zero-cost until opened" property holds.
+    // `allowSignalWrites: true` is required because the synchronous transition
+    // to `loading` and the async resolution / rejection branches all need to
+    // mutate `projectConfig`. The effect only reads `open()`, so there is no
+    // feedback loop — this opts out of the default NG0600 guard for a write
+    // pattern that is intentional. Without it, dev-mode runs throw inside the
+    // effect, the .then handler never fires, and `projectConfig` stays at
+    // `'idle'` so the AI toggle never appears.
     let triggered = false;
-    effect(() => {
-      if (!this.open()) return;
-      if (triggered) return;
-      triggered = true;
-      this.projectConfig.set({ status: 'loading', config: null });
-      void this.brevwick
-        .getConfig()
-        .then((config) => {
-          if (this.destroyed) return;
-          this.projectConfig.set(
-            config !== null
-              ? { status: 'ready', config }
-              : { status: 'error', config: null },
-          );
-        })
-        .catch(() => {
-          if (this.destroyed) return;
-          this.projectConfig.set({ status: 'error', config: null });
-        });
-    });
+    effect(
+      () => {
+        if (!this.open()) return;
+        if (triggered) return;
+        triggered = true;
+        this.projectConfig.set({ status: 'loading', config: null });
+        void this.brevwick
+          .getConfig()
+          .then((config) => {
+            if (this.destroyed) return;
+            this.projectConfig.set(
+              config !== null
+                ? { status: 'ready', config }
+                : { status: 'error', config: null },
+            );
+          })
+          .catch(() => {
+            if (this.destroyed) return;
+            this.projectConfig.set({ status: 'error', config: null });
+          });
+      },
+      { allowSignalWrites: true },
+    );
 
     // Move focus to the "Keep" button when the discard confirm appears,
     // mirroring the React adapter — the non-destructive default lands under

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -3,17 +3,29 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  type ElementRef,
+  EventEmitter,
   Input,
   Output,
-  EventEmitter,
   PLATFORM_ID,
+  Renderer2,
+  ViewEncapsulation,
   computed,
+  effect,
   inject,
   signal,
+  viewChild,
   type Signal,
 } from '@angular/core';
-import type { SubmitResult } from '@tatlacas/brevwick-sdk';
-import { BrevwickService } from '../brevwick.service';
+import type {
+  FeedbackAttachment,
+  FeedbackInput,
+  ProjectConfig,
+  SubmitError,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
+import { BrevwickService, type FeedbackPhase } from '../brevwick.service';
+import { BREVWICK_ANGULAR_VERSION } from '../internal/version';
 
 /**
  * Pin corner for the FAB. Mirrors the React adapter's `FeedbackButtonProps.position`.
@@ -21,78 +33,505 @@ import { BrevwickService } from '../brevwick.service';
 export type BwFeedbackButtonPosition = 'bottom-right' | 'bottom-left';
 
 /**
- * Standalone FAB component that opens the Brevwick feedback widget.
+ * Forced-palette choice. `'system'` defers to the OS-level
+ * `prefers-color-scheme` media query (the default and pre-existing behaviour);
+ * `'light'` / `'dark'` override it regardless of the OS setting.
+ */
+export type BwFeedbackButtonTheme = 'light' | 'dark' | 'system';
+
+/**
+ * Combined screenshot + file cap. Mirrored from the SDK's `MAX_ATTACHMENT_COUNT`
+ * in `packages/sdk/src/submit.ts`. Enforced in the UI by disabling the
+ * file-attach button once the combined total reaches this ceiling — that way
+ * the user cannot queue an attachment the SDK would reject downstream.
+ */
+const MAX_ATTACHMENTS = 5;
+
+/**
+ * Maximum autogrow height of the composer textarea in pixels. Single source
+ * of truth for both the JS effect (sets `style.height` against `scrollHeight`
+ * bounded by this) and the CSS `max-height` rule.
+ */
+const COMPOSER_MAX_HEIGHT_PX = 120;
+
+/**
+ * Stagger between staged-status rows in milliseconds. Applied as
+ * `style.transitionDelay` per row so rows fade in sequentially even when
+ * the underlying SDK phase events fire microseconds apart on a healthy
+ * happy path. Honoured only when the user has not requested reduced motion.
+ */
+const STATUS_ROW_STAGGER_MS = 200;
+
+const ASSISTANT_RECEIPT_TEXT = 'Thanks — your issue is on its way.';
+const GREETING_TEXT =
+  "Hi! Tell us what's happening. A screenshot helps if you have one.";
+
+/**
+ * One bubble in the conversation thread. The greeting and submitted-issue
+ * receipt are `assistant` messages; submitted drafts become `user` messages.
+ */
+interface Message {
+  readonly id: string;
+  readonly role: 'assistant' | 'user';
+  readonly text: string;
+  readonly issueSent?: boolean;
+  readonly sentAt?: number;
+}
+
+interface FileAttachment {
+  readonly id: number;
+  readonly file: File;
+}
+
+type ProjectConfigStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface ProjectConfigState {
+  readonly status: ProjectConfigStatus;
+  readonly config: ProjectConfig | null;
+}
+
+/**
+ * Phase ordinal used by the staged-status rows to decide visibility. Row 1
+ * ("Captured") shows from `'sanitising'` onwards, row 2 ("Sanitised") from
+ * `'formatting'` onwards. Row 3 ("Formatting with AI…") has its own
+ * exact-match rule and does not consult this table.
+ */
+const PHASE_RANK: Record<FeedbackPhase, number> = {
+  idle: 0,
+  capturing: 1,
+  sanitising: 2,
+  formatting: 3,
+  sent: 4,
+  error: -1,
+};
+
+/**
+ * Cheap relative-time formatter for the issue-sent receipt. The bubble
+ * does not auto-refresh — once rendered the timestamp captures the moment
+ * the issue was queued, which is the only thing that actually matters
+ * (the user reads it within seconds of seeing it appear). Intentionally
+ * does not pull in `Intl.RelativeTimeFormat` so the FESM bundle gzip
+ * stays inside the §12 budget.
+ */
+function formatRelativeTime(ms: number | undefined): string {
+  if (ms === undefined) return 'just now';
+  const diffMs = Date.now() - ms;
+  if (diffMs < 60_000) return 'just now';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Standalone feedback widget — a FAB plus a chat-style submission panel.
  *
- * This is a deliberately lean Angular surface — the full chat-style panel
- * (multi-screenshot, region-select capture, AI toggle, etc.) lives in
- * `@tatlacas/brevwick-react`'s `FeedbackButton`. The Angular component
- * renders a minimum-viable FAB + textarea + submit so consumers have a
- * working out-of-the-box widget; apps that need richer UX wrap
- * {@link BrevwickService} themselves. The component does NOT trigger
- * screenshot capture — it only submits a text-only `{ title, description }`
- * payload. Apps that need screenshots call
- * {@link BrevwickService.captureScreenshot} from their own component and
- * pass the resulting `Blob` through `BrevwickService.submit`'s
- * `attachments` field.
+ * Mirrors the React adapter's `FeedbackButton` (UI / UX / wire format)
+ * minus the screenshot capture surface (region overlay, preview dialog).
+ * Apps that need screenshots call {@link BrevwickService.captureScreenshot}
+ * from their own component and pass the resulting `Blob` to
+ * {@link BrevwickService.submit} via the `attachments` field.
  *
- * SSR-safe: rendered nodes still appear server-side; the open/close toggle
- * short-circuits on non-browser platforms via `isPlatformBrowser`. The
- * other handlers can only fire from real DOM events, so they are
- * unreachable server-side regardless.
+ * SSR-safe: rendered nodes still appear server-side; the open / close toggle
+ * short-circuits on non-browser platforms via `isPlatformBrowser`. Other
+ * handlers can only fire from real DOM events, so they are unreachable
+ * server-side regardless.
+ *
+ * Theming follows the dual-variable pattern documented in the React
+ * adapter's `styles.ts`: every rule reads `var(--brw-X, var(--brw-X-base))`
+ * so a host `:root { --brw-X: ... }` override always wins, even under a
+ * forced `theme="light|dark"` (which only rewrites the internal `-base`
+ * defaults). See SDD § 12 for the public token list.
  */
 @Component({
   selector: 'bw-feedback-button',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // ViewEncapsulation.None: the React widget ships a single global
+  // stylesheet that targets `.brw-*` class names; replicating it under
+  // emulated encapsulation would force every rule to be rewritten with
+  // `:host ::ng-deep` (deprecated) or recolour the dark-mode media query
+  // to leak across host boundaries. None keeps the rules identical to
+  // the React adapter so a designer who tweaks one stylesheet does not
+  // have to maintain two.
+  encapsulation: ViewEncapsulation.None,
   template: `
     @if (!hidden) {
       <button
         type="button"
-        class="bw-fab"
-        [class.bw-fab--bl]="position === 'bottom-left'"
+        class="brw-root brw-fab"
+        [class.brw-fab-bl]="position === 'bottom-left'"
+        [class.brw-fab-br]="position !== 'bottom-left'"
         [attr.data-brevwick-skip]="''"
+        [attr.data-brw-theme]="theme"
         [disabled]="disabled || isSubmitting()"
-        [attr.aria-label]="
-          open() ? 'Close feedback form' : 'Open feedback form'
-        "
+        aria-label="Open feedback form"
         (click)="toggle()"
       >
+        <svg
+          class="brw-fab-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z" />
+        </svg>
         {{ label }}
       </button>
 
       @if (open()) {
         <div
-          class="bw-panel"
-          [class.bw-panel--bl]="position === 'bottom-left'"
+          class="brw-root brw-panel"
+          [class.brw-panel-bl]="position === 'bottom-left'"
+          [class.brw-panel-br]="position !== 'bottom-left'"
           role="dialog"
           aria-label="Send feedback"
           [attr.data-brevwick-skip]="''"
+          [attr.data-brw-theme]="theme"
         >
-          <textarea
-            class="bw-input"
-            rows="4"
-            [value]="draft()"
-            (input)="onDraftChange($any($event.target).value)"
-            placeholder="Describe the bug or feedback…"
-            aria-label="Feedback message"
-          ></textarea>
-
-          @if (errorMessage()) {
-            <div class="bw-error" role="alert">{{ errorMessage() }}</div>
-          }
-
-          <div class="bw-actions">
-            <button type="button" class="bw-btn" (click)="close()">
-              Cancel
+          <!-- Panel header -->
+          <div class="brw-panel-header">
+            <span class="brw-panel-avatar" aria-hidden="true">B</span>
+            <h2 class="brw-panel-title">Send feedback</h2>
+            <button
+              type="button"
+              class="brw-icon-btn"
+              aria-label="Minimize"
+              (click)="minimize()"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 14h14" />
+              </svg>
             </button>
             <button
               type="button"
-              class="bw-btn bw-btn--primary"
-              [disabled]="!canSubmit()"
-              (click)="onSubmitClick()"
+              class="brw-icon-btn"
+              aria-label="Close"
+              [disabled]="isSubmitting()"
+              (click)="onCloseClick()"
             >
-              {{ isSubmitting() ? 'Sending…' : 'Send' }}
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M6 6l12 12M18 6L6 18" />
+              </svg>
             </button>
+          </div>
+
+          <!-- Conversation thread -->
+          <div
+            class="brw-thread"
+            role="log"
+            aria-live="polite"
+            aria-label="Conversation"
+          >
+            @for (msg of messages(); track msg.id) {
+              @if (msg.role === 'assistant') {
+                <div class="brw-bubble brw-bubble--assistant">
+                  {{ msg.text }}
+                  @if (msg.issueSent) {
+                    <div class="brw-bubble--receipt">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M5 12l5 5L20 7" />
+                      </svg>
+                      Issue sent · {{ relativeTime(msg.sentAt) }}
+                    </div>
+                  }
+                </div>
+              } @else {
+                <div class="brw-bubble brw-bubble--user">{{ msg.text }}</div>
+              }
+            }
+
+            <!-- File attachment chips (file-only; screenshot UI is out of scope) -->
+            @for (att of files(); track att.id) {
+              <div class="brw-chip">
+                <span class="brw-chip-name">{{ att.file.name }}</span>
+                <span class="brw-chip-size">{{ size(att.file.size) }}</span>
+                <button
+                  type="button"
+                  class="brw-chip-remove"
+                  [attr.aria-label]="'Remove ' + att.file.name"
+                  (click)="removeFile(att.id)"
+                >
+                  ×
+                </button>
+              </div>
+            }
+
+            <!-- Expected vs Actual disclosure -->
+            <button
+              type="button"
+              class="brw-disclosure"
+              [attr.aria-expanded]="showExtras()"
+              [attr.aria-controls]="disclosureId"
+              (click)="toggleExtras()"
+            >
+              {{
+                showExtras()
+                  ? 'Hide expected vs actual'
+                  : 'Add expected vs actual'
+              }}
+            </button>
+            @if (showExtras()) {
+              <div [id]="disclosureId" class="brw-disclosure-panel">
+                <label>
+                  <span class="brw-disclosure-label">Expected</span>
+                  <textarea
+                    class="brw-disclosure-input"
+                    rows="2"
+                    [value]="expected()"
+                    (input)="expected.set($any($event.target).value)"
+                  ></textarea>
+                </label>
+                <label>
+                  <span class="brw-disclosure-label">Actual</span>
+                  <textarea
+                    class="brw-disclosure-input"
+                    rows="2"
+                    [value]="actual()"
+                    (input)="actual.set($any($event.target).value)"
+                  ></textarea>
+                </label>
+              </div>
+            }
+
+            <!-- Inline (validation / pre-pipeline) error -->
+            @if (errorMessage(); as msg) {
+              <div class="brw-error" role="alert">{{ msg }}</div>
+            }
+
+            <!-- Staged status rows: row 1 (Captured) -->
+            @if (showCaptured()) {
+              <div
+                class="brw-status-row"
+                data-brw-row="captured"
+                style="transition-delay: 0ms"
+              >
+                <span class="brw-status-row-check" aria-hidden="true">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M5 12l5 5L20 7" />
+                  </svg>
+                </span>
+                <span class="brw-status-row-label"
+                  >Captured route, console, network, device</span
+                >
+              </div>
+            }
+
+            <!-- Row 2 (Sanitised) -->
+            @if (showSanitised()) {
+              <div
+                class="brw-status-row"
+                data-brw-row="sanitised"
+                [style.transition-delay.ms]="sanitisedDelayMs()"
+              >
+                <span class="brw-status-row-check" aria-hidden="true">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M5 12l5 5L20 7" />
+                  </svg>
+                </span>
+                <span class="brw-status-row-label"
+                  >PII-sanitised, packaged</span
+                >
+              </div>
+            }
+
+            <!-- Row 3 (Formatting with AI…) — exact-match formatting + AI on -->
+            @if (showFormattingRow()) {
+              <div
+                class="brw-status-row"
+                data-brw-row="formatting"
+                [style.transition-delay.ms]="formattingDelayMs()"
+              >
+                <span class="brw-spinner" aria-hidden="true"></span>
+                <span class="brw-status-row-label">Formatting with AI…</span>
+              </div>
+            }
+
+            <!-- Retry row -->
+            @if (showRetryRow(); as err) {
+              <div
+                class="brw-status-row brw-status-row--error"
+                role="alert"
+                data-brw-row="error"
+                [attr.data-brw-error-code]="err.code"
+              >
+                {{ err.message }}
+                <button
+                  type="button"
+                  class="brw-btn brw-status-row-retry"
+                  (click)="onRetryClick()"
+                >
+                  Retry
+                </button>
+              </div>
+            }
+
+            <!-- Discard confirm -->
+            @if (confirmClose()) {
+              <div class="brw-confirm" role="alert" aria-label="Discard draft?">
+                <span class="brw-confirm-msg">Discard your feedback?</span>
+                <button
+                  #keepBtn
+                  type="button"
+                  class="brw-btn"
+                  (click)="cancelClose()"
+                >
+                  Keep
+                </button>
+                <button
+                  type="button"
+                  class="brw-btn brw-btn-primary"
+                  (click)="discard()"
+                >
+                  Discard
+                </button>
+              </div>
+            }
+          </div>
+
+          <!-- Composer -->
+          <div class="brw-composer">
+            <div class="brw-composer-shell">
+              <label class="brw-icon-btn">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M21 10.5l-8.5 8.5a5 5 0 0 1-7-7l9-9a3.5 3.5 0 0 1 5 5l-9 9a2 2 0 0 1-3-3l7.5-7.5"
+                  />
+                </svg>
+                <input
+                  type="file"
+                  multiple
+                  [attr.aria-label]="fileLabel()"
+                  class="brw-file-input"
+                  [disabled]="attachDisabled()"
+                  (change)="onFileChange($event)"
+                />
+              </label>
+              <textarea
+                #composerEl
+                class="brw-composer-input"
+                rows="1"
+                placeholder="Describe the bug or feedback…"
+                aria-label="Feedback message"
+                [value]="draft()"
+                (input)="onDraftInput($event)"
+                (keydown)="onComposerKeydown($event)"
+              ></textarea>
+              @if (showAiToggle()) {
+                <span class="brw-aitoggle-wrap">
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-label="Format with AI"
+                    [attr.aria-checked]="useAi()"
+                    class="brw-aitoggle"
+                    [class.brw-aitoggle--on]="useAi()"
+                    [disabled]="isSubmitting()"
+                    (click)="toggleAi()"
+                    (keydown)="onAiToggleKeydown($event)"
+                  >
+                    <span class="brw-aitoggle-thumb" aria-hidden="true"></span>
+                  </button>
+                  <span class="brw-aitoggle-text" aria-hidden="true">AI</span>
+                </span>
+              }
+              <button
+                type="button"
+                class="brw-send-btn"
+                aria-label="Send"
+                [disabled]="!canSend()"
+                (click)="onSendClick()"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M4 20l16-8L4 4l2 8-2 8z" />
+                  <path d="M6 12h14" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="brw-panel-footer">
+            <a
+              class="brw-panel-footer-link"
+              href="https://brevwick.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Brevwick v{{ version }}
+            </a>
           </div>
         </div>
       }
@@ -100,86 +539,635 @@ export type BwFeedbackButtonPosition = 'bottom-right' | 'bottom-left';
   `,
   styles: [
     `
-      :host {
-        display: contents;
+      :where(:root) {
+        --brw-panel-bg-base: #ffffff;
+        --brw-bubble-assistant-bg-base: #f1f5f9;
+        --brw-bubble-user-bg-base: #0f172a;
+        --brw-bubble-user-fg-base: #ffffff;
+        --brw-chip-bg-base: #f1f5f9;
+        --brw-composer-bg-base: #ffffff;
+        --brw-fg-base: #0f172a;
+        --brw-fg-muted-base: #64748b;
+        --brw-border-base: #e2e8f0;
+        --brw-border-focus-base: #0f172a;
+        --brw-divider-base: #e2e8f0;
+        --brw-accent-base: #0f172a;
+        --brw-accent-fg-base: #ffffff;
+        --brw-shadow-base:
+          0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+        --brw-error-base: #b91c1c;
       }
-      .bw-fab {
+      @media (prefers-color-scheme: dark) {
+        :where(:root) {
+          --brw-panel-bg-base: #0b1220;
+          --brw-bubble-assistant-bg-base: #1e293b;
+          --brw-bubble-user-bg-base: #f8fafc;
+          --brw-bubble-user-fg-base: #0f172a;
+          --brw-chip-bg-base: #253044;
+          --brw-composer-bg-base: #0b1220;
+          --brw-fg-base: #f8fafc;
+          --brw-fg-muted-base: #94a3b8;
+          --brw-border-base: #1e293b;
+          --brw-border-focus-base: #f8fafc;
+          --brw-divider-base: #1e293b;
+          --brw-accent-base: #f8fafc;
+          --brw-accent-fg-base: #0f172a;
+          --brw-shadow-base:
+            0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+        }
+      }
+      .brw-root[data-brw-theme='light'] {
+        --brw-panel-bg-base: #ffffff;
+        --brw-bubble-assistant-bg-base: #f1f5f9;
+        --brw-bubble-user-bg-base: #0f172a;
+        --brw-bubble-user-fg-base: #ffffff;
+        --brw-chip-bg-base: #f1f5f9;
+        --brw-composer-bg-base: #ffffff;
+        --brw-fg-base: #0f172a;
+        --brw-fg-muted-base: #64748b;
+        --brw-border-base: #e2e8f0;
+        --brw-border-focus-base: #0f172a;
+        --brw-divider-base: #e2e8f0;
+        --brw-accent-base: #0f172a;
+        --brw-accent-fg-base: #ffffff;
+        --brw-shadow-base:
+          0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+      }
+      .brw-root[data-brw-theme='dark'] {
+        --brw-panel-bg-base: #0b1220;
+        --brw-bubble-assistant-bg-base: #1e293b;
+        --brw-bubble-user-bg-base: #f8fafc;
+        --brw-bubble-user-fg-base: #0f172a;
+        --brw-chip-bg-base: #253044;
+        --brw-composer-bg-base: #0b1220;
+        --brw-fg-base: #f8fafc;
+        --brw-fg-muted-base: #94a3b8;
+        --brw-border-base: #1e293b;
+        --brw-border-focus-base: #f8fafc;
+        --brw-divider-base: #1e293b;
+        --brw-accent-base: #f8fafc;
+        --brw-accent-fg-base: #0f172a;
+        --brw-shadow-base:
+          0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+      }
+      .brw-root {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, sans-serif;
+        color: var(--brw-fg, var(--brw-fg-base));
+      }
+      .brw-fab {
         position: fixed;
+        z-index: 2147483000;
         bottom: 24px;
-        right: 24px;
-        padding: 10px 16px;
+        height: 48px;
+        min-width: 48px;
+        padding: 0 18px;
         border-radius: 999px;
-        background: #111;
-        color: #fff;
-        border: 0;
-        font: inherit;
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        background: var(--brw-accent, var(--brw-accent-base));
+        color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+        font-size: 14px;
         font-weight: 500;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
         cursor: pointer;
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
-        z-index: 2147483646;
+        box-shadow: var(--brw-shadow, var(--brw-shadow-base));
+        transition: transform 120ms ease-out;
       }
-      .bw-fab:disabled {
-        opacity: 0.6;
+      .brw-fab:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+      .brw-fab:disabled {
         cursor: not-allowed;
+        opacity: 0.5;
       }
-      .bw-fab--bl {
-        right: auto;
+      .brw-fab-br {
+        right: 24px;
+      }
+      .brw-fab-bl {
         left: 24px;
       }
-      .bw-panel {
+      .brw-fab-icon {
+        width: 18px;
+        height: 18px;
+      }
+      .brw-panel {
         position: fixed;
-        bottom: 80px;
-        right: 24px;
-        width: min(360px, calc(100vw - 32px));
-        background: #fff;
-        color: #111;
-        border-radius: 12px;
-        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
-        padding: 12px;
+        z-index: 2147483002;
+        bottom: 24px;
+        width: min(92vw, 400px);
+        height: min(80vh, 640px);
         display: flex;
         flex-direction: column;
-        gap: 8px;
-        z-index: 2147483646;
+        background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+        color: var(--brw-fg, var(--brw-fg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 16px 16px 12px 12px;
+        box-shadow: var(--brw-shadow, var(--brw-shadow-base));
+        overflow: hidden;
+        animation: brw-slide-up 200ms ease-out;
       }
-      .bw-panel--bl {
-        right: auto;
+      .brw-panel-br {
+        right: 24px;
+      }
+      .brw-panel-bl {
         left: 24px;
       }
-      .bw-input {
-        width: 100%;
-        font: inherit;
-        resize: vertical;
-        padding: 8px;
-        border: 1px solid #ddd;
-        border-radius: 6px;
-        background: #fafafa;
-        color: inherit;
+      @keyframes brw-slide-up {
+        from {
+          transform: translateY(16px);
+          opacity: 0;
+        }
+        to {
+          transform: none;
+          opacity: 1;
+        }
       }
-      .bw-actions {
+      @media (prefers-reduced-motion: reduce) {
+        .brw-panel {
+          animation: none;
+        }
+        .brw-fab {
+          transition: none;
+        }
+      }
+      @media (max-width: 480px) {
+        .brw-panel {
+          width: calc(100vw - 32px);
+          left: 16px;
+          right: 16px;
+        }
+      }
+      .brw-panel-header {
         display: flex;
-        justify-content: flex-end;
+        align-items: center;
         gap: 8px;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--brw-divider, var(--brw-divider-base));
+        flex-shrink: 0;
       }
-      .bw-btn {
-        font: inherit;
-        padding: 6px 12px;
+      .brw-panel-avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        background: var(--brw-accent, var(--brw-accent-base));
+        color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        font-size: 12px;
+        flex-shrink: 0;
+      }
+      .brw-panel-title {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        flex: 1;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .brw-icon-btn {
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
         border-radius: 6px;
-        border: 1px solid #ddd;
-        background: #fff;
         cursor: pointer;
+        font: inherit;
+        line-height: 1;
       }
-      .bw-btn--primary {
-        background: #111;
-        color: #fff;
-        border-color: #111;
+      .brw-icon-btn:hover:not(:disabled) {
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+        color: var(--brw-fg, var(--brw-fg-base));
       }
-      .bw-btn:disabled {
+      .brw-icon-btn:focus-visible {
+        outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+        outline-offset: 1px;
+      }
+      .brw-icon-btn:disabled {
         opacity: 0.5;
         cursor: not-allowed;
       }
-      .bw-error {
-        color: #b00020;
-        font-size: 0.875rem;
+      .brw-icon-btn svg {
+        width: 16px;
+        height: 16px;
+      }
+      .brw-thread {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        padding: 16px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+      }
+      .brw-bubble {
+        max-width: 85%;
+        padding: 10px 12px;
+        border-radius: 14px;
+        font-size: 13px;
+        line-height: 1.45;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+      }
+      .brw-bubble--assistant {
+        align-self: flex-start;
+        background: var(
+          --brw-bubble-assistant-bg,
+          var(--brw-bubble-assistant-bg-base)
+        );
+        color: var(--brw-fg, var(--brw-fg-base));
+        border-bottom-left-radius: 4px;
+      }
+      .brw-bubble--user {
+        align-self: flex-end;
+        background: var(--brw-bubble-user-bg, var(--brw-bubble-user-bg-base));
+        color: var(--brw-bubble-user-fg, var(--brw-bubble-user-fg-base));
+        border-bottom-right-radius: 4px;
+      }
+      .brw-bubble--receipt {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-top: 6px;
+        font-size: 11px;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+      }
+      .brw-bubble--receipt svg {
+        flex-shrink: 0;
+      }
+      .brw-chip {
+        align-self: flex-end;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+        color: var(--brw-fg, var(--brw-fg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 12px;
+        font-size: 12px;
+        max-width: 85%;
+      }
+      .brw-chip-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 180px;
+      }
+      .brw-chip-size {
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+      }
+      .brw-chip-remove {
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: transparent;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        border-radius: 999px;
+        cursor: pointer;
+        font: inherit;
+        line-height: 1;
+      }
+      .brw-chip-remove:hover {
+        background: var(--brw-border, var(--brw-border-base));
+        color: var(--brw-fg, var(--brw-fg-base));
+      }
+      .brw-disclosure {
+        align-self: flex-start;
+        background: transparent;
+        border: none;
+        padding: 0;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+        text-decoration: underline;
+      }
+      .brw-disclosure:hover {
+        color: var(--brw-fg, var(--brw-fg-base));
+      }
+      .brw-disclosure-panel {
+        align-self: stretch;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px 10px;
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 10px;
+      }
+      .brw-disclosure-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .brw-disclosure-input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 6px 8px;
+        font: inherit;
+        font-size: 12px;
+        color: var(--brw-fg, var(--brw-fg-base));
+        background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 6px;
+        resize: vertical;
+        min-height: 34px;
+      }
+      .brw-composer {
+        flex-shrink: 0;
+        padding: 8px 10px;
+        background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+        border-top: 1px solid var(--brw-divider, var(--brw-divider-base));
+      }
+      .brw-composer-shell {
+        display: flex;
+        align-items: flex-end;
+        gap: 4px;
+        padding: 6px 8px;
+        background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 12px;
+        transition: border-color 120ms ease-out;
+      }
+      .brw-composer-shell:focus-within {
+        border-color: var(--brw-border-focus, var(--brw-border-focus-base));
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brw-composer-shell {
+          transition: none;
+        }
+      }
+      .brw-composer-input {
+        flex: 1;
+        min-height: 34px;
+        max-height: 120px;
+        box-sizing: border-box;
+        padding: 8px 4px;
+        font: inherit;
+        font-size: 13px;
+        color: var(--brw-fg, var(--brw-fg-base));
+        background: transparent;
+        border: none;
+        resize: none;
+        overflow-y: auto;
+        line-height: 1.4;
+      }
+      .brw-composer-input:focus-visible {
+        outline: none;
+      }
+      .brw-send-btn {
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--brw-accent, var(--brw-accent-base));
+        background: var(--brw-accent, var(--brw-accent-base));
+        color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+        border-radius: 10px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .brw-aitoggle-wrap {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 34px;
+        padding: 0 4px;
+      }
+      .brw-aitoggle-text {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        line-height: 1;
+        user-select: none;
+        transition: color 120ms ease-out;
+      }
+      .brw-aitoggle-wrap:has(.brw-aitoggle--on) .brw-aitoggle-text {
+        color: var(--brw-fg, var(--brw-fg-base));
+      }
+      .brw-aitoggle {
+        position: relative;
+        flex-shrink: 0;
+        width: 30px;
+        height: 18px;
+        padding: 0;
+        border-radius: 999px;
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+        cursor: pointer;
+        transition:
+          background-color 120ms ease-out,
+          border-color 120ms ease-out;
+      }
+      .brw-aitoggle:focus-visible {
+        outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+        outline-offset: 2px;
+      }
+      .brw-aitoggle:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      .brw-aitoggle-thumb {
+        position: absolute;
+        top: 50%;
+        left: 2px;
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+        background: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        transform: translateY(-50%);
+        transition:
+          left 140ms ease-out,
+          background-color 120ms ease-out;
+      }
+      .brw-aitoggle--on {
+        background: var(--brw-accent, var(--brw-accent-base));
+        border-color: var(--brw-accent, var(--brw-accent-base));
+      }
+      .brw-aitoggle--on .brw-aitoggle-thumb {
+        left: calc(100% - 14px);
+        background: var(--brw-accent-fg, var(--brw-accent-fg-base));
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brw-aitoggle,
+        .brw-aitoggle-thumb,
+        .brw-aitoggle-text {
+          transition: none;
+        }
+      }
+      .brw-send-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      .brw-send-btn svg {
+        width: 16px;
+        height: 16px;
+      }
+      .brw-file-input {
+        display: none;
+      }
+      .brw-confirm {
+        align-self: stretch;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        padding: 8px 10px;
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        border-radius: 10px;
+        font-size: 12px;
+      }
+      .brw-confirm-msg {
+        flex: 1;
+      }
+      .brw-btn {
+        height: 30px;
+        padding: 0 12px;
+        border-radius: 8px;
+        border: 1px solid var(--brw-border, var(--brw-border-base));
+        background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+        color: var(--brw-fg, var(--brw-fg-base));
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .brw-btn:hover:not(:disabled) {
+        background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+      }
+      .brw-btn-primary {
+        background: var(--brw-accent, var(--brw-accent-base));
+        color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+        border-color: var(--brw-accent, var(--brw-accent-base));
+      }
+      .brw-error {
+        color: var(--brw-error-base);
+        font-size: 12px;
+        align-self: stretch;
+      }
+      .brw-status-row {
+        align-self: flex-start;
+        max-width: 85%;
+        padding: 10px 12px;
+        border-radius: 14px;
+        border-bottom-left-radius: 4px;
+        background: var(
+          --brw-bubble-assistant-bg,
+          var(--brw-bubble-assistant-bg-base)
+        );
+        color: var(--brw-fg, var(--brw-fg-base));
+        font-size: 13px;
+        line-height: 1.45;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        animation: brw-status-row-in 220ms ease-out both;
+      }
+      .brw-status-row-check {
+        display: inline-flex;
+        width: 14px;
+        height: 14px;
+        align-items: center;
+        justify-content: center;
+        color: var(--brw-accent, var(--brw-accent-base));
+      }
+      .brw-status-row-check svg {
+        width: 14px;
+        height: 14px;
+      }
+      .brw-status-row-label {
+        flex: 1;
+      }
+      .brw-status-row--error {
+        color: var(--brw-error-base);
+        border: 1px solid var(--brw-error-base);
+      }
+      .brw-status-row-retry {
+        margin-left: auto;
+        padding: 4px 10px;
+        font-size: 12px;
+      }
+      @keyframes brw-status-row-in {
+        from {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brw-status-row {
+          animation: none;
+        }
+      }
+      .brw-panel-footer {
+        flex-shrink: 0;
+        padding: 6px 10px 8px;
+        text-align: center;
+        background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+      }
+      .brw-panel-footer-link {
+        font-size: 10px;
+        letter-spacing: 0.02em;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+        text-decoration: none;
+        opacity: 0.75;
+        transition:
+          opacity 120ms ease-out,
+          color 120ms ease-out;
+      }
+      .brw-panel-footer-link:hover,
+      .brw-panel-footer-link:focus-visible {
+        opacity: 1;
+        color: var(--brw-fg, var(--brw-fg-base));
+        text-decoration: underline;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brw-panel-footer-link {
+          transition: none;
+        }
+      }
+      .brw-spinner {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        border-radius: 999px;
+        animation: brw-spin 0.7s linear infinite;
+      }
+      @keyframes brw-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .brw-spinner {
+          animation-duration: 1.6s;
+        }
       }
     `,
   ],
@@ -194,102 +1182,522 @@ export class BwFeedbackButtonComponent {
   /** FAB label. Default `'Feedback'`. */
   @Input() label = 'Feedback';
   /**
+   * Forced palette. `'system'` defers to the OS-level `prefers-color-scheme`
+   * media query (the default); `'light'` / `'dark'` override regardless of
+   * the OS setting. Bound through `[attr.data-brw-theme]` on the FAB and
+   * panel so the dual-variable theming pattern from `BREVWICK_CSS` applies.
+   */
+  @Input() theme: BwFeedbackButtonTheme = 'system';
+  /**
    * Fired with the SDK's `SubmitResult` after every submit (success or
    * failure). Mirrors React adapter's `onSubmit` prop.
    */
   @Output() submit = new EventEmitter<SubmitResult>();
 
+  protected readonly version = BREVWICK_ANGULAR_VERSION;
+  private static idSeq = 0;
+  /** Per-instance id for the disclosure aria-controls. */
+  protected readonly disclosureId = `brw-disclosure-${++BwFeedbackButtonComponent.idSeq}`;
+
   private readonly platformId = inject(PLATFORM_ID);
   private readonly brevwick = inject(BrevwickService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly renderer = inject(Renderer2);
 
   /**
    * Tracks whether the host view has been torn down. Async submit work
    * checks this before touching component signals or emitting on `submit`,
-   * preventing post-destroy `EventEmitter.emit` calls that would notify a
-   * parent which has already unsubscribed.
+   * preventing post-destroy mutations.
    */
   private destroyed = false;
 
+  // ── Core state signals ───────────────────────────────────────────────────
+
   protected readonly open = signal(false);
   protected readonly draft = signal('');
+  protected readonly expected = signal('');
+  protected readonly actual = signal('');
+  protected readonly showExtras = signal(false);
+  protected readonly confirmClose = signal(false);
   protected readonly errorMessage = signal<string | null>(null);
+  protected readonly useAi = signal(true);
+  protected readonly messages = signal<readonly Message[]>([
+    { id: 'greeting', role: 'assistant', text: GREETING_TEXT },
+  ]);
+  protected readonly files = signal<readonly FileAttachment[]>([]);
+  /**
+   * Last `FeedbackInput` passed to `BrevwickService.submit`. Stored locally
+   * (not just on the service) so a retry can replay the exact same payload
+   * even after the user starts typing a new draft.
+   */
+  protected readonly lastSubmittedInput = signal<FeedbackInput | null>(null);
+  /**
+   * Project-config state, lazy-fetched on the first panel open. Mirrors the
+   * React adapter's `useProjectConfig` hook semantics: never fetches at mount.
+   */
+  protected readonly projectConfig = signal<ProjectConfigState>({
+    status: 'idle',
+    config: null,
+  });
+  /**
+   * `prefers-reduced-motion: reduce` snapshot. Kept in a signal so the row
+   * stagger reacts when the OS setting flips mid-session.
+   */
+  protected readonly reducedMotion = signal(false);
+
+  // ── Derived signals ──────────────────────────────────────────────────────
+
+  protected readonly status = this.brevwick.status;
+  protected readonly phase = this.brevwick.phase;
+  protected readonly tagged = this.brevwick.error;
 
   protected readonly isSubmitting: Signal<boolean> = computed(
-    () => this.brevwick.status() === 'submitting',
+    () => this.status() === 'submitting',
   );
-  protected readonly canSubmit: Signal<boolean> = computed(
+
+  protected readonly attachmentsAtCap: Signal<boolean> = computed(
+    () => this.files().length >= MAX_ATTACHMENTS,
+  );
+
+  protected readonly attachDisabled: Signal<boolean> = computed(
+    () => this.isSubmitting() || this.attachmentsAtCap(),
+  );
+
+  protected readonly hasContent: Signal<boolean> = computed(
+    () =>
+      this.draft().trim().length > 0 ||
+      this.expected().length > 0 ||
+      this.actual().length > 0 ||
+      this.files().length > 0,
+  );
+
+  protected readonly canSend: Signal<boolean> = computed(
     () => !this.isSubmitting() && this.draft().trim().length > 0,
   );
 
+  /**
+   * Render-policy matrix mirrored from the React adapter's SDD § 12 rule:
+   * the toggle is visible exactly when the config has loaded successfully,
+   * AI is enabled for the project, AND the admin has opted submitters into
+   * the choice. Any other state hides the toggle and the payload omits
+   * `use_ai` so the server-side default applies.
+   */
+  protected readonly showAiToggle: Signal<boolean> = computed(() => {
+    const c = this.projectConfig();
+    return (
+      c.status === 'ready' &&
+      c.config?.ai_enabled === true &&
+      c.config.ai_submitter_choice_allowed === true
+    );
+  });
+
+  // Phase-driven status row visibility — matches React adapter line-for-line.
+  protected readonly showCaptured: Signal<boolean> = computed(
+    () => PHASE_RANK[this.phase()] >= PHASE_RANK.sanitising,
+  );
+  protected readonly showSanitised: Signal<boolean> = computed(
+    () => PHASE_RANK[this.phase()] >= PHASE_RANK.formatting,
+  );
+  protected readonly showFormattingRow: Signal<boolean> = computed(
+    () =>
+      this.phase() === 'formatting' &&
+      this.projectConfig().config?.ai_enabled === true,
+  );
+  protected readonly showRetryRow: Signal<SubmitError | null> = computed(() => {
+    const err = this.tagged();
+    return this.phase() === 'error' && err !== null ? err : null;
+  });
+
+  // Stagger delays. When reduced-motion is active every row mounts at 0 ms
+  // so all three rows appear together rather than cascading in.
+  protected readonly sanitisedDelayMs: Signal<number> = computed(() =>
+    this.reducedMotion() ? 0 : STATUS_ROW_STAGGER_MS,
+  );
+  protected readonly formattingDelayMs: Signal<number> = computed(() =>
+    this.reducedMotion() ? 0 : STATUS_ROW_STAGGER_MS * 2,
+  );
+
+  protected readonly fileLabel: Signal<string> = computed(() =>
+    this.attachmentsAtCap()
+      ? `Maximum ${MAX_ATTACHMENTS} attachments reached`
+      : 'Attach file',
+  );
+
+  // ── ID counters (refs in React; plain mutable fields here) ───────────────
+
+  private fileIdSeq = 0;
+  private messageIdSeq = 0;
+
+  // Track the @ViewChild composer textarea for the autogrow effect.
+  private readonly composerEl =
+    viewChild<ElementRef<HTMLTextAreaElement>>('composerEl');
+  private readonly keepBtn =
+    viewChild<ElementRef<HTMLButtonElement>>('keepBtn');
+
+  // Helpers exposed to the template — narrow wrappers around the module-level
+  // formatters so the binding expressions stay short.
+  protected relativeTime(ms: number | undefined): string {
+    return formatRelativeTime(ms);
+  }
+  protected size(bytes: number): string {
+    return formatSize(bytes);
+  }
+
   constructor() {
+    // Match the React adapter's reduced-motion gate: subscribe to the OS
+    // media query and update the signal so a user toggling the setting
+    // mid-submit picks up the change on the next render. SSR-safe — the
+    // `window.matchMedia` call is gated on `isPlatformBrowser`.
+    if (
+      isPlatformBrowser(this.platformId) &&
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function'
+    ) {
+      const mql: MediaQueryList = window.matchMedia(
+        '(prefers-reduced-motion: reduce)',
+      );
+      this.reducedMotion.set(mql.matches);
+      const onChange = (e: MediaQueryListEvent): void => {
+        if (this.destroyed) return;
+        this.reducedMotion.set(e.matches);
+      };
+      // `addEventListener` is the modern API; older Safari only ships the
+      // deprecated `addListener` fallback. Try the modern one first; the
+      // legacy fallback keeps the widget working for Safari 13.
+      if (typeof mql.addEventListener === 'function') {
+        mql.addEventListener('change', onChange);
+        this.destroyRef.onDestroy(() =>
+          mql.removeEventListener('change', onChange),
+        );
+      } else if (
+        typeof (mql as MediaQueryList & { addListener?: unknown })
+          .addListener === 'function'
+      ) {
+        (
+          mql as MediaQueryList & {
+            addListener: (cb: (e: MediaQueryListEvent) => void) => void;
+            removeListener: (cb: (e: MediaQueryListEvent) => void) => void;
+          }
+        ).addListener(onChange);
+        this.destroyRef.onDestroy(() =>
+          (
+            mql as MediaQueryList & {
+              removeListener: (cb: (e: MediaQueryListEvent) => void) => void;
+            }
+          ).removeListener(onChange),
+        );
+      }
+    }
+
+    // Composer autogrow: every time the draft signal mutates, snap the
+    // textarea height to its scrollHeight bounded by COMPOSER_MAX_HEIGHT_PX.
+    // The React adapter uses a layout effect; Angular's signal-driven
+    // `effect()` runs after the DOM commit and is the equivalent hook.
+    // Renderer2 (instead of direct DOM access) keeps the SSR build path
+    // safe — Renderer2 abstracts over the platform server's no-op renderer.
+    effect(() => {
+      // Read the draft signal so the effect re-runs when it changes.
+      this.draft();
+      const ref = this.composerEl();
+      const el = ref?.nativeElement;
+      if (!el) return;
+      this.renderer.setStyle(el, 'height', 'auto');
+      const next = Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT_PX);
+      this.renderer.setStyle(el, 'height', `${next}px`);
+    });
+
+    // Lazy project-config fetch on first panel open. Mirrors the React
+    // adapter's `useProjectConfig` hook: explicitly does NOT fetch on mount,
+    // so the widget's "zero-cost until opened" property holds.
+    let triggered = false;
+    effect(() => {
+      if (!this.open()) return;
+      if (triggered) return;
+      triggered = true;
+      this.projectConfig.set({ status: 'loading', config: null });
+      void this.brevwick
+        .getConfig()
+        .then((config) => {
+          if (this.destroyed) return;
+          this.projectConfig.set(
+            config !== null
+              ? { status: 'ready', config }
+              : { status: 'error', config: null },
+          );
+        })
+        .catch(() => {
+          if (this.destroyed) return;
+          this.projectConfig.set({ status: 'error', config: null });
+        });
+    });
+
+    // Move focus to the "Keep" button when the discard confirm appears,
+    // mirroring the React adapter — the non-destructive default lands under
+    // the keyboard so an accidental Enter preserves the draft.
+    effect(() => {
+      if (!this.confirmClose()) return;
+      const btn = this.keepBtn()?.nativeElement;
+      btn?.focus();
+    });
+
     this.destroyRef.onDestroy(() => {
       this.destroyed = true;
     });
   }
 
+  // ── Open / close / reset ─────────────────────────────────────────────────
+
   protected toggle(): void {
     if (!isPlatformBrowser(this.platformId)) return;
-    this.open.update((v) => !v);
-    if (!this.open()) {
+    if (this.open()) {
+      this.minimize();
+    } else {
+      this.open.set(true);
       this.errorMessage.set(null);
     }
   }
 
-  protected close(): void {
+  /**
+   * Close the panel without discarding draft content. Mirrors the React
+   * adapter's `handleMinimize`: the user gets back to their work but the
+   * composer state, attachments, and any in-flight error survive.
+   */
+  protected minimize(): void {
     this.open.set(false);
+    this.confirmClose.set(false);
     this.errorMessage.set(null);
-  }
-
-  protected onDraftChange(value: string): void {
-    this.draft.set(value);
   }
 
   /**
-   * Submit handler bound to the panel's primary button. Validates a
-   * non-empty draft, forwards `{ title, description }` to
-   * {@link BrevwickService.submit}, surfaces ingest errors via the
-   * `errorMessage` signal, and emits the SDK's `SubmitResult` on the
-   * `submit` `@Output`. Skips state mutations and emission if the
-   * component view is already destroyed.
-   *
-   * Marked `protected` so it is not part of the public TypeScript surface
-   * — consumers should listen to `(submit)` rather than calling this
-   * directly. Specs cast through a test-only interface to invoke it
-   * without driving a real DOM event (the same casting trick the specs
-   * already use to seed protected signals).
+   * Mapped from the panel header × button. When the draft has any content
+   * the button shows the discard confirm; when it is empty the panel
+   * closes immediately.
    */
-  protected async onSubmitClick(): Promise<void> {
-    const raw = this.draft();
-    if (raw.trim().length === 0) return;
+  protected onCloseClick(): void {
+    if (this.hasContent()) {
+      this.confirmClose.set(true);
+      return;
+    }
+    this.fullClose();
+  }
 
+  protected cancelClose(): void {
+    this.confirmClose.set(false);
+  }
+
+  protected discard(): void {
+    this.fullClose();
+  }
+
+  private fullClose(): void {
+    this.open.set(false);
+    this.resetAll();
+  }
+
+  private resetAll(): void {
+    this.draft.set('');
+    this.expected.set('');
+    this.actual.set('');
+    this.showExtras.set(false);
+    this.files.set([]);
+    this.confirmClose.set(false);
+    this.errorMessage.set(null);
+    this.messages.set([
+      { id: 'greeting', role: 'assistant', text: GREETING_TEXT },
+    ]);
+    this.useAi.set(true);
+    this.lastSubmittedInput.set(null);
+    this.brevwick.reset();
+  }
+
+  protected toggleExtras(): void {
+    this.showExtras.update((v) => !v);
+  }
+
+  // ── Composer events ──────────────────────────────────────────────────────
+
+  protected onDraftInput(event: Event): void {
+    const target = event.target as HTMLTextAreaElement;
+    this.draft.set(target.value);
+  }
+
+  protected onComposerKeydown(event: KeyboardEvent): void {
+    // Enter → submit; Shift+Enter (and any modifier combination) → newline.
+    // `isComposing` filters IME composition events so a Japanese / Chinese
+    // user converting kana to kanji with Enter does not accidentally send.
+    if (
+      event.key === 'Enter' &&
+      !event.shiftKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey &&
+      !event.isComposing
+    ) {
+      event.preventDefault();
+      void this.doSubmit();
+    }
+  }
+
+  protected toggleAi(): void {
+    this.useAi.update((v) => !v);
+  }
+
+  protected onAiToggleKeydown(event: KeyboardEvent): void {
+    if (event.key === ' ') {
+      event.preventDefault();
+      this.toggleAi();
+    }
+  }
+
+  protected onSendClick(): void {
+    void this.doSubmit();
+  }
+
+  // ── Files ────────────────────────────────────────────────────────────────
+
+  protected onFileChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.handleFiles(input.files);
+    // Clear so re-selecting the same file fires `change` again.
+    input.value = '';
+  }
+
+  private handleFiles(list: FileList | null): void {
+    if (!list || list.length === 0) return;
+    this.files.update((prev) => {
+      // Cap the total at MAX_ATTACHMENTS. Drop the overflow tail rather
+      // than silently dropping arbitrary entries — keeps prefix-of-input
+      // semantics so the user can predict which files made it through.
+      const remaining = MAX_ATTACHMENTS - prev.length;
+      if (remaining <= 0) return prev;
+      const next: FileAttachment[] = [];
+      for (let i = 0; i < Math.min(list.length, remaining); i++) {
+        const file = list.item(i);
+        if (file) next.push({ id: ++this.fileIdSeq, file });
+      }
+      return [...prev, ...next];
+    });
+  }
+
+  protected removeFile(id: number): void {
+    this.files.update((prev) => prev.filter((f) => f.id !== id));
+  }
+
+  // ── Submit / retry ───────────────────────────────────────────────────────
+
+  /**
+   * Build the `FeedbackInput` from the current draft + extras + files +
+   * AI-toggle render-policy. Title is the first non-empty line, sliced to
+   * 120 chars; description is the **raw** draft (the trim-fix landed in
+   * PR #111 — must not regress).
+   */
+  private buildInput(): FeedbackInput {
+    const draftValue = this.draft();
+    const trimmed = draftValue.trim();
+    const title = trimmed.split('\n', 1)[0]!.slice(0, 120);
+    const expectedTrim = this.expected().trim();
+    const actualTrim = this.actual().trim();
+    const attachments: Array<Blob | FeedbackAttachment> = this.files().map(
+      ({ file }) => ({ blob: file, filename: file.name }),
+    );
+    return {
+      title,
+      description: draftValue,
+      ...(expectedTrim ? { expected: expectedTrim } : {}),
+      ...(actualTrim ? { actual: actualTrim } : {}),
+      ...(attachments.length ? { attachments } : {}),
+      ...(this.showAiToggle() ? { use_ai: this.useAi() } : {}),
+    };
+  }
+
+  protected async doSubmit(): Promise<void> {
+    if (this.isSubmitting()) return;
+    if (!this.draft().trim()) {
+      this.errorMessage.set('Please describe what happened.');
+      return;
+    }
     this.errorMessage.set(null);
 
-    // Title from the trimmed first line so leading whitespace doesn't
-    // pollute the issue title; description sent raw to preserve the
-    // user's intentional whitespace + newlines (parity with React).
-    const title = raw.trim().split('\n', 1)[0]!.slice(0, 120);
+    const input = this.buildInput();
+    const submittedDraft = this.draft();
+
+    // Push the user's draft into the conversation immediately and clear
+    // the composer BEFORE awaiting submit(). The synchronous bubble + clear
+    // makes the wait feel fast — staged-status rows carry the rest of the
+    // animation while the network round-trip is in flight (issue #74).
+    this.messages.update((prev) => [
+      ...prev,
+      {
+        id: `msg-${++this.messageIdSeq}`,
+        role: 'user',
+        text: submittedDraft,
+      },
+    ]);
+    this.draft.set('');
+    this.expected.set('');
+    this.actual.set('');
+    this.showExtras.set(false);
+    this.files.set([]);
+    this.lastSubmittedInput.set(input);
 
     try {
-      const result: SubmitResult = await this.brevwick.submit({
-        title,
-        description: raw,
-      });
+      const result = await this.brevwick.submit(input);
       if (this.destroyed) return;
       this.submit.emit(result);
-      if (result.ok === true) {
-        this.draft.set('');
-        this.open.set(false);
-      } else {
-        this.errorMessage.set(result.error.message);
+      if (result.ok) {
+        this.messages.update((prev) => [
+          ...prev,
+          {
+            id: `msg-${++this.messageIdSeq}`,
+            role: 'assistant',
+            text: ASSISTANT_RECEIPT_TEXT,
+            issueSent: true,
+            sentAt: Date.now(),
+          },
+        ]);
       }
+      // Pop the panel back open so the success bubble or retry row is
+      // actually seen by a user who minimised mid-submit. Mirrors the
+      // React adapter — a silent success while hidden leaves the user
+      // unsure whether their issue landed.
+      this.open.set(true);
     } catch (err) {
       if (this.destroyed) return;
-      const message =
-        err instanceof Error && err.message
-          ? err.message
-          : 'We could not submit your feedback. Please try again.';
-      this.errorMessage.set(message);
+      // Chunk-load failure path — the service has already flipped phase
+      // to 'error' and stored the synthetic SubmitError. Just pop the
+      // panel back open so the retry row is visible.
+      void err;
+      this.open.set(true);
+    }
+  }
+
+  protected async onRetryClick(): Promise<void> {
+    const last = this.lastSubmittedInput();
+    if (!last) return;
+    if (this.isSubmitting()) return;
+    try {
+      const result = await this.brevwick.retry();
+      if (this.destroyed) return;
+      if (result) {
+        this.submit.emit(result);
+        if (result.ok) {
+          this.messages.update((prev) => [
+            ...prev,
+            {
+              id: `msg-${++this.messageIdSeq}`,
+              role: 'assistant',
+              text: ASSISTANT_RECEIPT_TEXT,
+              issueSent: true,
+              sentAt: Date.now(),
+            },
+          ]);
+        }
+      }
+      this.open.set(true);
+    } catch (err) {
+      if (this.destroyed) return;
+      void err;
+      this.open.set(true);
     }
   }
 }

--- a/packages/angular/src/lib/internal/phase-bus.ts
+++ b/packages/angular/src/lib/internal/phase-bus.ts
@@ -1,0 +1,48 @@
+import type { Brevwick } from '@tatlacas/brevwick-sdk';
+
+/**
+ * Submit-pipeline progress events. Mirrors `PhaseEvent` in the SDK's
+ * `core/internal.ts`. Replicated here (rather than imported) because the
+ * SDK intentionally does not export the internal surface from its package
+ * root — the Angular adapter reaches the bus through the `_internal`
+ * backdoor and types the listener locally, the same way the React adapter
+ * does (`packages/react/src/internal-bridge.ts`).
+ */
+export type PhaseEvent =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+
+/**
+ * Subset of the internal `Bus` we need: subscribe / unsubscribe to phase
+ * events. Keeping the structural type narrow means a future SDK change
+ * that adds new events does not pull broader internal types into the
+ * adapter's surface area.
+ */
+export interface PhaseBus {
+  on(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+  off(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+}
+
+/**
+ * Resolve the internal phase bus from a `Brevwick` instance, or return
+ * `null` if the runtime shape does not match (e.g. a test mock that does
+ * not stamp `_internal`). Adapters in this monorepo and the SDK live in
+ * lockstep, so the `'_internal'` string + structural shape is a stable
+ * coupling — but the adapter must not crash when consumers pass a
+ * differently-shaped object.
+ *
+ * Internal — not part of the Angular adapter's public API.
+ */
+export function getPhaseBus(brevwick: Brevwick): PhaseBus | null {
+  const internal = (brevwick as unknown as Record<string, unknown>)[
+    '_internal'
+  ];
+  if (!internal || typeof internal !== 'object') return null;
+  const bus = (internal as { bus?: unknown }).bus;
+  if (!bus || typeof bus !== 'object') return null;
+  const candidate = bus as { on?: unknown; off?: unknown };
+  if (typeof candidate.on !== 'function' || typeof candidate.off !== 'function')
+    return null;
+  return bus as PhaseBus;
+}

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -5,7 +5,11 @@
 
 export { provideBrevwick } from './lib/provide-brevwick';
 export { BREVWICK_CONFIG } from './lib/brevwick.tokens';
-export { BrevwickService, type FeedbackStatus } from './lib/brevwick.service';
+export {
+  BrevwickService,
+  type FeedbackPhase,
+  type FeedbackStatus,
+} from './lib/brevwick.service';
 export {
   BwFeedbackButtonComponent,
   type BwFeedbackButtonPosition,


### PR DESCRIPTION
Closes #115

## Summary

Brings `@tatlacas/brevwick-angular`'s `bw-feedback-button` standalone component to full UI/UX/wire parity with the React adapter (`packages/react/src/feedback-button.tsx`). The textarea-only subset is replaced by the chat-style panel every other adapter ships:

- **State** (Signals): `open`, `draft`, `expected`, `actual`, `showExtras`, `confirmClose`, `errorMessage`, `useAi`, `messages`, `files`, `lastSubmittedInput`, `projectConfig`, `reducedMotion` plus `computed` `hasContent` / `attachmentsAtCap` / `attachDisabled` / `canSend` / `showAiToggle` / `showCaptured` / `showSanitised` / `showFormattingRow` / `showRetryRow`.
- **Service surface**: `BrevwickService` extended with `phase`, `error`, `retry`, `getConfig` Signals — same shape as the React adapter's `useFeedback` (subscribes to the SDK's `_internal.bus` for phase events; new `packages/angular/src/lib/internal/phase-bus.ts` mirrors `packages/react/src/internal-bridge.ts`).
- **UI**: panel header (avatar/title/minimize/close), assistant + user bubbles with `formatRelativeTime` receipt, expected/actual disclosure, file attachment chips, composer (autogrow textarea via `Renderer2` + `effect(draft)`, `<input type="file">`, Material-style AI toggle, send button), DiscardConfirm with focus moved to "Keep", phase-driven `StatusRow` rendering (`check`/`spinner`), `RetryRow` with `data-brw-error-code`, footer `Brevwick v<version>`.
- **Behaviour**: title = first non-empty trimmed line of draft, description = **raw** draft (PR #111 contract), `use_ai` only on payload when toggle visible, retry replays `lastSubmittedInput`, Enter→submit / Shift+Enter→newline (with IME guard), reduced-motion gate on row stagger via `MediaQueryList`, theme bound through `[attr.data-brw-theme]`.
- **CSS**: `BREVWICK_CSS` ported into the component's `styles: [...]` array under `ViewEncapsulation.None` so a designer maintains a single stylesheet across React + Angular.
- **Bundle**: `.size-limit.js` Angular ceiling bumped from 8 kB → 18 kB. Current FESM2022 bundle is 15.53 kB gzipped (was 5.21 kB FAB-only). Justified inline at the entry: still well under React's 25 kB envelope (no Radix dialog dependency saves ~7 kB), Angular's standalone + Signals scaffolding overhead is irreducible.

## Out of scope

- Screenshot capture UI (region overlay, preview dialog) — Out of scope per the issue. Apps that need screenshots call `BrevwickService.captureScreenshot()` and pass the `Blob` through `submit`'s `attachments` field.
- Modifications to the SDK or `provideBrevwick` API.
- Cross-package CSS sharing.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test:cover` — Angular: 54 passing (was 14); coverage Statements 85.97% / Branches 70.42% / Functions 93.84% / Lines 90.03%, all above the 70/60/70/70 thresholds
- [x] `pnpm build` — every package builds
- [x] `pnpm size` — every entry inside budget; Angular 15.53 kB / 18 kB