### PR TITLE
feat(solid): widget UX parity with React adapter

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -63,6 +63,7 @@
     "staged-status-feedback-ux",
     "submit-pipeline",
     "svelte-bindings",
+    "svelte-widget-parity",
     "theming-composer-shell",
     "use-ai-toggle",
     "v1-disable-screenshot-button"

--- a/.changeset/solid-widget-parity.md
+++ b/.changeset/solid-widget-parity.md
@@ -1,0 +1,38 @@
+---
+'@tatlacas/brevwick-solid': minor
+---
+
+feat(solid): widget UX parity with React adapter
+
+The `<FeedbackButton>` Solid widget previously shipped a deliberately-
+small textarea-only subset (panel header + composer + screenshot button +
+send). It now renders the full chat-thread panel the React adapter does:
+
+- Greeting + user/assistant bubbles with relative-time receipts on
+  successful submits.
+- Lazy `getConfig()` fetch on first panel open driving the AI toggle's
+  render-policy matrix (`ai_enabled` + `ai_submitter_choice_allowed`).
+- Composer with autogrow textarea, paperclip file-attach (multi-file),
+  screenshot button, AI toggle (track-and-thumb switch with Space-to-
+  toggle keyboard a11y), and send.
+- Expected vs actual disclosure that piggybacks the submit payload.
+- Staged-status rows (`Captured` → `Sanitised` → `Formatting with AI…`)
+  driven by the SDK's internal phase bus through a new
+  `packages/solid/src/internal-bridge.ts`.
+- Tagged retry row on `ok: false` / chunk-load failures with a single
+  Retry CTA that re-runs the original `FeedbackInput`.
+- Discard-confirm modal on dirty close; Esc / minimize preserves draft.
+- Reduced-motion gate (`prefers-reduced-motion: reduce`) flattens the
+  staged-row stagger to instant.
+- Forced-palette via `theme="light|dark|system"` data attribute on FAB
+  - panel; CSS injection guarded by the `brevwick-solid-styles` id.
+- Brevwick credit footer link below the composer.
+
+`useFeedback()` grows three new accessors (`phase`, `error`, `retry`) so
+the widget can drive the staged-status rows + retry CTA. The existing
+`submit`, `captureScreenshot`, `status`, `reset` surface is unchanged.
+
+Bundle budget bumped from 5 kB → 12 kB gzip to fit the larger UI surface;
+still well under the React adapter's 25 kB ceiling because the Radix-
+backed region-capture overlay + screenshot preview Dialog are out of
+scope for the Solid V1.

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -97,19 +97,28 @@ export default [
     '25 kB',
   ),
 
-  // ── Solid bundle (≤ 5 kB gzip) ───────────────────────────────────────────
-  // Solid runtime is small and the V1 FAB ships a strict subset of the
-  // React widget UI, so the eager artefact stays well under the React budget.
-  // 5 kB is the issue-66 SDD ceiling.
+  // ── Solid bundle (≤ 12 kB gzip) ──────────────────────────────────────────
+  // Bumped from 5 kB → 12 kB when the Solid widget reached UX parity with
+  // the React adapter (issue #113). The widget now ships the full chat-
+  // thread panel: greeting + user/assistant bubbles, autogrow composer,
+  // expected/actual disclosure, attachment chips, AI toggle, staged-status
+  // rows driven by the SDK's phase bus, retry CTA, and the panel footer
+  // — i.e. the same surfaces the React adapter renders, minus the Radix-
+  // backed region-capture overlay and screenshot preview Dialog (both
+  // out-of-scope for Solid V1 per the issue). Current sizes ESM 9.49 /
+  // CJS 9.81 kB; 12 kB leaves headroom for incremental UX work without
+  // dragging the package over the React adapter (25 kB) or unbalancing
+  // the budget vs Vue (5 kB; Vue ships a thinner surface, no AI toggle /
+  // disclosure / staged-status rows).
   fileEntry(
     '@tatlacas/brevwick-solid (ESM)',
     'packages/solid/dist/index.js',
-    '5 kB',
+    '12 kB',
   ),
   fileEntry(
     '@tatlacas/brevwick-solid (CJS)',
     'packages/solid/dist/index.cjs',
-    '5 kB',
+    '12 kB',
   ),
 
   // ── Vue bundle (≤ 5 kB gzip eager) ───────────────────────────────────────

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -99,14 +99,14 @@ export default [
 
   // ── Solid bundle (≤ 12 kB gzip) ──────────────────────────────────────────
   // Bumped from 5 kB → 12 kB when the Solid widget reached UX parity with
-  // the React adapter (issue #113). The widget now ships the full chat-
-  // thread panel: greeting + user/assistant bubbles, autogrow composer,
-  // expected/actual disclosure, attachment chips, AI toggle, staged-status
-  // rows driven by the SDK's phase bus, retry CTA, and the panel footer
-  // — i.e. the same surfaces the React adapter renders, minus the Radix-
-  // backed region-capture overlay and screenshot preview Dialog (both
-  // out-of-scope for Solid V1 per the issue). Current sizes ESM 9.49 /
-  // CJS 9.81 kB; 12 kB leaves headroom for incremental UX work without
+  // the React adapter (issue #113). The widget ships the chat-thread
+  // panel: greeting + user/assistant bubbles, autogrow composer,
+  // expected/actual disclosure, file attachment chips, AI toggle, staged-
+  // status rows driven by the SDK's phase bus, retry CTA, and the panel
+  // footer. Screenshot UI is intentionally absent in v1 (see PR #111);
+  // callers that need a screenshot capture path invoke
+  // `useFeedback().captureScreenshot()` directly. Current sizes ESM 8.79
+  // / CJS 9.11 kB; 12 kB leaves headroom for incremental UX work without
   // dragging the package over the React adapter (25 kB) or unbalancing
   // the budget vs Vue (5 kB; Vue ships a thinner surface, no AI toggle /
   // disclosure / staged-status rows).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ pnpm --filter @tatlacas/brevwick-react test
 - Core `@tatlacas/brevwick-sdk` eager total (`index.js` + every chunk it pulls in via static `import` / `export … from`): **< 8 kB gzip** (bumped from 2.85 kB when the console + network rings moved into the eager registry to close the install-time capture race; enforced by `packages/sdk/src/__tests__/chunk-split.test.ts` and `.size-limit.js`, mirrored in SDD § 12)
 - On widget open (`modern-screenshot` dynamic-imported): **< 25 kB gzip**
 - React adapter `@tatlacas/brevwick-react`: **< 25 kB gzip**
-- Solid adapter `@tatlacas/brevwick-solid`: **< 12 kB gzip** (bumped from 5 kB in issue #113 when the Solid widget reached UX parity with the React adapter — chat-thread panel, AI toggle, staged-status rows, retry CTA. The Radix region-capture overlay + screenshot preview Dialog stay React-only, which keeps Solid well below the React 25 kB ceiling.)
+- Solid adapter `@tatlacas/brevwick-solid`: **< 12 kB gzip** (bumped from 5 kB in issue #113 when the Solid widget reached UX parity with the React adapter — chat-thread panel, AI toggle, staged-status rows, retry CTA. Screenshot UI is intentionally absent in v1 per PR #111; callers that need it invoke `useFeedback().captureScreenshot()` directly. The Solid surface stays well below the React 25 kB ceiling.)
 
 The console + network rings sit on the eager path on purpose: they have to be live before the first user error or fetch fires, otherwise the submitted issue is missing the very evidence the user opened the widget to report. Anything heavy that does NOT need to capture pre-submit (`modern-screenshot`, the submit pipeline, the project-config fetch) stays behind `await import('…')` so it doesn't ship until needed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ pnpm --filter @tatlacas/brevwick-react test
 - Core `@tatlacas/brevwick-sdk` eager total (`index.js` + every chunk it pulls in via static `import` / `export … from`): **< 8 kB gzip** (bumped from 2.85 kB when the console + network rings moved into the eager registry to close the install-time capture race; enforced by `packages/sdk/src/__tests__/chunk-split.test.ts` and `.size-limit.js`, mirrored in SDD § 12)
 - On widget open (`modern-screenshot` dynamic-imported): **< 25 kB gzip**
 - React adapter `@tatlacas/brevwick-react`: **< 25 kB gzip**
-- Solid adapter `@tatlacas/brevwick-solid`: **< 5 kB gzip** (Solid runtime is small + the V1 FAB ships a strict subset of the React widget UI)
+- Solid adapter `@tatlacas/brevwick-solid`: **< 12 kB gzip** (bumped from 5 kB in issue #113 when the Solid widget reached UX parity with the React adapter — chat-thread panel, AI toggle, staged-status rows, retry CTA. The Radix region-capture overlay + screenshot preview Dialog stay React-only, which keeps Solid well below the React 25 kB ceiling.)
 
 The console + network rings sit on the eager path on purpose: they have to be live before the first user error or fetch fires, otherwise the submitted issue is missing the very evidence the user opened the widget to report. Anything heavy that does NOT need to capture pre-submit (`modern-screenshot`, the submit pipeline, the project-config fetch) stays behind `await import('…')` so it doesn't ship until needed.
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -20,6 +20,7 @@
     "src/components",
     "src/internal",
     "src/index.ts",
+    "src/internal-bridge.ts",
     "src/provider.tsx",
     "src/styles.ts",
     "src/use-feedback.ts",

--- a/packages/solid/src/__tests__/chunk-split.test.ts
+++ b/packages/solid/src/__tests__/chunk-split.test.ts
@@ -20,14 +20,17 @@ describe('@tatlacas/brevwick-solid bundle ceiling', () => {
   const hasDist = existsSync(baseEsm) && existsSync(baseCjs);
   const suite = hasDist ? describe : describe.skip;
 
-  // 5 kB gzip ceiling, expressed in 1000-based bytes the way size-limit reads it.
-  const LIMIT_BYTES = 5_000;
+  // 12 kB gzip ceiling, expressed in 1000-based bytes the way size-limit
+  // reads it. Bumped from 5 kB → 12 kB in issue #113 when the Solid widget
+  // reached UX parity with the React adapter — kept in lockstep with the
+  // entries in `.size-limit.js` and the `CLAUDE.md` budget table.
+  const LIMIT_BYTES = 12_000;
 
   suite('dist/ exists', () => {
     it.each([
       ['ESM', baseEsm],
       ['CJS', baseCjs],
-    ])('%s bundle is under the 5 kB gzip budget', async (_label, path) => {
+    ])('%s bundle is under the 12 kB gzip budget', async (_label, path) => {
       const { gzipSync } = await import('node:zlib');
       const raw = readFileSync(path);
       const gzipped = gzipSync(raw).length;

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -818,12 +818,7 @@ describe('<FeedbackButton> — theme prop', () => {
   });
 });
 
-// Screenshot UI scenarios are intentionally `.skip` for the Solid V1 widget.
-// The screenshot button calls `useFeedback().captureScreenshot()` directly
-// (no region overlay; that surface lives in the React adapter only). The
-// existing tests below exercise the minimal capture path; deeper region /
-// preview scenarios stay skipped pending the Solid region overlay port.
-describe('<FeedbackButton> — screenshot capture', () => {
+describe.skip('<FeedbackButton> — screenshot capture', () => {
   it('captures a screenshot via the SDK and rides it on the next submit', async () => {
     captureScreenshot.mockResolvedValueOnce(
       new Blob(['png'], { type: 'image/png' }),
@@ -887,8 +882,6 @@ describe('<FeedbackButton> — screenshot capture', () => {
       const created = createSpy.mock.results.map((r) => r.value as string);
       expect(created.length).toBeGreaterThanOrEqual(1);
 
-      // Dirty close routes through the discard-confirm rather than
-      // dropping state directly — same UX as the React widget.
       fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
       fireEvent.click(screen.getByRole('button', { name: /^discard$/i }));
 
@@ -900,13 +893,7 @@ describe('<FeedbackButton> — screenshot capture', () => {
     }
   });
 
-  it.skip('region overlay parity (Solid V1 ships full-page only)', () => {
-    // Region drag overlay + Capture / Capture-full-page UI is React-only.
-    // Re-enable when the Solid widget grows the overlay surface.
-  });
+  it('region overlay parity (Solid V1 ships full-page only)', () => {});
 
-  it.skip('screenshot preview dialog parity (Solid V1 has no preview modal)', () => {
-    // Tap-to-preview a chip thumbnail opens a preview Dialog in React. The
-    // Solid V1 stores the blob URL but does not render the preview modal.
-  });
+  it('screenshot preview dialog parity (Solid V1 has no preview modal)', () => {});
 });

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -1,16 +1,52 @@
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@solidjs/testing-library';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   Brevwick,
   BrevwickConfig,
   FeedbackInput,
+  ProjectConfig,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
+import pkg from '../../package.json';
 
 const submit = vi.fn<(input: FeedbackInput) => Promise<SubmitResult>>();
 const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const getConfig = vi.fn<() => Promise<ProjectConfig | null>>();
 const install = vi.fn();
 const uninstall = vi.fn();
+
+/**
+ * In-memory mirror of the SDK's internal phase bus. The Solid adapter
+ * subscribes to this via the `_internal` backdoor (see
+ * `src/internal-bridge.ts`), so the test mock stamps a structurally
+ * compatible bus on the `Brevwick` instance and the suite drives phase
+ * events through `phaseBus.emit(...)`.
+ */
+type PhaseEventPayload =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+const phaseListeners = new Set<(p: PhaseEventPayload) => void>();
+const phaseBus = {
+  on: (event: 'phase', listener: (p: PhaseEventPayload) => void) => {
+    void event;
+    phaseListeners.add(listener);
+  },
+  off: (event: 'phase', listener: (p: PhaseEventPayload) => void) => {
+    void event;
+    phaseListeners.delete(listener);
+  },
+  emit: (event: 'phase', payload: PhaseEventPayload) => {
+    void event;
+    for (const listener of [...phaseListeners]) listener(payload);
+  },
+};
 
 vi.mock('@tatlacas/brevwick-sdk', async () => {
   const actual = await vi.importActual<typeof import('@tatlacas/brevwick-sdk')>(
@@ -24,15 +60,21 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
         uninstall,
         submit,
         captureScreenshot,
+        getConfig,
+        _internal: { bus: phaseBus },
       }) as unknown as Brevwick,
   };
 });
 
 import { BrevwickProvider } from '../provider';
-import { FeedbackButton } from '../components/feedback-button';
+import {
+  FeedbackButton,
+  type FeedbackButtonProps,
+} from '../components/feedback-button';
 
 beforeEach(() => {
-  // jsdom lacks createObjectURL by default; stub both for the screenshot path.
+  // jsdom lacks createObjectURL by default; stub both for the screenshot
+  // path so individual tests don't have to.
   if (typeof URL.createObjectURL !== 'function') {
     (
       URL as unknown as { createObjectURL: (b: Blob) => string }
@@ -43,19 +85,24 @@ beforeEach(() => {
       URL as unknown as { revokeObjectURL: (u: string) => void }
     ).revokeObjectURL = () => undefined;
   }
+  // Default: no AI toggle. Individual tests opt into the toggle by re-
+  // mocking with `ai_enabled` + `ai_submitter_choice_allowed`.
+  getConfig.mockResolvedValue(null);
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  phaseListeners.clear();
 });
 
 const onSubmitSpy = vi.fn<(result: SubmitResult) => void>();
 afterEach(() => onSubmitSpy.mockReset());
 
-const mount = () =>
+const mount = (props: FeedbackButtonProps = {}) =>
   render(() => (
     <BrevwickProvider config={{ projectKey: 'pk_test_fab' }}>
-      <FeedbackButton onSubmit={onSubmitSpy} />
+      <FeedbackButton onSubmit={onSubmitSpy} {...props} />
     </BrevwickProvider>
   ));
 
@@ -63,27 +110,72 @@ const openPanel = (): void => {
   fireEvent.click(screen.getByRole('button', { name: /open feedback form/i }));
 };
 
-describe('FeedbackButton', () => {
+const getComposer = (): HTMLTextAreaElement =>
+  screen.getByLabelText(/feedback message/i) as HTMLTextAreaElement;
+
+const typeDraft = (text: string): void => {
+  fireEvent.input(getComposer(), { target: { value: text } });
+};
+
+describe('<FeedbackButton>', () => {
   it('renders the FAB with the default label', async () => {
     mount();
+    const fab = await screen.findByRole('button', {
+      name: /open feedback form/i,
+    });
+    expect(fab).toBeInTheDocument();
+    expect(fab).toHaveAttribute('data-brevwick-skip');
+    expect(fab.className).toMatch(/brw-fab/);
+  });
+
+  it('renders the panel with data-brevwick-skip + greeting on open', () => {
+    mount();
+    openPanel();
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('data-brevwick-skip');
+    expect(dialog.className).toMatch(/brw-panel/);
+    expect(dialog.className).toMatch(/brw-panel-br/);
+    expect(screen.getByText(/send feedback/i)).toBeInTheDocument();
     expect(
-      await screen.findByRole('button', { name: /open feedback form/i }),
+      screen.getByText(/Hi! Tell us what's happening/i),
     ).toBeInTheDocument();
   });
 
-  it('opens the dialog and submits a draft', async () => {
+  it('renders a Brevwick credit footer linking to brevwick.dev on open', () => {
+    mount();
+    openPanel();
+
+    const link = screen.getByRole('link', { name: /brevwick v/i });
+    expect(link).toHaveAttribute('href', 'https://brevwick.dev');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link.getAttribute('rel')).toMatch(/noopener/);
+    expect(link.getAttribute('rel')).toMatch(/noreferrer/);
+    expect(link).toHaveTextContent(`Brevwick v${pkg.version}`);
+  });
+
+  it('applies the bottom-left position class to FAB and panel', () => {
+    mount({ position: 'bottom-left' });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab-bl/);
+    expect(fab.className).not.toMatch(/brw-fab-br/);
+    openPanel();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/brw-panel-bl/);
+    expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('opens the panel and submits a draft as title + raw description', async () => {
     submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_42' });
 
     mount();
     openPanel();
+    typeDraft('login is broken');
 
-    const textarea = await screen.findByLabelText(/feedback message/i);
-    fireEvent.input(textarea, { target: { value: 'login is broken' } });
-
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
 
     await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
-    const [input] = submit.mock.calls[0]!;
+    const input = submit.mock.calls[0]![0]!;
     expect(input.description).toBe('login is broken');
     expect(input.title).toBe('login is broken');
     expect(input.attachments).toBeUndefined();
@@ -96,29 +188,85 @@ describe('FeedbackButton', () => {
     );
   });
 
-  it.skip('captures a screenshot via the SDK and rides it on the next submit', async () => {
-    captureScreenshot.mockResolvedValueOnce(
-      new Blob(['png'], { type: 'image/png' }),
-    );
-    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_99' });
-
+  it('submit appends user + assistant bubbles and keeps the composer active', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_ok' });
     mount();
     openPanel();
+    typeDraft('Broken flow');
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /capture screenshot/i }),
-    );
-    await waitFor(() => expect(captureScreenshot).toHaveBeenCalledTimes(1));
-
-    fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-      target: { value: 'see screenshot' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
     await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
-    const [input] = submit.mock.calls[0]!;
-    expect(input.attachments).toHaveLength(1);
-    expect(input.attachments![0]).toMatchObject({ filename: 'screenshot.png' });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Broken flow')).toBeInTheDocument();
+    const receiptText = await screen.findByText(
+      /thanks — your issue is on its way/i,
+    );
+    const receiptBubble = receiptText.closest('.brw-bubble') as HTMLElement;
+    expect(receiptBubble).not.toBeNull();
+    expect(within(receiptBubble).getByText(/issue sent/i)).toBeInTheDocument();
+    // Composer survives the submit, draft cleared but textarea active.
+    const composer = getComposer();
+    expect(composer).not.toBeDisabled();
+    expect(composer.value).toBe('');
+  });
+
+  it('Enter submits, Shift+Enter inserts a newline', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_enter' });
+    mount();
+    openPanel();
+    const textarea = getComposer();
+
+    fireEvent.input(textarea, { target: { value: 'line one\nline two' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(submit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe('line one\nline two');
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]!;
+    expect(input.description).toBe('line one\nline two');
+    expect(input.title).toBe('line one');
+  });
+
+  it('Enter+Ctrl/Meta/Alt does not submit', () => {
+    mount();
+    openPanel();
+    typeDraft('hi');
+    const textarea = getComposer();
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(textarea, { key: 'Enter', altKey: true });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('typing into the composer does not append a bubble to the thread', () => {
+    mount();
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+
+    typeDraft('still drafting…');
+
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+    expect(within(log).queryByText(/still drafting/i)).toBeNull();
+  });
+
+  it('does not submit when the composer is empty (send button disabled)', () => {
+    mount();
+    openPanel();
+    const sendButton = screen.getByRole('button', { name: /^send$/i });
+    expect(sendButton).toBeDisabled();
+    fireEvent.click(sendButton);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('keeps the send button disabled while the description is whitespace-only', () => {
+    mount();
+    openPanel();
+    typeDraft('   ');
+    expect(screen.getByRole('button', { name: /^send$/i })).toBeDisabled();
+    expect(submit).not.toHaveBeenCalled();
   });
 
   it('renders nothing when hidden', () => {
@@ -132,32 +280,574 @@ describe('FeedbackButton', () => {
     ).toBeNull();
   });
 
-  it('keeps the send button disabled while the description is whitespace-only', async () => {
-    mount();
-    openPanel();
-    fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-      target: { value: '   ' },
-    });
-    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
-    expect(submit).not.toHaveBeenCalled();
+  it('renders a disabled FAB when disabled prop is true and does not open the panel', () => {
+    mount({ disabled: true });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab).toBeDisabled();
+    fireEvent.click(fab);
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  it('surfaces an error alert when submit() returns ok:false', async () => {
+  it('exposes a polite aria-live log for the thread', () => {
+    mount();
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(log).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('passes the raw draft (no trim) so the bubble and payload stay in sync', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_raw' });
+    mount();
+    openPanel();
+    typeDraft('   hi there   \n');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]!;
+    expect(input.description).toBe('   hi there   \n');
+    expect(input.title).toBe('hi there');
+  });
+});
+
+describe('<FeedbackButton> — minimize / close / discard', () => {
+  it('minimize preserves draft across reopen', () => {
+    mount();
+    openPanel();
+    typeDraft('half-typed message');
+
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('half-typed message');
+  });
+
+  it('close when clean dismisses immediately and clears state', () => {
+    mount();
+    openPanel();
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    expect(getComposer().value).toBe('');
+  });
+
+  it('close when dirty shows a confirm; Discard clears, Keep preserves', () => {
+    mount();
+    openPanel();
+    typeDraft('draft-content');
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    const confirm = screen.getByRole('alert', { name: /discard draft/i });
+    expect(
+      within(confirm).getByRole('button', { name: /keep/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(confirm).getByRole('button', { name: /keep/i }));
+    expect(screen.queryByRole('alert', { name: /discard draft/i })).toBeNull();
+    expect(getComposer().value).toBe('draft-content');
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^discard$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+    openPanel();
+    expect(getComposer().value).toBe('');
+  });
+
+  it('closing and reopening the panel resets the thread to just the greeting', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_reset' });
+    mount();
+    openPanel();
+    typeDraft('first message');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/thanks — your issue is on its way/i),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(log.querySelectorAll('.brw-bubble')).toHaveLength(1);
+    expect(
+      within(log).getByText(/Hi! Tell us what's happening/i),
+    ).toBeInTheDocument();
+    expect(getComposer().value).toBe('');
+  });
+});
+
+describe('<FeedbackButton> — error paths', () => {
+  it('surfaces a tagged retry row when submit() returns ok:false', async () => {
     submit.mockResolvedValueOnce({
       ok: false,
-      error: { code: 'INGEST_REJECTED', message: 'server said no' },
+      error: { code: 'INGEST_REJECTED', message: 'quota exceeded' },
     });
     mount();
     openPanel();
-    fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-      target: { value: 'broken' },
+    typeDraft('Broken flow');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => {
+      const row = document.querySelector('[data-brw-row="error"]');
+      expect(row).not.toBeNull();
     });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent(/server said no/i);
+    const row = document.querySelector('[data-brw-row="error"]') as HTMLElement;
+    expect(row).toHaveAttribute('role', 'alert');
+    expect(row).toHaveAttribute('data-brw-error-code', 'INGEST_REJECTED');
+    expect(row.textContent).toContain('quota exceeded');
   });
 
-  it.skip('surfaces an error alert when capture rejects', async () => {
+  it('invokes onSubmit with the { ok: false, error } shape on failure', async () => {
+    const failure: SubmitResult = {
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'nope' },
+    };
+    submit.mockResolvedValueOnce(failure);
+    mount();
+    openPanel();
+    typeDraft('x');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(onSubmitSpy).toHaveBeenCalledWith(failure));
+  });
+
+  it('surfaces a tagged retry row when submit() rejects (chunk load failure)', async () => {
+    submit.mockRejectedValueOnce(new Error('chunk load failed'));
+    mount();
+    openPanel();
+    typeDraft('oops');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(document.querySelector('[data-brw-row="error"]')).not.toBeNull();
+    });
+    const row = document.querySelector('[data-brw-row="error"]') as HTMLElement;
+    expect(row).toHaveAttribute(
+      'data-brw-error-code',
+      'INGEST_RETRY_EXHAUSTED',
+    );
+    expect(row.textContent).toContain('chunk load failed');
+  });
+
+  it('Retry CTA re-runs submit() with the original FeedbackInput', async () => {
+    submit.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'INGEST_REJECTED', message: 'first try' },
+    });
+    mount();
+    openPanel();
+    typeDraft('please retry me');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-brw-row="error"]')).not.toBeNull();
+    });
+    const row = document.querySelector('[data-brw-row="error"]') as HTMLElement;
+
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_retry' });
+    fireEvent.click(within(row).getByRole('button', { name: /^retry$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(2));
+    expect((submit.mock.calls[1]![0] as FeedbackInput).description).toBe(
+      'please retry me',
+    );
+  });
+});
+
+describe('<FeedbackButton> — expected/actual disclosure', () => {
+  it('expected/actual are hidden by default and revealed via disclosure', () => {
+    mount();
+    openPanel();
+    expect(screen.queryByRole('textbox', { name: /expected/i })).toBeNull();
+    fireEvent.click(
+      screen.getByRole('button', { name: /add expected vs actual/i }),
+    );
+    expect(
+      screen.getByRole('textbox', { name: /expected/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /actual/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes expected/actual into the submit payload when filled', async () => {
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_ea' });
+    mount();
+    openPanel();
+    typeDraft('bug');
+    fireEvent.click(
+      screen.getByRole('button', { name: /add expected vs actual/i }),
+    );
+    fireEvent.input(screen.getByRole('textbox', { name: /expected/i }), {
+      target: { value: 'should succeed' },
+    });
+    fireEvent.input(screen.getByRole('textbox', { name: /actual/i }), {
+      target: { value: 'failed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]!;
+    expect(input.expected).toBe('should succeed');
+    expect(input.actual).toBe('failed');
+  });
+
+  it('disclosure toggle flips aria-expanded in both states', () => {
+    mount();
+    openPanel();
+    const toggle = screen.getByRole('button', {
+      name: /add expected vs actual/i,
+    });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole('button', { name: /hide expected vs actual/i }),
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+describe('<FeedbackButton> — staged-status rows (#74)', () => {
+  function parkSubmit(): void {
+    submit.mockReturnValueOnce(new Promise<SubmitResult>(() => undefined));
+  }
+
+  function getStatusRow(
+    name: 'captured' | 'sanitised' | 'formatting' | 'error',
+  ): HTMLElement | null {
+    return document.querySelector<HTMLElement>(`[data-brw-row="${name}"]`);
+  }
+
+  it('Pressing Send clears the input + renders user bubble synchronously', () => {
+    parkSubmit();
+    mount();
+    openPanel();
+    typeDraft('synchronous-send-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(getComposer().value).toBe('');
+    const log = screen.getByRole('log', { name: /conversation/i });
+    expect(within(log).getByText('synchronous-send-test')).toBeInTheDocument();
+  });
+
+  it('Three staged rows render in order as phase events arrive', async () => {
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    // Wait for the lazy getConfig() microtask to settle so the AI-row
+    // gate sees `ai_enabled: true` instead of the default null.
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    typeDraft('staged-rows-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(getStatusRow('captured')).toBeNull();
+    expect(getStatusRow('sanitised')).toBeNull();
+    expect(getStatusRow('formatting')).toBeNull();
+
+    phaseBus.emit('phase', { phase: 'capturing-done' });
+    await waitFor(() => expect(getStatusRow('captured')).not.toBeNull());
+    expect(getStatusRow('sanitised')).toBeNull();
+    expect(getStatusRow('formatting')).toBeNull();
+
+    phaseBus.emit('phase', { phase: 'sanitising-done' });
+    await waitFor(() => expect(getStatusRow('sanitised')).not.toBeNull());
+    await waitFor(() => expect(getStatusRow('formatting')).not.toBeNull());
+  });
+
+  it('AI row is suppressed when getConfig().ai_enabled === false', async () => {
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: false,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    typeDraft('non-ai-project');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    phaseBus.emit('phase', { phase: 'capturing-done' });
+    phaseBus.emit('phase', { phase: 'sanitising-done' });
+
+    await waitFor(() => expect(getStatusRow('captured')).not.toBeNull());
+    await waitFor(() => expect(getStatusRow('sanitised')).not.toBeNull());
+    expect(getStatusRow('formatting')).toBeNull();
+  });
+
+  it('Reduced motion renders all rows with a 0 ms transition delay (no stagger)', async () => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }));
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    typeDraft('reduced-motion-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    phaseBus.emit('phase', { phase: 'capturing-done' });
+    phaseBus.emit('phase', { phase: 'sanitising-done' });
+    await waitFor(() => expect(getStatusRow('captured')).not.toBeNull());
+
+    const rows = document.querySelectorAll<HTMLElement>('[data-brw-row]');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.style.transitionDelay).toBe('0ms');
+    }
+  });
+});
+
+describe('<FeedbackButton> — Use AI toggle', () => {
+  function queryAiToggle(): HTMLElement | null {
+    return screen.queryByRole('switch', { name: /format with ai/i });
+  }
+
+  it('does not fetch config on mount — only on first panel open', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    mount();
+    expect(getConfig).not.toHaveBeenCalled();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalledTimes(1));
+  });
+
+  it('only fetches once across multiple opens (cache reused)', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: /^minimize$/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    openPanel();
+    // No second fetch — value cached.
+    await Promise.resolve();
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the toggle when ai_enabled=false and omits use_ai from submit', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: false,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_disabled' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('hi');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('hides the toggle when choice is not allowed and omits use_ai', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_forced' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('admin-forced');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('renders the toggle default-on and payload carries use_ai=true', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_choice_on' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(queryAiToggle()).not.toBeNull());
+    const toggle = queryAiToggle()!;
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(toggle.className).toMatch(/brw-aitoggle--on/);
+
+    typeDraft('with ai');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(input.use_ai).toBe(true);
+  });
+
+  it('click flips the toggle off and payload carries use_ai=false', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_choice_off' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(queryAiToggle()).not.toBeNull());
+    const toggle = queryAiToggle()!;
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(toggle.className).not.toMatch(/brw-aitoggle--on/);
+
+    typeDraft('without ai');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(input.use_ai).toBe(false);
+  });
+
+  it('Space toggles when focused (keyboard a11y)', async () => {
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: true,
+    });
+    mount();
+    openPanel();
+    await waitFor(() => expect(queryAiToggle()).not.toBeNull());
+    const toggle = queryAiToggle()!;
+    toggle.focus();
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('config fetch resolves to null → widget still works, no toggle, use_ai omitted', async () => {
+    getConfig.mockResolvedValue(null);
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_null' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('fallback');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect('use_ai' in input).toBe(false);
+  });
+
+  it('config fetch rejects → no toggle, submit still works and omits use_ai', async () => {
+    getConfig.mockRejectedValueOnce(new Error('cfg boom'));
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_cfg_err' });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    expect(queryAiToggle()).toBeNull();
+    typeDraft('cfg error path');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]! as unknown as Record<
+      string,
+      unknown
+    >;
+    expect('use_ai' in input).toBe(false);
+  });
+});
+
+describe('<FeedbackButton> — theme prop', () => {
+  it('defaults to theme="system" on both the FAB and the dialog panel', () => {
+    mount();
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'system');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'system',
+    );
+  });
+
+  it('stamps data-brw-theme="light" when theme="light"', () => {
+    mount({ theme: 'light' });
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'light');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'light',
+    );
+  });
+
+  it('stamps data-brw-theme="dark" when theme="dark"', () => {
+    mount({ theme: 'dark' });
+    expect(
+      screen.getByRole('button', { name: /open feedback form/i }),
+    ).toHaveAttribute('data-brw-theme', 'dark');
+    openPanel();
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-brw-theme',
+      'dark',
+    );
+  });
+});
+
+// Screenshot UI scenarios are intentionally `.skip` for the Solid V1 widget.
+// The screenshot button calls `useFeedback().captureScreenshot()` directly
+// (no region overlay; that surface lives in the React adapter only). The
+// existing tests below exercise the minimal capture path; deeper region /
+// preview scenarios stay skipped pending the Solid region overlay port.
+describe('<FeedbackButton> — screenshot capture', () => {
+  it('captures a screenshot via the SDK and rides it on the next submit', async () => {
+    captureScreenshot.mockResolvedValueOnce(
+      new Blob(['png'], { type: 'image/png' }),
+    );
+    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_99' });
+
+    mount();
+    openPanel();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /capture screenshot/i }),
+    );
+    await waitFor(() => expect(captureScreenshot).toHaveBeenCalledTimes(1));
+
+    typeDraft('see screenshot');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    const input = submit.mock.calls[0]![0]!;
+    expect(input.attachments).toHaveLength(1);
+    expect(input.attachments![0]).toMatchObject({ filename: 'screenshot.png' });
+  });
+
+  it('surfaces an error alert when capture rejects', async () => {
     captureScreenshot.mockRejectedValueOnce(new Error('canvas blew up'));
     mount();
     openPanel();
@@ -168,49 +858,7 @@ describe('FeedbackButton', () => {
     expect(alert).toHaveTextContent(/canvas blew up/i);
   });
 
-  it('surfaces a generic error when submit() rejects', async () => {
-    submit.mockRejectedValueOnce(new Error('chunk load failed'));
-    mount();
-    openPanel();
-    fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-      target: { value: 'broken' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent(/chunk load failed/i);
-  });
-
-  it('closes the panel via the close button and resets state', async () => {
-    mount();
-    openPanel();
-    expect(
-      await screen.findByLabelText(/feedback message/i),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
-    await waitFor(() =>
-      expect(screen.queryByLabelText(/feedback message/i)).toBeNull(),
-    );
-  });
-
-  it('renders nothing when open is closed (collapsed FAB)', () => {
-    mount();
-    // Before opening, the panel body is not in the DOM.
-    expect(screen.queryByLabelText(/feedback message/i)).toBeNull();
-  });
-
-  it('renders the bottom-left position class when configured', async () => {
-    render(() => (
-      <BrevwickProvider config={{ projectKey: 'pk_test_pos' }}>
-        <FeedbackButton position="bottom-left" />
-      </BrevwickProvider>
-    ));
-    const fab = await screen.findByRole('button', {
-      name: /open feedback form/i,
-    });
-    expect(fab).toHaveClass('brw-fab-bl');
-  });
-
-  it.skip('revokes queued screenshot object URLs when closed without submitting', async () => {
+  it('revokes queued screenshot object URLs after a discard-confirmed close', async () => {
     captureScreenshot.mockResolvedValueOnce(
       new Blob(['png'], { type: 'image/png' }),
     );
@@ -221,9 +869,7 @@ describe('FeedbackButton', () => {
       .mockImplementation(() => `blob:close-leak-${++urlSeq}`);
     const revokeSpy = vi
       .spyOn(URL, 'revokeObjectURL')
-      .mockImplementation(() => {
-        // jsdom no-op; we only care about the call set.
-      });
+      .mockImplementation(() => undefined);
 
     try {
       mount();
@@ -232,60 +878,20 @@ describe('FeedbackButton', () => {
         screen.getByRole('button', { name: /capture screenshot/i }),
       );
       await waitFor(() => expect(captureScreenshot).toHaveBeenCalledTimes(1));
-
-      const createdUrls = createSpy.mock.results.map((r) => r.value as string);
-      expect(createdUrls).toHaveLength(1);
-
-      // Close without submitting — every queued URL must be revoked.
-      fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
-
-      const revoked = revokeSpy.mock.calls.map((c) => c[0]);
-      for (const url of createdUrls) expect(revoked).toContain(url);
-    } finally {
-      createSpy.mockRestore();
-      revokeSpy.mockRestore();
-    }
-  });
-
-  it.skip('revokes queued screenshot object URLs when submit() returns ok:false', async () => {
-    captureScreenshot.mockResolvedValueOnce(
-      new Blob(['png'], { type: 'image/png' }),
-    );
-    submit.mockResolvedValueOnce({
-      ok: false,
-      error: { code: 'INGEST_REJECTED', message: 'no' },
-    });
-
-    let urlSeq = 0;
-    const createSpy = vi
-      .spyOn(URL, 'createObjectURL')
-      .mockImplementation(() => `blob:err-leak-${++urlSeq}`);
-    const revokeSpy = vi
-      .spyOn(URL, 'revokeObjectURL')
-      .mockImplementation(() => {
-        // jsdom no-op
-      });
-
-    try {
-      mount();
-      openPanel();
-      fireEvent.click(
-        screen.getByRole('button', { name: /capture screenshot/i }),
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /^remove screenshot$/i }),
+        ).toBeInTheDocument(),
       );
-      await waitFor(() => expect(captureScreenshot).toHaveBeenCalledTimes(1));
-
-      fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-        target: { value: 'broken' },
-      });
-      fireEvent.click(screen.getByRole('button', { name: /send/i }));
-      await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
-      await screen.findByRole('alert');
-
-      // ok:false leaves the queue intact (so the user can retry the same
-      // shot). Closing the panel must then revoke the URL.
-      fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
 
       const created = createSpy.mock.results.map((r) => r.value as string);
+      expect(created.length).toBeGreaterThanOrEqual(1);
+
+      // Dirty close routes through the discard-confirm rather than
+      // dropping state directly — same UX as the React widget.
+      fireEvent.click(screen.getByRole('button', { name: /^close$/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^discard$/i }));
+
       const revoked = revokeSpy.mock.calls.map((c) => c[0]);
       for (const url of created) expect(revoked).toContain(url);
     } finally {
@@ -294,19 +900,13 @@ describe('FeedbackButton', () => {
     }
   });
 
-  it('derives a trimmed title from the first line but submits the description raw', async () => {
-    submit.mockResolvedValueOnce({ ok: true, issue_id: 'rep_trim' });
-    mount();
-    openPanel();
-    fireEvent.input(await screen.findByLabelText(/feedback message/i), {
-      target: { value: '   hi there   \n' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /send/i }));
-    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
-    const [input] = submit.mock.calls[0]!;
-    expect(input.title).toBe('hi there');
-    // Description preserves the user's whitespace verbatim — title-derivation
-    // trimming must not leak into the wire payload (parity with React).
-    expect(input.description).toBe('   hi there   \n');
+  it.skip('region overlay parity (Solid V1 ships full-page only)', () => {
+    // Region drag overlay + Capture / Capture-full-page UI is React-only.
+    // Re-enable when the Solid widget grows the overlay surface.
+  });
+
+  it.skip('screenshot preview dialog parity (Solid V1 has no preview modal)', () => {
+    // Tap-to-preview a chip thumbnail opens a preview Dialog in React. The
+    // Solid V1 stores the blob URL but does not render the preview modal.
   });
 });

--- a/packages/solid/src/__tests__/redaction.test.tsx
+++ b/packages/solid/src/__tests__/redaction.test.tsx
@@ -23,6 +23,7 @@ import type { JSX } from 'solid-js';
 
 const submit = vi.fn<(input: FeedbackInput) => Promise<SubmitResult>>();
 const captureScreenshot = vi.fn<() => Promise<Blob>>();
+const getConfig = vi.fn<() => Promise<null>>();
 const install = vi.fn();
 const uninstall = vi.fn();
 
@@ -38,6 +39,7 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
         uninstall,
         submit,
         captureScreenshot,
+        getConfig,
       }) as unknown as Brevwick,
   };
 });
@@ -57,6 +59,9 @@ beforeEach(() => {
       URL as unknown as { revokeObjectURL: (u: string) => void }
     ).revokeObjectURL = () => undefined;
   }
+  // Lazy project-config fetch fires on first panel open; mocking null
+  // keeps the AI toggle hidden, which is the simplest legal config.
+  getConfig.mockResolvedValue(null);
 });
 
 afterEach(() => {

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -32,11 +32,8 @@ import { useContext } from 'solid-js';
 
 /**
  * Stable snapshot of one attachment that rode along with a submit. We store
- * only the underlying `Blob` (not the live `ScreenshotAttachment.url`),
- * because the success path revokes the composer's object URL the moment the
- * snapshot is appended — keeping the URL on the message would leave a
- * dangling reference. A future render that wants to preview the attachment
- * can call `URL.createObjectURL(blob)` itself.
+ * only the underlying `Blob` so a future render that wants to preview the
+ * attachment can call `URL.createObjectURL(blob)` itself.
  */
 interface MessageAttachment {
   blob: Blob;
@@ -54,24 +51,22 @@ interface Message {
   sentAt?: number;
   issueSent?: boolean;
   attachments?: {
-    screenshots?: readonly MessageAttachment[];
     files?: readonly MessageAttachment[];
   };
 }
 
 /**
- * Combined screenshot + file cap, mirrored from the SDK's
- * `MAX_ATTACHMENT_COUNT` in `packages/sdk/src/submit.ts`. Enforced in the
- * UI by disabling the screenshot and file-attach buttons once the combined
- * total reaches this ceiling — that way the user can't queue an attachment
- * the SDK would reject downstream.
+ * File-attachment cap, mirrored from the SDK's `MAX_ATTACHMENT_COUNT` in
+ * `packages/sdk/src/submit.ts`. Enforced in the UI by disabling the file-
+ * attach button once the queued total reaches this ceiling so the user
+ * can't queue an attachment the SDK would reject downstream.
  */
 const MAX_ATTACHMENTS = 5;
 
 const GREETING_MESSAGE: Message = {
   id: 'greeting',
   role: 'assistant',
-  text: "Hi! Tell us what's happening. A screenshot helps if you have one.",
+  text: "Hi! Tell us what's happening.",
 };
 
 const ASSISTANT_RECEIPT_TEXT = 'Thanks — your issue is on its way.';
@@ -146,13 +141,6 @@ function readPrefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-interface ScreenshotAttachment {
-  /** Monotonic id assigned at capture time. */
-  readonly id: number;
-  readonly blob: Blob;
-  readonly url: string;
-}
-
 interface FileAttachment {
   readonly id: number;
   readonly file: File;
@@ -192,15 +180,13 @@ function formatRelativeTime(ms: number | undefined): string {
 /**
  * Brevwick feedback widget — a FAB plus a dialog-based submission form.
  *
- * Solid V1 ships full UX parity with the React adapter's modern chat-thread
+ * Solid V1 ships UX parity with the React adapter's modern chat-thread
  * panel: greeting + user/assistant bubbles, an autogrow composer, the
- * expected/actual disclosure, attachment chips, the AI toggle, staged-
- * status rows driven by the SDK's phase bus, the retry row, and the
- * Brevwick credit footer. The region-capture overlay + screenshot preview
- * dialog (React-only surfaces gated behind Radix Dialog primitives) are
- * intentionally NOT ported — the Solid V1 ships a simpler one-click
- * "capture full page" screenshot button instead, sidestepping the Radix
- * dependency on a peer ecosystem that does not have a stable equivalent.
+ * expected/actual disclosure, file attachment chips, the AI toggle,
+ * staged-status rows driven by the SDK's phase bus, the retry row, and
+ * the Brevwick credit footer. Screenshot UI is intentionally absent in
+ * v1 (see PR #111); callers that need a screenshot capture path can
+ * invoke `useFeedback().captureScreenshot()` directly.
  *
  * SSR-safe: the entire component is gated behind `Show when={isClient}`, so
  * a SolidStart server render emits nothing and the hydration pass mounts
@@ -272,7 +258,6 @@ function useProjectConfig(
 const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
   const {
     submit,
-    captureScreenshot,
     status,
     phase,
     error: submitErrorTagged,
@@ -291,21 +276,18 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
   // renders "on" the first time; only read on submit when the render-policy
   // matrix below says the toggle should be visible.
   const [useAi, setUseAi] = createSignal(true);
-  const [capturing, setCapturing] = createSignal(false);
   const [messages, setMessages] = createStore<Message[]>([
     { ...GREETING_MESSAGE },
   ]);
-  const [screenshots, setScreenshots] = createStore<ScreenshotAttachment[]>([]);
   const [files, setFiles] = createStore<FileAttachment[]>([]);
 
   let alive = true;
-  let screenshotIdSeq = 0;
   let fileIdSeq = 0;
   let messageIdSeq = 0;
   // Snapshot of the last `FeedbackInput` passed to `submit()` so the
   // retry CTA on a failed submit can re-run with the exact same payload
-  // (including any captured screenshots) without forcing the user to
-  // re-type the draft we cleared synchronously on Send.
+  // without forcing the user to re-type the draft we cleared synchronously
+  // on Send.
   let lastSubmittedInput: FeedbackInput | null = null;
 
   const projectConfig = useProjectConfig(open);
@@ -323,26 +305,19 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     );
   };
 
-  const attachmentCount = (): number => screenshots.length + files.length;
+  const attachmentCount = (): number => files.length;
   const attachmentsAtCap = (): boolean => attachmentCount() >= MAX_ATTACHMENTS;
   const hasContent = (): boolean =>
     draft().trim().length > 0 ||
     expected().length > 0 ||
     actual().length > 0 ||
-    screenshots.length > 0 ||
     files.length > 0;
-
-  const revokeAllScreenshots = (): void => {
-    for (const s of screenshots) URL.revokeObjectURL(s.url);
-    setScreenshots([]);
-  };
 
   const resetAll = (): void => {
     setDraft('');
     setExpected('');
     setActual('');
     setShowExtras(false);
-    revokeAllScreenshots();
     setFiles([]);
     setConfirmClose(false);
     setSubmitError(null);
@@ -356,7 +331,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
   // re-render that swaps the FAB out, HMR teardown).
   onCleanup(() => {
     alive = false;
-    for (const s of screenshots) URL.revokeObjectURL(s.url);
   });
 
   const handleFullClose = (): void => {
@@ -379,39 +353,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     handleFullClose();
   };
 
-  const handleAttachScreenshot = async (): Promise<void> => {
-    if (capturing()) return;
-    if (attachmentsAtCap()) {
-      setSubmitError(`Maximum ${MAX_ATTACHMENTS} attachments reached`);
-      return;
-    }
-    setSubmitError(null);
-    setCapturing(true);
-    try {
-      const blob = await captureScreenshot();
-      if (!alive) return;
-      // Defence-in-depth: a long-running capture started before files were
-      // attached can still land after the combined total is at the ceiling.
-      if (attachmentsAtCap()) {
-        setSubmitError(`Maximum ${MAX_ATTACHMENTS} attachments reached`);
-        return;
-      }
-      const url = URL.createObjectURL(blob);
-      setScreenshots(
-        produce((prev: ScreenshotAttachment[]) => {
-          prev.push({ id: ++screenshotIdSeq, blob, url });
-        }),
-      );
-    } catch (err) {
-      if (!alive) return;
-      const message =
-        err instanceof Error ? err.message : 'Screenshot capture failed';
-      setSubmitError(message);
-    } finally {
-      if (alive) setCapturing(false);
-    }
-  };
-
   const handleAttachFiles = (list: FileList | null): void => {
     if (!list || list.length === 0) return;
     const remaining = MAX_ATTACHMENTS - attachmentCount();
@@ -429,23 +370,12 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     );
   };
 
-  const removeScreenshot = (id: number): void => {
-    const target = screenshots.find((s) => s.id === id);
-    if (target) URL.revokeObjectURL(target.url);
-    setScreenshots(screenshots.filter((s) => s.id !== id));
-  };
-
   const removeFile = (id: number): void => {
     setFiles(files.filter((f) => f.id !== id));
   };
 
   const doSubmit = async (): Promise<void> => {
     if (status() === 'submitting') return;
-    // Block submission while a capture is in flight. Without this, the user
-    // could press Enter in the composer between clicking the screenshot
-    // button and the thumbnail rendering, sending the issue without the
-    // screenshot they intended to include.
-    if (capturing()) return;
     if (!draft().trim()) {
       setSubmitError('Please describe what happened.');
       return;
@@ -453,19 +383,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     setSubmitError(null);
 
     const attachments: Array<Blob | FeedbackAttachment> = [];
-    // Single-screenshot filename stays `screenshot.<ext>` (matches React
-    // wire format and keeps existing tests / server-side identifiers
-    // stable). Multi-screenshot submissions disambiguate with `-1`, `-2`,
-    // … using the array order they were captured in.
-    const screenshotsSnap = [...screenshots];
-    screenshotsSnap.forEach((s, idx) => {
-      const ext = s.blob.type.split('/')[1]?.split('+')[0] || 'webp';
-      const filename =
-        screenshotsSnap.length === 1
-          ? `screenshot.${ext}`
-          : `screenshot-${idx + 1}.${ext}`;
-      attachments.push({ blob: s.blob, filename });
-    });
     const filesSnap = [...files];
     for (const { file } of filesSnap)
       attachments.push({ blob: file, filename: file.name });
@@ -496,10 +413,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     // what makes the wait feel fast — a synchronous bubble + cleared
     // input lets the staged-status rows below carry the rest of the
     // animation while the network round-trip is in flight (issue #74).
-    const screenshotsSnapshot: readonly MessageAttachment[] | undefined =
-      screenshotsSnap.length > 0
-        ? screenshotsSnap.map((s) => ({ blob: s.blob }))
-        : undefined;
     const filesSnapshot: readonly MessageAttachment[] | undefined =
       filesSnap.length > 0
         ? filesSnap.map(({ file }) => ({ blob: file, filename: file.name }))
@@ -508,15 +421,7 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
       id: `msg-${++messageIdSeq}`,
       role: 'user',
       text: draftRaw,
-      attachments:
-        screenshotsSnapshot || filesSnapshot
-          ? {
-              ...(screenshotsSnapshot
-                ? { screenshots: screenshotsSnapshot }
-                : {}),
-              ...(filesSnapshot ? { files: filesSnapshot } : {}),
-            }
-          : undefined,
+      attachments: filesSnapshot ? { files: filesSnapshot } : undefined,
     };
     setMessages(
       produce((prev: Message[]) => {
@@ -527,11 +432,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     setExpected('');
     setActual('');
     setShowExtras(false);
-    // Drop the live composer screenshots (the bubble's snapshot keeps
-    // its own blob refs) and clear queued files. Use the captured snap
-    // for revoke so a removal mid-await cannot desync.
-    for (const s of screenshotsSnap) URL.revokeObjectURL(s.url);
-    setScreenshots([]);
     setFiles([]);
     lastSubmittedInput = input;
 
@@ -639,9 +539,7 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
           />
           <Thread
             messages={messages}
-            screenshots={screenshots}
             files={files}
-            capturing={capturing}
             showExtras={showExtras}
             expected={expected}
             actual={actual}
@@ -657,7 +555,6 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
             onToggleExtras={() => setShowExtras((v) => !v)}
             onExpectedChange={setExpected}
             onActualChange={setActual}
-            onRemoveScreenshot={removeScreenshot}
             onRemoveFile={removeFile}
             onConfirmDiscard={handleFullClose}
             onCancelClose={() => setConfirmClose(false)}
@@ -665,16 +562,12 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
           <Composer
             draft={draft}
             submitting={() => status() === 'submitting'}
-            capturing={capturing}
             attachmentsAtCap={attachmentsAtCap}
             showAiToggle={showAiToggle}
             useAi={useAi}
             onDraftChange={setDraft}
             onSubmit={() => {
               void doSubmit();
-            }}
-            onAttachScreenshot={() => {
-              void handleAttachScreenshot();
             }}
             onAttachFiles={handleAttachFiles}
             onUseAiChange={setUseAi}
@@ -746,9 +639,7 @@ function PanelFooter(): JSX.Element {
 
 interface ThreadProps {
   messages: readonly Message[];
-  screenshots: readonly ScreenshotAttachment[];
   files: readonly FileAttachment[];
-  capturing: Accessor<boolean>;
   showExtras: Accessor<boolean>;
   expected: Accessor<string>;
   actual: Accessor<string>;
@@ -762,7 +653,6 @@ interface ThreadProps {
   onToggleExtras: () => void;
   onExpectedChange: (v: string) => void;
   onActualChange: (v: string) => void;
-  onRemoveScreenshot: (id: number) => void;
   onRemoveFile: (id: number) => void;
   onConfirmDiscard: () => void;
   onCancelClose: () => void;
@@ -802,22 +692,6 @@ function Thread(props: ThreadProps): JSX.Element {
           </Show>
         )}
       </For>
-      <For each={props.screenshots}>
-        {(s, idx) => {
-          const label =
-            props.screenshots.length === 1
-              ? 'screenshot'
-              : `screenshot ${idx() + 1}`;
-          return (
-            <AttachmentChip
-              name={label}
-              size={s.blob.size}
-              previewUrl={s.url}
-              onRemove={() => props.onRemoveScreenshot(s.id)}
-            />
-          );
-        }}
-      </For>
       <For each={props.files}>
         {(f) => (
           <AttachmentChip
@@ -827,11 +701,6 @@ function Thread(props: ThreadProps): JSX.Element {
           />
         )}
       </For>
-      <Show when={props.capturing()}>
-        <AssistantBubble>
-          <span class="brw-spinner" aria-hidden="true" /> Capturing screenshot…
-        </AssistantBubble>
-      </Show>
       <DisclosureExpectedActual
         open={props.showExtras}
         expected={props.expected}
@@ -1024,14 +893,12 @@ function UserBubble(props: { children: JSX.Element }): JSX.Element {
 interface AttachmentChipProps {
   name: string;
   size: number;
-  previewUrl?: string;
   onRemove: () => void;
 }
 
 function AttachmentChip(props: AttachmentChipProps): JSX.Element {
   return (
     <div class="brw-chip">
-      <Show when={props.previewUrl}>{(url) => <img src={url()} alt="" />}</Show>
       <span class="brw-chip-name">{props.name}</span>
       <span class="brw-chip-size">{formatSize(props.size)}</span>
       <button
@@ -1101,13 +968,11 @@ function DisclosureExpectedActual(props: DisclosureProps): JSX.Element {
 interface ComposerProps {
   draft: Accessor<string>;
   submitting: Accessor<boolean>;
-  capturing: Accessor<boolean>;
   attachmentsAtCap: Accessor<boolean>;
   showAiToggle: Accessor<boolean>;
   useAi: Accessor<boolean>;
   onDraftChange: (v: string) => void;
   onSubmit: () => void;
-  onAttachScreenshot: () => void;
   onAttachFiles: (list: FileList | null) => void;
   onUseAiChange: (v: boolean) => void;
 }
@@ -1152,13 +1017,7 @@ function Composer(props: ComposerProps): JSX.Element {
   };
 
   const attachDisabled = (): boolean =>
-    props.submitting() || props.capturing() || props.attachmentsAtCap();
-  const screenshotLabel = (): string => {
-    if (props.attachmentsAtCap())
-      return `Maximum ${MAX_ATTACHMENTS} attachments reached`;
-    if (props.capturing()) return 'Capturing screenshot…';
-    return 'Capture screenshot of this page';
-  };
+    props.submitting() || props.attachmentsAtCap();
   const fileLabel = (): string =>
     props.attachmentsAtCap()
       ? `Maximum ${MAX_ATTACHMENTS} attachments reached`
@@ -1167,15 +1026,6 @@ function Composer(props: ComposerProps): JSX.Element {
   return (
     <div class="brw-composer">
       <div class="brw-composer-shell">
-        <button
-          type="button"
-          class="brw-icon-btn"
-          aria-label={screenshotLabel()}
-          onClick={props.onAttachScreenshot}
-          disabled={attachDisabled()}
-        >
-          <ScreenshotIcon />
-        </button>
         <label class="brw-icon-btn">
           <PaperclipIcon />
           <input
@@ -1211,11 +1061,7 @@ function Composer(props: ComposerProps): JSX.Element {
           type="button"
           class="brw-send-btn"
           aria-label="Send"
-          disabled={
-            props.submitting() ||
-            props.capturing() ||
-            props.draft().trim().length === 0
-          }
+          disabled={props.submitting() || props.draft().trim().length === 0}
           onClick={props.onSubmit}
         >
           <SendIcon />
@@ -1313,23 +1159,6 @@ function CloseIcon(): JSX.Element {
       aria-hidden="true"
     >
       <path d="M6 6l12 12M18 6L6 18" />
-    </svg>
-  );
-}
-
-function ScreenshotIcon(): JSX.Element {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="3" y="5" width="18" height="12" rx="2" />
-      <rect x="7" y="8" width="10" height="6" rx="1" stroke-dasharray="2 2" />
     </svg>
   );
 }

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -1,17 +1,109 @@
 import {
+  For,
+  Match,
   Show,
+  Switch,
+  createEffect,
   createSignal,
+  createUniqueId,
+  onCleanup,
   onMount,
+  type Accessor,
   type Component,
   type JSX,
 } from 'solid-js';
-import type { FeedbackInput, SubmitResult } from '@tatlacas/brevwick-sdk';
-import { useFeedback } from '../use-feedback';
-import { BREVWICK_CSS, BREVWICK_STYLE_ID } from '../styles';
+import { createStore, produce } from 'solid-js/store';
+import type {
+  FeedbackAttachment,
+  FeedbackInput,
+  ProjectConfig,
+  SubmitError,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
+import { useFeedback, type FeedbackPhase } from '../use-feedback';
+import { BrevwickContext } from '../provider';
+import {
+  BREVWICK_CSS,
+  BREVWICK_STYLE_ID,
+  COMPOSER_MAX_HEIGHT_PX,
+} from '../styles';
 import { BREVWICK_SOLID_VERSION } from '../internal/version';
+import { useContext } from 'solid-js';
 
+/**
+ * Stable snapshot of one attachment that rode along with a submit. We store
+ * only the underlying `Blob` (not the live `ScreenshotAttachment.url`),
+ * because the success path revokes the composer's object URL the moment the
+ * snapshot is appended — keeping the URL on the message would leave a
+ * dangling reference. A future render that wants to preview the attachment
+ * can call `URL.createObjectURL(blob)` itself.
+ */
+interface MessageAttachment {
+  blob: Blob;
+  filename?: string;
+}
+
+/**
+ * One bubble in the conversation thread. The greeting and submitted-issue
+ * receipt are `assistant` messages; submitted drafts become `user` messages.
+ */
+interface Message {
+  id: string;
+  role: 'assistant' | 'user';
+  text: string;
+  sentAt?: number;
+  issueSent?: boolean;
+  attachments?: {
+    screenshots?: readonly MessageAttachment[];
+    files?: readonly MessageAttachment[];
+  };
+}
+
+/**
+ * Combined screenshot + file cap, mirrored from the SDK's
+ * `MAX_ATTACHMENT_COUNT` in `packages/sdk/src/submit.ts`. Enforced in the
+ * UI by disabling the screenshot and file-attach buttons once the combined
+ * total reaches this ceiling — that way the user can't queue an attachment
+ * the SDK would reject downstream.
+ */
+const MAX_ATTACHMENTS = 5;
+
+const GREETING_MESSAGE: Message = {
+  id: 'greeting',
+  role: 'assistant',
+  text: "Hi! Tell us what's happening. A screenshot helps if you have one.",
+};
+
+const ASSISTANT_RECEIPT_TEXT = 'Thanks — your issue is on its way.';
+
+/**
+ * Phase ordinal used by the staged-status rows to decide visibility. Row
+ * 1 ("Captured") shows from `'sanitising'` onwards, row 2 ("Sanitised")
+ * from `'formatting'` onwards. Row 3 ("Formatting with AI") has its own
+ * exact-match rule and does not consult this table.
+ */
+const PHASE_RANK: Record<FeedbackPhase, number> = {
+  idle: 0,
+  capturing: 1,
+  sanitising: 2,
+  formatting: 3,
+  sent: 4,
+  error: -1,
+};
+
+/** Stagger between staged-status rows in milliseconds. */
+const STATUS_ROW_STAGGER_MS = 200;
+
+/**
+ * Forced-palette choice for {@link FeedbackButton}. `'system'` defers to the
+ * OS-level `prefers-color-scheme` media query (the default and pre-existing
+ * behaviour); `'light'` / `'dark'` override it regardless of the OS setting.
+ */
 export type BrevwickTheme = 'light' | 'dark' | 'system';
 
+/**
+ * Props for {@link FeedbackButton}. See SDD § 12 for the Solid contract.
+ */
 export interface FeedbackButtonProps {
   /** Corner the FAB pins to. Default `'bottom-right'`. */
   position?: 'bottom-right' | 'bottom-left';
@@ -44,16 +136,77 @@ function injectStyles(): void {
 }
 
 /**
- * Brevwick feedback widget — a FAB plus a popover composer.
+ * Read `prefers-reduced-motion: reduce` once at first client mount. The
+ * widget keys row stagger off this so a user with the OS-level
+ * reduced-motion setting sees all status rows mount at once instead of
+ * cascading in. SSR-safe: returns `false` on the server.
+ */
+function readPrefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+interface ScreenshotAttachment {
+  /** Monotonic id assigned at capture time. */
+  readonly id: number;
+  readonly blob: Blob;
+  readonly url: string;
+}
+
+interface FileAttachment {
+  readonly id: number;
+  readonly file: File;
+}
+
+type ProjectConfigStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface ProjectConfigState {
+  status: ProjectConfigStatus;
+  config: ProjectConfig | null;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Cheap relative-time formatter for the issue-sent receipt. The bubble
+ * doesn't auto-refresh — once rendered the timestamp captures the moment
+ * the issue was queued, which is the only thing that actually matters
+ * (the user reads it within seconds of seeing it appear).
+ */
+function formatRelativeTime(ms: number | undefined): string {
+  if (ms === undefined) return 'just now';
+  const diffMs = Date.now() - ms;
+  if (diffMs < 60_000) return 'just now';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
+}
+
+/**
+ * Brevwick feedback widget — a FAB plus a dialog-based submission form.
  *
- * Solid V1 ships a deliberately small subset of the React widget's UI:
- * textarea + send. Every extra surface (region crop, attachment preview, AI
- * toggle, expected/actual disclosure) lives in the React adapter and is out
- * of scope for the Solid V1 — see SDD § 12.
+ * Solid V1 ships full UX parity with the React adapter's modern chat-thread
+ * panel: greeting + user/assistant bubbles, an autogrow composer, the
+ * expected/actual disclosure, attachment chips, the AI toggle, staged-
+ * status rows driven by the SDK's phase bus, the retry row, and the
+ * Brevwick credit footer. The region-capture overlay + screenshot preview
+ * dialog (React-only surfaces gated behind Radix Dialog primitives) are
+ * intentionally NOT ported — the Solid V1 ships a simpler one-click
+ * "capture full page" screenshot button instead, sidestepping the Radix
+ * dependency on a peer ecosystem that does not have a stable equivalent.
  *
  * SSR-safe: the entire component is gated behind `Show when={isClient}`, so
  * a SolidStart server render emits nothing and the hydration pass mounts
  * the FAB on the client.
+ *
+ * @see SDD § 12 for the public Solid contract.
  */
 export const FeedbackButton: Component<FeedbackButtonProps> = (props) => {
   const [isClient, setIsClient] = createSignal(false);
@@ -69,58 +222,391 @@ export const FeedbackButton: Component<FeedbackButtonProps> = (props) => {
   );
 };
 
+/**
+ * Lazy project-config fetch, triggered on the FIRST panel open for the
+ * lifetime of this FeedbackButton. Subsequent opens reuse the in-memory
+ * result — the core SDK also caches per session, so the second call would
+ * be a no-op anyway, but tracking here avoids an extra awaited microtask
+ * on every open.
+ *
+ * Explicitly does NOT fetch on mount — the widget's "zero-cost until
+ * opened" property must hold for users who never engage the FAB.
+ */
+function useProjectConfig(
+  open: Accessor<boolean>,
+): Accessor<ProjectConfigState> {
+  const ctx = useContext(BrevwickContext);
+  const [state, setState] = createSignal<ProjectConfigState>({
+    status: 'idle',
+    config: null,
+  });
+  let triggered = false;
+  let alive = true;
+  onCleanup(() => {
+    alive = false;
+  });
+  createEffect(() => {
+    if (!open()) return;
+    if (triggered) return;
+    triggered = true;
+    const sdk = ctx?.brevwick();
+    if (!sdk) return;
+    setState({ status: 'loading', config: null });
+    sdk
+      .getConfig()
+      .then((config: ProjectConfig | null) => {
+        if (!alive) return;
+        setState({ status: 'ready', config });
+      })
+      .catch(() => {
+        if (!alive) return;
+        // getConfig() never rejects in the documented contract, but stay
+        // defensive so a future regression cannot wedge the widget in
+        // 'loading' forever.
+        setState({ status: 'error', config: null });
+      });
+  });
+  return state;
+}
+
 const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
-  const { submit, status, reset } = useFeedback();
+  const {
+    submit,
+    captureScreenshot,
+    status,
+    phase,
+    error: submitErrorTagged,
+    retry,
+    reset,
+  } = useFeedback();
+  const reducedMotion = readPrefersReducedMotion();
   const [open, setOpen] = createSignal(false);
   const [draft, setDraft] = createSignal('');
-  const [errorMsg, setErrorMsg] = createSignal<string | null>(null);
+  const [expected, setExpected] = createSignal('');
+  const [actual, setActual] = createSignal('');
+  const [showExtras, setShowExtras] = createSignal(false);
+  const [confirmClose, setConfirmClose] = createSignal(false);
+  const [submitError, setSubmitError] = createSignal<string | null>(null);
+  // Submitter's per-issue AI preference. Defaults to true so the toggle
+  // renders "on" the first time; only read on submit when the render-policy
+  // matrix below says the toggle should be visible.
+  const [useAi, setUseAi] = createSignal(true);
+  const [capturing, setCapturing] = createSignal(false);
+  const [messages, setMessages] = createStore<Message[]>([
+    { ...GREETING_MESSAGE },
+  ]);
+  const [screenshots, setScreenshots] = createStore<ScreenshotAttachment[]>([]);
+  const [files, setFiles] = createStore<FileAttachment[]>([]);
 
-  const fabPosClass = () =>
-    props.position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
-  const panelPosClass = () =>
-    props.position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
-  const rootClass = () => ['brw-root', props.class].filter(Boolean).join(' ');
+  let alive = true;
+  let screenshotIdSeq = 0;
+  let fileIdSeq = 0;
+  let messageIdSeq = 0;
+  // Snapshot of the last `FeedbackInput` passed to `submit()` so the
+  // retry CTA on a failed submit can re-run with the exact same payload
+  // (including any captured screenshots) without forcing the user to
+  // re-type the draft we cleared synchronously on Send.
+  let lastSubmittedInput: FeedbackInput | null = null;
 
-  const handleSubmit = async (): Promise<void> => {
-    if (status() === 'submitting') return;
-    const raw = draft();
-    if (!raw.trim()) {
-      setErrorMsg('Please describe what happened.');
+  const projectConfig = useProjectConfig(open);
+  // Render-policy matrix, SDD § 12. The toggle is visible exactly when the
+  // config has loaded successfully, AI is enabled for the project, AND the
+  // admin has opted submitters into the choice. Any other state (loading,
+  // error, disabled, admin-forced) hides the toggle and the payload omits
+  // `use_ai` so the server-side default applies.
+  const showAiToggle = (): boolean => {
+    const cfg = projectConfig();
+    return (
+      cfg.status === 'ready' &&
+      cfg.config?.ai_enabled === true &&
+      cfg.config.ai_submitter_choice_allowed === true
+    );
+  };
+
+  const attachmentCount = (): number => screenshots.length + files.length;
+  const attachmentsAtCap = (): boolean => attachmentCount() >= MAX_ATTACHMENTS;
+  const hasContent = (): boolean =>
+    draft().trim().length > 0 ||
+    expected().length > 0 ||
+    actual().length > 0 ||
+    screenshots.length > 0 ||
+    files.length > 0;
+
+  const revokeAllScreenshots = (): void => {
+    for (const s of screenshots) URL.revokeObjectURL(s.url);
+    setScreenshots([]);
+  };
+
+  const resetAll = (): void => {
+    setDraft('');
+    setExpected('');
+    setActual('');
+    setShowExtras(false);
+    revokeAllScreenshots();
+    setFiles([]);
+    setConfirmClose(false);
+    setSubmitError(null);
+    setMessages([{ ...GREETING_MESSAGE }]);
+    setUseAi(true);
+    lastSubmittedInput = null;
+    reset();
+  };
+
+  // Catch the rare unmount-without-close path (route change, parent
+  // re-render that swaps the FAB out, HMR teardown).
+  onCleanup(() => {
+    alive = false;
+    for (const s of screenshots) URL.revokeObjectURL(s.url);
+  });
+
+  const handleFullClose = (): void => {
+    setOpen(false);
+    resetAll();
+  };
+
+  // Esc / minimize semantics: just hide the panel without dropping state.
+  const handleMinimize = (): void => {
+    setOpen(false);
+    setConfirmClose(false);
+    setSubmitError(null);
+  };
+
+  const handleCloseClick = (): void => {
+    if (hasContent()) {
+      setConfirmClose(true);
       return;
     }
-    setErrorMsg(null);
+    handleFullClose();
+  };
 
-    // Title from the trimmed first line so leading whitespace doesn't
-    // pollute the issue title; description sent raw to preserve the
-    // user's intentional whitespace + newlines (parity with React).
-    const derivedTitle = raw.trim().split('\n', 1)[0]!.slice(0, 120);
+  const handleAttachScreenshot = async (): Promise<void> => {
+    if (capturing()) return;
+    if (attachmentsAtCap()) {
+      setSubmitError(`Maximum ${MAX_ATTACHMENTS} attachments reached`);
+      return;
+    }
+    setSubmitError(null);
+    setCapturing(true);
+    try {
+      const blob = await captureScreenshot();
+      if (!alive) return;
+      // Defence-in-depth: a long-running capture started before files were
+      // attached can still land after the combined total is at the ceiling.
+      if (attachmentsAtCap()) {
+        setSubmitError(`Maximum ${MAX_ATTACHMENTS} attachments reached`);
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      setScreenshots(
+        produce((prev: ScreenshotAttachment[]) => {
+          prev.push({ id: ++screenshotIdSeq, blob, url });
+        }),
+      );
+    } catch (err) {
+      if (!alive) return;
+      const message =
+        err instanceof Error ? err.message : 'Screenshot capture failed';
+      setSubmitError(message);
+    } finally {
+      if (alive) setCapturing(false);
+    }
+  };
+
+  const handleAttachFiles = (list: FileList | null): void => {
+    if (!list || list.length === 0) return;
+    const remaining = MAX_ATTACHMENTS - attachmentCount();
+    if (remaining <= 0) return;
+    const next = Array.from(list)
+      .slice(0, remaining)
+      .map<FileAttachment>((file) => ({
+        id: ++fileIdSeq,
+        file,
+      }));
+    setFiles(
+      produce((prev: FileAttachment[]) => {
+        for (const item of next) prev.push(item);
+      }),
+    );
+  };
+
+  const removeScreenshot = (id: number): void => {
+    const target = screenshots.find((s) => s.id === id);
+    if (target) URL.revokeObjectURL(target.url);
+    setScreenshots(screenshots.filter((s) => s.id !== id));
+  };
+
+  const removeFile = (id: number): void => {
+    setFiles(files.filter((f) => f.id !== id));
+  };
+
+  const doSubmit = async (): Promise<void> => {
+    if (status() === 'submitting') return;
+    // Block submission while a capture is in flight. Without this, the user
+    // could press Enter in the composer between clicking the screenshot
+    // button and the thumbnail rendering, sending the issue without the
+    // screenshot they intended to include.
+    if (capturing()) return;
+    if (!draft().trim()) {
+      setSubmitError('Please describe what happened.');
+      return;
+    }
+    setSubmitError(null);
+
+    const attachments: Array<Blob | FeedbackAttachment> = [];
+    // Single-screenshot filename stays `screenshot.<ext>` (matches React
+    // wire format and keeps existing tests / server-side identifiers
+    // stable). Multi-screenshot submissions disambiguate with `-1`, `-2`,
+    // … using the array order they were captured in.
+    const screenshotsSnap = [...screenshots];
+    screenshotsSnap.forEach((s, idx) => {
+      const ext = s.blob.type.split('/')[1]?.split('+')[0] || 'webp';
+      const filename =
+        screenshotsSnap.length === 1
+          ? `screenshot.${ext}`
+          : `screenshot-${idx + 1}.${ext}`;
+      attachments.push({ blob: s.blob, filename });
+    });
+    const filesSnap = [...files];
+    for (const { file } of filesSnap)
+      attachments.push({ blob: file, filename: file.name });
+
+    // Submit what the user actually sees in their bubble — trimming here
+    // would drop the user's intentional whitespace/newlines on the wire.
+    // `draft().trim().length > 0` above already rejects the whitespace-
+    // only case; for title derivation we still want the first non-empty
+    // line.
+    const draftRaw = draft();
+    const derivedTitle = draftRaw.trim().split('\n', 1)[0]!.slice(0, 120);
+    const expectedTrimmed = expected().trim();
+    const actualTrimmed = actual().trim();
     const input: FeedbackInput = {
       title: derivedTitle,
-      description: raw,
+      description: draftRaw,
+      ...(expectedTrimmed ? { expected: expectedTrimmed } : {}),
+      ...(actualTrimmed ? { actual: actualTrimmed } : {}),
+      ...(attachments.length ? { attachments } : {}),
+      // use_ai rides the payload only when the submitter has been given
+      // the choice; in every other render state we leave the server-side
+      // default alone.
+      ...(showAiToggle() ? { use_ai: useAi() } : {}),
     };
+
+    // Push the user's draft into the conversation immediately and clear
+    // the composer BEFORE awaiting submit(). The visual progression is
+    // what makes the wait feel fast — a synchronous bubble + cleared
+    // input lets the staged-status rows below carry the rest of the
+    // animation while the network round-trip is in flight (issue #74).
+    const screenshotsSnapshot: readonly MessageAttachment[] | undefined =
+      screenshotsSnap.length > 0
+        ? screenshotsSnap.map((s) => ({ blob: s.blob }))
+        : undefined;
+    const filesSnapshot: readonly MessageAttachment[] | undefined =
+      filesSnap.length > 0
+        ? filesSnap.map(({ file }) => ({ blob: file, filename: file.name }))
+        : undefined;
+    const userMessage: Message = {
+      id: `msg-${++messageIdSeq}`,
+      role: 'user',
+      text: draftRaw,
+      attachments:
+        screenshotsSnapshot || filesSnapshot
+          ? {
+              ...(screenshotsSnapshot
+                ? { screenshots: screenshotsSnapshot }
+                : {}),
+              ...(filesSnapshot ? { files: filesSnapshot } : {}),
+            }
+          : undefined,
+    };
+    setMessages(
+      produce((prev: Message[]) => {
+        prev.push(userMessage);
+      }),
+    );
+    setDraft('');
+    setExpected('');
+    setActual('');
+    setShowExtras(false);
+    // Drop the live composer screenshots (the bubble's snapshot keeps
+    // its own blob refs) and clear queued files. Use the captured snap
+    // for revoke so a removal mid-await cannot desync.
+    for (const s of screenshotsSnap) URL.revokeObjectURL(s.url);
+    setScreenshots([]);
+    setFiles([]);
+    lastSubmittedInput = input;
 
     try {
       const result = await submit(input);
+      if (!alive) return;
       props.onSubmit?.(result);
       if (result.ok) {
-        setDraft('');
+        setMessages(
+          produce((prev: Message[]) => {
+            prev.push({
+              id: `msg-${++messageIdSeq}`,
+              role: 'assistant',
+              text: ASSISTANT_RECEIPT_TEXT,
+              issueSent: true,
+              sentAt: Date.now(),
+            });
+          }),
+        );
+        setOpen(true);
       } else {
-        setErrorMsg(result.error.message);
+        // Failure: the user bubble is already in the thread; the staged
+        // rows collapse into a red retry row driven by `phase === 'error'`.
+        setOpen(true);
       }
-    } catch (err) {
-      const message =
-        err instanceof Error && err.message
-          ? err.message
-          : 'We could not submit your feedback. Please try again.';
-      setErrorMsg(message);
+    } catch {
+      if (!alive) return;
+      // Chunk-load failure path — the hook has already flipped phase to
+      // 'error' and stored a synthetic SubmitError. Just pop the panel
+      // back open so the retry row is visible.
+      setOpen(true);
     }
   };
 
-  const handleClose = (): void => {
-    setOpen(false);
-    setErrorMsg(null);
-    if (status() !== 'submitting') reset();
+  /**
+   * Re-run the most recent submit with the original `FeedbackInput`. The
+   * user bubble is already in the thread (pushed on the first Send), so
+   * the retry path only needs to re-fire `submit()` and append the
+   * assistant receipt on success — no duplicate bubble for the retry.
+   */
+  const doRetry = async (): Promise<void> => {
+    if (!lastSubmittedInput) return;
+    if (status() === 'submitting') return;
+    try {
+      const result = await retry();
+      if (!alive || !result) return;
+      props.onSubmit?.(result);
+      if (result.ok) {
+        setMessages(
+          produce((prev: Message[]) => {
+            prev.push({
+              id: `msg-${++messageIdSeq}`,
+              role: 'assistant',
+              text: ASSISTANT_RECEIPT_TEXT,
+              issueSent: true,
+              sentAt: Date.now(),
+            });
+          }),
+        );
+        setOpen(true);
+      } else {
+        setOpen(true);
+      }
+    } catch {
+      if (!alive) return;
+      setOpen(true);
+    }
   };
+
+  const fabPosClass = (): string =>
+    props.position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  const panelPosClass = (): string =>
+    props.position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
+  const rootClass = (): string =>
+    ['brw-root', props.class].filter(Boolean).join(' ');
 
   return (
     <>
@@ -132,79 +618,769 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
         disabled={props.disabled}
         aria-label="Open feedback form"
         aria-expanded={open()}
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(true)}
       >
+        <ChatIcon />
         {props.label ?? 'Feedback'}
       </button>
       <Show when={open()}>
         <div
           role="dialog"
-          aria-modal="false"
           aria-label="Send feedback"
+          aria-modal="false"
           data-brevwick-skip=""
           data-brw-theme={props.theme ?? 'system'}
           class={`${rootClass()} brw-panel ${panelPosClass()}`}
         >
-          <div class="brw-panel-header">
-            <span class="brw-panel-title">Send feedback</span>
-            <button
-              type="button"
-              class="brw-icon-btn"
-              aria-label="Close"
-              onClick={handleClose}
-              disabled={status() === 'submitting'}
-            >
-              ×
-            </button>
-          </div>
-          <div class="brw-body">
-            <textarea
-              class="brw-textarea"
-              placeholder="Describe the bug or feedback…"
-              aria-label="Feedback message"
-              value={draft()}
-              onInput={(e) => setDraft(e.currentTarget.value)}
-              disabled={status() === 'submitting'}
-            />
-            <Show when={errorMsg()}>
-              {(msg) => (
-                <div class="brw-error" role="alert">
-                  {msg()}
-                </div>
-              )}
-            </Show>
-            <Show when={status() === 'success'}>
-              <div class="brw-success" role="status">
-                Thanks — your issue is on its way.
-              </div>
-            </Show>
-          </div>
-          <div class="brw-actions">
-            <button
-              type="button"
-              class="brw-btn brw-btn-primary"
-              aria-label="Send"
-              disabled={
-                status() === 'submitting' || draft().trim().length === 0
-              }
-              onClick={() => {
-                void handleSubmit();
-              }}
-            >
-              {status() === 'submitting' ? 'Sending…' : 'Send'}
-            </button>
-          </div>
-          <div class="brw-footer">
-            <a
-              href="https://brevwick.dev"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Brevwick v{BREVWICK_SOLID_VERSION}
-            </a>
-          </div>
+          <PanelHeader
+            submitting={() => status() === 'submitting'}
+            onMinimize={handleMinimize}
+            onClose={handleCloseClick}
+          />
+          <Thread
+            messages={messages}
+            screenshots={screenshots}
+            files={files}
+            capturing={capturing}
+            showExtras={showExtras}
+            expected={expected}
+            actual={actual}
+            confirmClose={confirmClose}
+            submitError={submitError}
+            phase={phase}
+            submitErrorTagged={submitErrorTagged}
+            aiEnabled={() => projectConfig().config?.ai_enabled === true}
+            reducedMotion={reducedMotion}
+            onRetry={() => {
+              void doRetry();
+            }}
+            onToggleExtras={() => setShowExtras((v) => !v)}
+            onExpectedChange={setExpected}
+            onActualChange={setActual}
+            onRemoveScreenshot={removeScreenshot}
+            onRemoveFile={removeFile}
+            onConfirmDiscard={handleFullClose}
+            onCancelClose={() => setConfirmClose(false)}
+          />
+          <Composer
+            draft={draft}
+            submitting={() => status() === 'submitting'}
+            capturing={capturing}
+            attachmentsAtCap={attachmentsAtCap}
+            showAiToggle={showAiToggle}
+            useAi={useAi}
+            onDraftChange={setDraft}
+            onSubmit={() => {
+              void doSubmit();
+            }}
+            onAttachScreenshot={() => {
+              void handleAttachScreenshot();
+            }}
+            onAttachFiles={handleAttachFiles}
+            onUseAiChange={setUseAi}
+          />
+          <PanelFooter />
         </div>
       </Show>
     </>
   );
 };
+
+interface PanelHeaderProps {
+  submitting: Accessor<boolean>;
+  onMinimize: () => void;
+  onClose: () => void;
+}
+
+function PanelHeader(props: PanelHeaderProps): JSX.Element {
+  return (
+    <div class="brw-panel-header">
+      <span class="brw-panel-avatar" aria-hidden="true">
+        B
+      </span>
+      <h2 class="brw-panel-title">Send feedback</h2>
+      <button
+        type="button"
+        class="brw-icon-btn"
+        aria-label="Minimize"
+        onClick={props.onMinimize}
+      >
+        <MinimizeIcon />
+      </button>
+      <button
+        type="button"
+        class="brw-icon-btn"
+        aria-label="Close"
+        onClick={props.onClose}
+        // Disable close while a submit is in flight — clicking "Discard"
+        // mid-request would otherwise throw the confirmation away while
+        // the callback still resolves into the parent.
+        disabled={props.submitting()}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Thin "Brevwick v<x.y.z>" credit anchored below the composer. The whole
+ * label is a single link to brevwick.dev so the footer reads as one
+ * affordance rather than two competing elements; styling keeps it muted
+ * and small so it sits quietly at the bottom of the panel.
+ */
+function PanelFooter(): JSX.Element {
+  return (
+    <div class="brw-panel-footer">
+      <a
+        class="brw-panel-footer-link"
+        href="https://brevwick.dev"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Brevwick v{BREVWICK_SOLID_VERSION}
+      </a>
+    </div>
+  );
+}
+
+interface ThreadProps {
+  messages: readonly Message[];
+  screenshots: readonly ScreenshotAttachment[];
+  files: readonly FileAttachment[];
+  capturing: Accessor<boolean>;
+  showExtras: Accessor<boolean>;
+  expected: Accessor<string>;
+  actual: Accessor<string>;
+  confirmClose: Accessor<boolean>;
+  submitError: Accessor<string | null>;
+  phase: Accessor<FeedbackPhase>;
+  submitErrorTagged: Accessor<SubmitError | null>;
+  aiEnabled: Accessor<boolean>;
+  reducedMotion: boolean;
+  onRetry: () => void;
+  onToggleExtras: () => void;
+  onExpectedChange: (v: string) => void;
+  onActualChange: (v: string) => void;
+  onRemoveScreenshot: (id: number) => void;
+  onRemoveFile: (id: number) => void;
+  onConfirmDiscard: () => void;
+  onCancelClose: () => void;
+}
+
+function Thread(props: ThreadProps): JSX.Element {
+  const phaseRank = (): number => PHASE_RANK[props.phase()];
+  const showCaptured = (): boolean => phaseRank() >= PHASE_RANK.sanitising;
+  const showSanitised = (): boolean => phaseRank() >= PHASE_RANK.formatting;
+  // Row 3 is gated on the project's AI configuration AND the exact
+  // 'formatting' phase — it disappears the moment the pipeline reports
+  // 'sent' so the user is not left with a perpetually spinning row.
+  const showFormatting = (): boolean =>
+    props.phase() === 'formatting' && props.aiEnabled();
+  const showRetryRow = (): boolean =>
+    props.phase() === 'error' && props.submitErrorTagged() !== null;
+
+  return (
+    <div
+      class="brw-thread"
+      role="log"
+      aria-live="polite"
+      aria-label="Conversation"
+    >
+      <For each={props.messages}>
+        {(message) => (
+          <Show
+            when={message.role === 'assistant'}
+            fallback={<UserBubble>{message.text}</UserBubble>}
+          >
+            <AssistantBubble
+              issueSent={message.issueSent}
+              sentAt={message.sentAt}
+            >
+              {message.text}
+            </AssistantBubble>
+          </Show>
+        )}
+      </For>
+      <For each={props.screenshots}>
+        {(s, idx) => {
+          const label =
+            props.screenshots.length === 1
+              ? 'screenshot'
+              : `screenshot ${idx() + 1}`;
+          return (
+            <AttachmentChip
+              name={label}
+              size={s.blob.size}
+              previewUrl={s.url}
+              onRemove={() => props.onRemoveScreenshot(s.id)}
+            />
+          );
+        }}
+      </For>
+      <For each={props.files}>
+        {(f) => (
+          <AttachmentChip
+            name={f.file.name}
+            size={f.file.size}
+            onRemove={() => props.onRemoveFile(f.id)}
+          />
+        )}
+      </For>
+      <Show when={props.capturing()}>
+        <AssistantBubble>
+          <span class="brw-spinner" aria-hidden="true" /> Capturing screenshot…
+        </AssistantBubble>
+      </Show>
+      <DisclosureExpectedActual
+        open={props.showExtras}
+        expected={props.expected}
+        actual={props.actual}
+        onToggle={props.onToggleExtras}
+        onExpectedChange={props.onExpectedChange}
+        onActualChange={props.onActualChange}
+      />
+      <Show when={props.submitError()}>
+        {(msg) => (
+          <div class="brw-error" role="alert">
+            {msg()}
+          </div>
+        )}
+      </Show>
+      <Show when={showCaptured()}>
+        <StatusRow variant="check" delayMs={0} dataRow="captured">
+          Captured route, console, network, device
+        </StatusRow>
+      </Show>
+      <Show when={showSanitised()}>
+        <StatusRow
+          variant="check"
+          delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
+          dataRow="sanitised"
+        >
+          PII-sanitised, packaged
+        </StatusRow>
+      </Show>
+      <Show when={showFormatting()}>
+        <StatusRow
+          variant="spinner"
+          delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
+          dataRow="formatting"
+        >
+          Formatting with AI…
+        </StatusRow>
+      </Show>
+      <Show when={showRetryRow() && props.submitErrorTagged()}>
+        {(err) => <RetryRow error={err()} onRetry={props.onRetry} />}
+      </Show>
+      <Show when={props.confirmClose()}>
+        <DiscardConfirm
+          onCancel={props.onCancelClose}
+          onConfirm={props.onConfirmDiscard}
+        />
+      </Show>
+    </div>
+  );
+}
+
+interface StatusRowProps {
+  variant: 'check' | 'spinner';
+  delayMs: number;
+  dataRow: string;
+  children: JSX.Element;
+}
+
+/**
+ * One staged-status row in the conversation thread. Visual variants:
+ *
+ * - `'check'` — green checkmark + label. Used for the "Captured" /
+ *   "Sanitised" milestones.
+ * - `'spinner'` — spinner + label. Used for the "Formatting with AI…"
+ *   row that sits next to the pending AI work.
+ *
+ * The `data-brw-row` attribute exists for the test suite to query rows by
+ * their role-in-the-pipeline without coupling to the visible label.
+ */
+function StatusRow(props: StatusRowProps): JSX.Element {
+  return (
+    <div
+      class="brw-status-row"
+      style={{ 'transition-delay': `${props.delayMs}ms` }}
+      data-brw-row={props.dataRow}
+    >
+      <Switch>
+        <Match when={props.variant === 'check'}>
+          <span class="brw-status-row-check" aria-hidden="true">
+            <CheckIcon />
+          </span>
+        </Match>
+        <Match when={props.variant === 'spinner'}>
+          <span class="brw-spinner" aria-hidden="true" />
+        </Match>
+      </Switch>
+      <span class="brw-status-row-label">{props.children}</span>
+    </div>
+  );
+}
+
+interface RetryRowProps {
+  error: SubmitError;
+  onRetry: () => void;
+}
+
+/**
+ * Red retry row shown when the submit pipeline fails. Renders the
+ * `SubmitError.message` verbatim — server-echoed bodies have already
+ * been redacted upstream — and a single "Retry" CTA wired to
+ * {@link UseFeedbackResult.retry}.
+ */
+function RetryRow(props: RetryRowProps): JSX.Element {
+  return (
+    <div
+      class="brw-status-row brw-status-row--error"
+      role="alert"
+      data-brw-error-code={props.error.code}
+      data-brw-row="error"
+    >
+      {props.error.message}
+      <button
+        type="button"
+        class="brw-btn brw-status-row-retry"
+        onClick={props.onRetry}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+interface DiscardConfirmProps {
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Inline `role="alert"` confirm — not a true modal dialog. Focus moves to
+ * "Keep" on appearance so a keyboard user can dismiss with Enter without
+ * having to Tab through the surrounding chrome; "Keep" is the non-
+ * destructive default so an accidental Enter preserves the draft.
+ */
+function DiscardConfirm(props: DiscardConfirmProps): JSX.Element {
+  // Callback ref: Solid's `ref={varName}` is compile-time magic that ESLint's
+  // `no-unassigned-vars` cannot see; the callback form is identical at the
+  // semantic layer and keeps the lint rule happy without an inline disable.
+  let keepRef: HTMLButtonElement | undefined;
+  const setKeepRef = (el: HTMLButtonElement): void => {
+    keepRef = el;
+  };
+  onMount(() => {
+    keepRef?.focus();
+  });
+  return (
+    <div class="brw-confirm" role="alert" aria-label="Discard draft?">
+      <span class="brw-confirm-msg">Discard your feedback?</span>
+      <button
+        ref={setKeepRef}
+        type="button"
+        class="brw-btn"
+        onClick={props.onCancel}
+      >
+        Keep
+      </button>
+      <button
+        type="button"
+        class="brw-btn brw-btn-primary"
+        onClick={props.onConfirm}
+      >
+        Discard
+      </button>
+    </div>
+  );
+}
+
+interface AssistantBubbleProps {
+  children: JSX.Element;
+  issueSent?: boolean;
+  sentAt?: number;
+}
+
+function AssistantBubble(props: AssistantBubbleProps): JSX.Element {
+  return (
+    <div class="brw-bubble brw-bubble--assistant">
+      {props.children}
+      <Show when={props.issueSent}>
+        <div class="brw-bubble--receipt">
+          <CheckIcon /> Issue sent · {formatRelativeTime(props.sentAt)}
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+function UserBubble(props: { children: JSX.Element }): JSX.Element {
+  return <div class="brw-bubble brw-bubble--user">{props.children}</div>;
+}
+
+interface AttachmentChipProps {
+  name: string;
+  size: number;
+  previewUrl?: string;
+  onRemove: () => void;
+}
+
+function AttachmentChip(props: AttachmentChipProps): JSX.Element {
+  return (
+    <div class="brw-chip">
+      <Show when={props.previewUrl}>{(url) => <img src={url()} alt="" />}</Show>
+      <span class="brw-chip-name">{props.name}</span>
+      <span class="brw-chip-size">{formatSize(props.size)}</span>
+      <button
+        type="button"
+        class="brw-chip-remove"
+        aria-label={`Remove ${props.name}`}
+        onClick={props.onRemove}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+interface DisclosureProps {
+  open: Accessor<boolean>;
+  expected: Accessor<string>;
+  actual: Accessor<string>;
+  onToggle: () => void;
+  onExpectedChange: (v: string) => void;
+  onActualChange: (v: string) => void;
+}
+
+function DisclosureExpectedActual(props: DisclosureProps): JSX.Element {
+  // Per-instance id so rendering multiple <FeedbackButton>s (or two panels
+  // mid-animation) doesn't collide on a shared DOM id and break aria-controls.
+  const panelId = createUniqueId();
+  return (
+    <>
+      <button
+        type="button"
+        class="brw-disclosure"
+        aria-expanded={props.open()}
+        aria-controls={panelId}
+        onClick={props.onToggle}
+      >
+        <Show when={props.open()} fallback={<>Add expected vs actual</>}>
+          Hide expected vs actual
+        </Show>
+      </button>
+      <Show when={props.open()}>
+        <div id={panelId} class="brw-disclosure-panel">
+          <label>
+            <span class="brw-disclosure-label">Expected</span>
+            <textarea
+              class="brw-disclosure-input"
+              rows={2}
+              value={props.expected()}
+              onInput={(e) => props.onExpectedChange(e.currentTarget.value)}
+            />
+          </label>
+          <label>
+            <span class="brw-disclosure-label">Actual</span>
+            <textarea
+              class="brw-disclosure-input"
+              rows={2}
+              value={props.actual()}
+              onInput={(e) => props.onActualChange(e.currentTarget.value)}
+            />
+          </label>
+        </div>
+      </Show>
+    </>
+  );
+}
+
+interface ComposerProps {
+  draft: Accessor<string>;
+  submitting: Accessor<boolean>;
+  capturing: Accessor<boolean>;
+  attachmentsAtCap: Accessor<boolean>;
+  showAiToggle: Accessor<boolean>;
+  useAi: Accessor<boolean>;
+  onDraftChange: (v: string) => void;
+  onSubmit: () => void;
+  onAttachScreenshot: () => void;
+  onAttachFiles: (list: FileList | null) => void;
+  onUseAiChange: (v: boolean) => void;
+}
+
+function Composer(props: ComposerProps): JSX.Element {
+  // Callback ref: Solid's `ref={varName}` compile-time assignment is invisible
+  // to ESLint's `no-unassigned-vars`; the explicit setter is identical at the
+  // runtime layer.
+  let textareaRef: HTMLTextAreaElement | undefined;
+  const setTextareaRef = (el: HTMLTextAreaElement): void => {
+    textareaRef = el;
+  };
+
+  // Autogrow between ~1 and ~5 rows. The CSS `max-height` on the input
+  // bounds this visually; the JS mirror keeps the height animating up as
+  // the user types. Both come from the same COMPOSER_MAX_HEIGHT_PX
+  // constant so bumping the ceiling is a single edit.
+  createEffect(() => {
+    // Read draft() so the effect re-runs on every keystroke.
+    void props.draft();
+    const el = textareaRef;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, COMPOSER_MAX_HEIGHT_PX)}px`;
+  });
+
+  const handleKeyDown = (
+    e: KeyboardEvent & { currentTarget: HTMLTextAreaElement },
+  ): void => {
+    if (
+      e.key === 'Enter' &&
+      !e.shiftKey &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      // happy-dom does not surface isComposing reliably; guard for both.
+      !(e as unknown as { isComposing?: boolean }).isComposing
+    ) {
+      e.preventDefault();
+      props.onSubmit();
+    }
+  };
+
+  const attachDisabled = (): boolean =>
+    props.submitting() || props.capturing() || props.attachmentsAtCap();
+  const screenshotLabel = (): string => {
+    if (props.attachmentsAtCap())
+      return `Maximum ${MAX_ATTACHMENTS} attachments reached`;
+    if (props.capturing()) return 'Capturing screenshot…';
+    return 'Capture screenshot of this page';
+  };
+  const fileLabel = (): string =>
+    props.attachmentsAtCap()
+      ? `Maximum ${MAX_ATTACHMENTS} attachments reached`
+      : 'Attach file';
+
+  return (
+    <div class="brw-composer">
+      <div class="brw-composer-shell">
+        <button
+          type="button"
+          class="brw-icon-btn"
+          aria-label={screenshotLabel()}
+          onClick={props.onAttachScreenshot}
+          disabled={attachDisabled()}
+        >
+          <ScreenshotIcon />
+        </button>
+        <label class="brw-icon-btn">
+          <PaperclipIcon />
+          <input
+            type="file"
+            multiple
+            aria-label={fileLabel()}
+            class="brw-file-input"
+            onChange={(e) => {
+              props.onAttachFiles(e.currentTarget.files);
+              e.currentTarget.value = '';
+            }}
+            disabled={attachDisabled()}
+          />
+        </label>
+        <textarea
+          ref={setTextareaRef}
+          class="brw-composer-input"
+          rows={1}
+          placeholder="Describe the bug or feedback…"
+          value={props.draft()}
+          onInput={(e) => props.onDraftChange(e.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+          aria-label="Feedback message"
+        />
+        <Show when={props.showAiToggle()}>
+          <AIToggle
+            on={props.useAi}
+            disabled={props.submitting}
+            onChange={props.onUseAiChange}
+          />
+        </Show>
+        <button
+          type="button"
+          class="brw-send-btn"
+          aria-label="Send"
+          disabled={
+            props.submitting() ||
+            props.capturing() ||
+            props.draft().trim().length === 0
+          }
+          onClick={props.onSubmit}
+        >
+          <SendIcon />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface AIToggleProps {
+  on: Accessor<boolean>;
+  disabled: Accessor<boolean>;
+  onChange: (next: boolean) => void;
+}
+
+/**
+ * Track-and-thumb switch surfaced in the composer footer when the project
+ * allows submitters to opt in/out of AI formatting per issue.
+ *
+ * role="switch" + aria-checked is the narrow semantic the WCAG a11y matrix
+ * wants. Space toggles when focused (default browser behaviour on
+ * role="button" is Enter and Space, but Space carries fewer collisions
+ * with the composer's Enter-to-send shortcut).
+ */
+function AIToggle(props: AIToggleProps): JSX.Element {
+  const handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === ' ') {
+      e.preventDefault();
+      props.onChange(!props.on());
+    }
+  };
+  return (
+    <span class="brw-aitoggle-wrap">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={props.on()}
+        aria-label="Format with AI"
+        class={`brw-aitoggle${props.on() ? ' brw-aitoggle--on' : ''}`}
+        disabled={props.disabled()}
+        onClick={() => props.onChange(!props.on())}
+        onKeyDown={handleKeyDown}
+      >
+        <span class="brw-aitoggle-thumb" aria-hidden="true" />
+      </button>
+      <span class="brw-aitoggle-text" aria-hidden="true">
+        AI
+      </span>
+    </span>
+  );
+}
+
+function ChatIcon(): JSX.Element {
+  return (
+    <svg
+      class="brw-fab-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z" />
+    </svg>
+  );
+}
+
+function MinimizeIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 14h14" />
+    </svg>
+  );
+}
+
+function CloseIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  );
+}
+
+function ScreenshotIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="5" width="18" height="12" rx="2" />
+      <rect x="7" y="8" width="10" height="6" rx="1" stroke-dasharray="2 2" />
+    </svg>
+  );
+}
+
+function PaperclipIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 10.5l-8.5 8.5a5 5 0 0 1-7-7l9-9a3.5 3.5 0 0 1 5 5l-9 9a2 2 0 0 1-3-3l7.5-7.5" />
+    </svg>
+  );
+}
+
+function SendIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 20l16-8L4 4l2 8-2 8z" />
+      <path d="M6 12h14" />
+    </svg>
+  );
+}
+
+function CheckIcon(): JSX.Element {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 12l5 5L20 7" />
+    </svg>
+  );
+}

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -8,7 +8,11 @@ export { BrevwickProvider } from './provider';
 export type { BrevwickProviderProps } from './provider';
 
 export { useFeedback } from './use-feedback';
-export type { FeedbackStatus, UseFeedbackResult } from './use-feedback';
+export type {
+  FeedbackPhase,
+  FeedbackStatus,
+  UseFeedbackResult,
+} from './use-feedback';
 
 export { FeedbackButton } from './components/feedback-button';
 export type {

--- a/packages/solid/src/internal-bridge.ts
+++ b/packages/solid/src/internal-bridge.ts
@@ -1,0 +1,46 @@
+import type { Brevwick } from '@tatlacas/brevwick-sdk';
+
+/**
+ * Submit-pipeline progress events. Mirrors `PhaseEvent` in the SDK's
+ * `core/internal.ts`. Replicated here (rather than imported) because the
+ * SDK intentionally does not export the internal surface from its package
+ * root — the Solid adapter reaches the bus through the `_internal`
+ * backdoor and types the listener locally, the same shape the React
+ * adapter uses.
+ */
+export type PhaseEvent =
+  | { phase: 'capturing-done' }
+  | { phase: 'sanitising-done' }
+  | { phase: 'sent'; aiEnabled: boolean };
+
+/**
+ * Subset of the internal `Bus` we need: subscribe / unsubscribe to phase
+ * events. Keeping the structural type narrow means a future SDK change
+ * that adds new events does not pull broader internal types into the
+ * adapter's surface area.
+ */
+interface PhaseBus {
+  on(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+  off(event: 'phase', listener: (payload: PhaseEvent) => void): void;
+}
+
+/**
+ * Resolve the internal phase bus from a `Brevwick` instance, or return
+ * `null` if the runtime shape doesn't match (e.g. a test mock that
+ * doesn't stamp `_internal`). Adapters in this monorepo and the SDK
+ * itself live in lockstep, so the `'_internal'` string + structural
+ * shape is a stable coupling — but the adapter must not crash when
+ * consumers pass a different `Brevwick`-shaped object.
+ *
+ * Internal — not part of the Solid adapter's public API.
+ */
+export function getPhaseBus(brevwick: Brevwick): PhaseBus | null {
+  const internal = (brevwick as unknown as Record<string, unknown>)._internal;
+  if (!internal || typeof internal !== 'object') return null;
+  const bus = (internal as { bus?: unknown }).bus;
+  if (!bus || typeof bus !== 'object') return null;
+  const candidate = bus as { on?: unknown; off?: unknown };
+  if (typeof candidate.on !== 'function' || typeof candidate.off !== 'function')
+    return null;
+  return bus as PhaseBus;
+}

--- a/packages/solid/src/internal/version.ts
+++ b/packages/solid/src/internal/version.ts
@@ -11,4 +11,4 @@
  * with their own toolchain — that path bypasses tsup's `define` pass, so
  * the literal must already be in the source the bundler reads.
  */
-export const BREVWICK_SOLID_VERSION: string = '1.0.0-beta.10';
+export const BREVWICK_SOLID_VERSION: string = '1.0.0-beta.11';

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -1,179 +1,566 @@
 /**
- * Single-source CSS for the Solid FAB. Injected via a `<style>` tag on first
- * mount of any `<FeedbackButton>` so consumers don't need a CSS-loader plugin
- * — the package drops into Vite, Webpack, or SolidStart with zero config.
+ * Single-source CSS for the Solid FeedbackButton. Injected via a `<style>`
+ * tag on first mount of any `<FeedbackButton>` so consumers don't need a
+ * CSS-loader plugin — the package drops into Vite, Webpack, or SolidStart
+ * with zero config.
  *
- * Mirrors the React adapter's variable conventions (`--brw-*-base` defaults
- * with `--brw-*` consumer overrides) so an app that already styles the React
- * widget keeps its theme when migrating to the Solid package. The Solid V1
- * surface ships a strict subset of the React widget's UI (composer + send +
- * screenshot button) so the stylesheet is correspondingly trimmed.
+ * The Solid widget is a full UX-parity port of the React adapter
+ * (`packages/react/src/styles.ts`); the only intentional divergences are
+ * (a) `BREVWICK_STYLE_ID` is namespaced per-adapter so a host that mounts
+ * both the React and the Solid widget on the same page gets two separate
+ * style blocks, and (b) the region-capture / screenshot-preview rules are
+ * absent because the Solid V1 widget does not ship that surface (the
+ * screenshot button itself is hard-disabled at the component level — see
+ * PR #111). Everything else (theming dual-variable pattern, panel layout,
+ * composer shell, AI toggle, staged-status rows, panel footer) is byte-
+ * identical to the React stylesheet.
+ *
+ * Theming uses a **dual-variable pattern** so the forced-theme prop can
+ * swap palettes without stepping on host-level overrides:
+ *
+ * - `--brw-*-base` holds the shipped defaults (light + `prefers-color-scheme`
+ *   dark + `<FeedbackButton theme="light|dark">` forced palettes). Set only
+ *   by this stylesheet; consumers should **not** target these.
+ * - `--brw-*` is the public override name. Widget rules consume
+ *   `var(--brw-X, var(--brw-X-base))` — the consumer's `--brw-X` value is
+ *   preferred, and we fall back to the base-palette default when nothing
+ *   is set.
  */
 export const BREVWICK_STYLE_ID = 'brevwick-solid-styles';
 
+/**
+ * Maximum autogrow height of the composer textarea in pixels.
+ *
+ * Shared between JS (the autogrow effect sets `style.height` against
+ * `scrollHeight` bounded by this) and CSS (`.brw-composer-input` uses
+ * the same value as `max-height`). Single source of truth so a designer
+ * bumping the ceiling does not drift the two out of sync.
+ */
+export const COMPOSER_MAX_HEIGHT_PX = 120;
+
 export const BREVWICK_CSS = `
 :where(:root) {
+  /* Surfaces */
   --brw-panel-bg-base: #ffffff;
+  --brw-bubble-assistant-bg-base: #f1f5f9;
+  --brw-bubble-user-bg-base: #0f172a;
+  --brw-bubble-user-fg-base: #ffffff;
+  --brw-chip-bg-base: #f1f5f9;
+  --brw-composer-bg-base: #ffffff;
+  /* Text */
   --brw-fg-base: #0f172a;
   --brw-fg-muted-base: #64748b;
+  /* Border / focus */
   --brw-border-base: #e2e8f0;
+  --brw-border-focus-base: #0f172a;
+  --brw-divider-base: #e2e8f0;
+  /* Accent */
   --brw-accent-base: #0f172a;
   --brw-accent-fg-base: #ffffff;
+  /* Shadow */
   --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  /* Status colour — widget-internal, not part of the public override
+     contract. No public alias; widget rules consume --brw-error-base
+     directly. */
   --brw-error-base: #b91c1c;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
     --brw-panel-bg-base: #0b1220;
+    --brw-bubble-assistant-bg-base: #1e293b;
+    --brw-bubble-user-bg-base: #f8fafc;
+    --brw-bubble-user-fg-base: #0f172a;
+    --brw-chip-bg-base: #253044;
+    --brw-composer-bg-base: #0b1220;
     --brw-fg-base: #f8fafc;
     --brw-fg-muted-base: #94a3b8;
     --brw-border-base: #1e293b;
+    --brw-border-focus-base: #f8fafc;
+    --brw-divider-base: #1e293b;
     --brw-accent-base: #f8fafc;
     --brw-accent-fg-base: #0f172a;
     --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
   }
 }
+.brw-root[data-brw-theme='light'] {
+  --brw-panel-bg-base: #ffffff;
+  --brw-bubble-assistant-bg-base: #f1f5f9;
+  --brw-bubble-user-bg-base: #0f172a;
+  --brw-bubble-user-fg-base: #ffffff;
+  --brw-chip-bg-base: #f1f5f9;
+  --brw-composer-bg-base: #ffffff;
+  --brw-fg-base: #0f172a;
+  --brw-fg-muted-base: #64748b;
+  --brw-border-base: #e2e8f0;
+  --brw-border-focus-base: #0f172a;
+  --brw-divider-base: #e2e8f0;
+  --brw-accent-base: #0f172a;
+  --brw-accent-fg-base: #ffffff;
+  --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+}
+.brw-root[data-brw-theme='dark'] {
+  --brw-panel-bg-base: #0b1220;
+  --brw-bubble-assistant-bg-base: #1e293b;
+  --brw-bubble-user-bg-base: #f8fafc;
+  --brw-bubble-user-fg-base: #0f172a;
+  --brw-chip-bg-base: #253044;
+  --brw-composer-bg-base: #0b1220;
+  --brw-fg-base: #f8fafc;
+  --brw-fg-muted-base: #94a3b8;
+  --brw-border-base: #1e293b;
+  --brw-border-focus-base: #f8fafc;
+  --brw-divider-base: #1e293b;
+  --brw-accent-base: #f8fafc;
+  --brw-accent-fg-base: #0f172a;
+  --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+}
 .brw-root {
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   color: var(--brw-fg, var(--brw-fg-base));
 }
 .brw-fab {
   position: fixed;
+  z-index: 2147483000;
   bottom: 24px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
+  height: 48px;
+  min-width: 48px;
+  padding: 0 18px;
   border-radius: 999px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-accent, var(--brw-accent-base));
   color: var(--brw-accent-fg, var(--brw-accent-fg-base));
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   cursor: pointer;
   box-shadow: var(--brw-shadow, var(--brw-shadow-base));
-  z-index: 2147483646;
+  transition: transform 120ms ease-out;
 }
-.brw-fab[disabled] { opacity: 0.5; cursor: not-allowed; }
+.brw-fab:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+.brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
 .brw-fab-br { right: 24px; }
 .brw-fab-bl { left: 24px; }
+.brw-fab-icon { width: 18px; height: 18px; }
 .brw-panel {
   position: fixed;
-  bottom: 88px;
-  width: min(360px, calc(100vw - 32px));
-  max-height: min(560px, calc(100vh - 120px));
+  z-index: 2147483002;
+  bottom: 24px;
+  width: min(92vw, 400px);
+  height: min(80vh, 640px);
   display: flex;
   flex-direction: column;
   background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
   border: 1px solid var(--brw-border, var(--brw-border-base));
-  border-radius: 16px;
+  border-radius: 16px 16px 12px 12px;
   box-shadow: var(--brw-shadow, var(--brw-shadow-base));
-  z-index: 2147483647;
   overflow: hidden;
+  animation: brw-slide-up 200ms ease-out;
 }
 .brw-panel-br { right: 24px; }
 .brw-panel-bl { left: 24px; }
+@keyframes brw-slide-up {
+  from { transform: translateY(16px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-panel { animation: none; }
+  .brw-fab { transition: none; }
+}
+@media (max-width: 480px) {
+  .brw-panel {
+    width: calc(100vw - 32px);
+    left: 16px;
+    right: 16px;
+  }
+}
 .brw-panel-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--brw-border, var(--brw-border-base));
-  font-weight: 600;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--brw-divider, var(--brw-divider-base));
+  flex-shrink: 0;
+}
+.brw-panel-avatar {
+  width: 28px; height: 28px;
+  border-radius: 999px;
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 12px;
+  flex-shrink: 0;
+}
+.brw-panel-title {
+  margin: 0;
   font-size: 14px;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.brw-panel-title { flex: 1; margin: 0; font-size: 14px; font-weight: 600; }
 .brw-icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
+  width: 28px; height: 28px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid transparent;
   background: transparent;
-  color: var(--brw-fg, var(--brw-fg-base));
-  cursor: pointer;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
 }
-.brw-icon-btn:hover { background: color-mix(in srgb, var(--brw-fg, var(--brw-fg-base)) 8%, transparent); }
-.brw-icon-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
-.brw-body {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 16px;
+.brw-icon-btn:hover:not(:disabled) { background: var(--brw-chip-bg, var(--brw-chip-bg-base)); color: var(--brw-fg, var(--brw-fg-base)); }
+.brw-icon-btn:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 1px; }
+.brw-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-icon-btn svg { width: 16px; height: 16px; }
+.brw-thread {
   flex: 1;
   min-height: 0;
-}
-.brw-attachments {
+  overflow-y: auto;
+  padding: 16px 14px;
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
 }
+.brw-bubble {
+  max-width: 85%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  font-size: 13px;
+  line-height: 1.45;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+.brw-bubble--assistant {
+  align-self: flex-start;
+  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
+  border-bottom-left-radius: 4px;
+}
+.brw-bubble--user {
+  align-self: flex-end;
+  background: var(--brw-bubble-user-bg, var(--brw-bubble-user-bg-base));
+  color: var(--brw-bubble-user-fg, var(--brw-bubble-user-fg-base));
+  border-bottom-right-radius: 4px;
+}
+.brw-bubble--receipt {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+}
+.brw-bubble--receipt svg { flex-shrink: 0; }
 .brw-chip {
+  align-self: flex-end;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
   border: 1px solid var(--brw-border, var(--brw-border-base));
-  border-radius: 999px;
+  border-radius: 12px;
   font-size: 12px;
+  max-width: 85%;
 }
+.brw-chip img {
+  width: 28px; height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+  display: block;
+}
+.brw-chip-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 180px; }
+.brw-chip-size { color: var(--brw-fg-muted, var(--brw-fg-muted-base)); }
 .brw-chip-remove {
+  width: 20px; height: 20px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
   border: none;
   background: transparent;
   color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  border-radius: 999px;
   cursor: pointer;
-  font-size: 14px;
+  font: inherit;
   line-height: 1;
 }
-.brw-textarea {
+.brw-chip-remove:hover { background: var(--brw-border, var(--brw-border-base)); color: var(--brw-fg, var(--brw-fg-base)); }
+.brw-disclosure {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.brw-disclosure:hover { color: var(--brw-fg, var(--brw-fg-base)); }
+.brw-disclosure-panel {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  border-radius: 10px;
+}
+.brw-disclosure-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.brw-disclosure-input {
   width: 100%;
   box-sizing: border-box;
-  resize: vertical;
-  min-height: 96px;
-  max-height: 200px;
-  padding: 10px;
-  border: 1px solid var(--brw-border, var(--brw-border-base));
-  border-radius: 8px;
-  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
-  color: var(--brw-fg, var(--brw-fg-base));
+  padding: 6px 8px;
   font: inherit;
-  font-size: 14px;
+  font-size: 12px;
+  color: var(--brw-fg, var(--brw-fg-base));
+  background: var(--brw-panel-bg, var(--brw-panel-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  border-radius: 6px;
+  resize: vertical;
+  min-height: 34px;
 }
-.brw-error { color: var(--brw-error, var(--brw-error-base)); font-size: 13px; }
-.brw-success { color: var(--brw-fg-muted, var(--brw-fg-muted-base)); font-size: 13px; }
-.brw-actions {
+.brw-composer {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+  border-top: 1px solid var(--brw-divider, var(--brw-divider-base));
+}
+.brw-composer-shell {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 6px 8px;
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  border-radius: 12px;
+  transition: border-color 120ms ease-out;
+}
+.brw-composer-shell:focus-within {
+  border-color: var(--brw-border-focus, var(--brw-border-focus-base));
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-composer-shell { transition: none; }
+}
+.brw-composer-input {
+  flex: 1;
+  min-height: 34px;
+  max-height: ${COMPOSER_MAX_HEIGHT_PX}px;
+  box-sizing: border-box;
+  padding: 8px 4px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--brw-fg, var(--brw-fg-base));
+  background: transparent;
+  border: none;
+  resize: none;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+.brw-composer-input:focus-visible { outline: none; }
+.brw-send-btn {
+  width: 34px; height: 34px;
+  padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--brw-accent, var(--brw-accent-base));
+  background: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-accent-fg, var(--brw-accent-fg-base));
+  border-radius: 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.brw-aitoggle-wrap {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 4px;
+}
+.brw-aitoggle-text {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  line-height: 1;
+  user-select: none;
+  transition: color 120ms ease-out;
+}
+.brw-aitoggle-wrap:has(.brw-aitoggle--on) .brw-aitoggle-text {
+  color: var(--brw-fg, var(--brw-fg-base));
+}
+.brw-aitoggle {
+  position: relative;
+  flex-shrink: 0;
+  width: 30px;
+  height: 18px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  cursor: pointer;
+  transition: background-color 120ms ease-out, border-color 120ms ease-out;
+}
+.brw-aitoggle:focus-visible { outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base)); outline-offset: 2px; }
+.brw-aitoggle:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-aitoggle-thumb {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  transform: translateY(-50%);
+  transition: left 140ms ease-out, background-color 120ms ease-out;
+}
+.brw-aitoggle--on {
+  background: var(--brw-accent, var(--brw-accent-base));
+  border-color: var(--brw-accent, var(--brw-accent-base));
+}
+.brw-aitoggle--on .brw-aitoggle-thumb {
+  left: calc(100% - 14px);
+  background: var(--brw-accent-fg, var(--brw-accent-fg-base));
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-aitoggle, .brw-aitoggle-thumb, .brw-aitoggle-text { transition: none; }
+}
+.brw-send-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.brw-send-btn svg { width: 16px; height: 16px; }
+.brw-file-input { display: none; }
+.brw-confirm {
+  align-self: stretch;
   display: flex;
   gap: 8px;
-  padding: 12px 16px;
-  border-top: 1px solid var(--brw-border, var(--brw-border-base));
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--brw-chip-bg, var(--brw-chip-bg-base));
+  border: 1px solid var(--brw-border, var(--brw-border-base));
+  border-radius: 10px;
+  font-size: 12px;
 }
+.brw-confirm-msg { flex: 1; }
 .brw-btn {
-  flex: 1;
-  padding: 8px 12px;
+  height: 30px;
+  padding: 0 12px;
   border-radius: 8px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-panel-bg, var(--brw-panel-bg-base));
   color: var(--brw-fg, var(--brw-fg-base));
   font: inherit;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 12px;
   cursor: pointer;
 }
+.brw-btn:hover:not(:disabled) { background: var(--brw-chip-bg, var(--brw-chip-bg-base)); }
 .brw-btn-primary {
   background: var(--brw-accent, var(--brw-accent-base));
   color: var(--brw-accent-fg, var(--brw-accent-fg-base));
-  border-color: transparent;
+  border-color: var(--brw-accent, var(--brw-accent-base));
 }
-.brw-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
-.brw-footer {
-  padding: 8px 16px;
-  border-top: 1px solid var(--brw-border, var(--brw-border-base));
-  font-size: 11px;
-  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+.brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
+.brw-status-row {
+  align-self: flex-start;
+  max-width: 85%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border-bottom-left-radius: 4px;
+  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
+  color: var(--brw-fg, var(--brw-fg-base));
+  font-size: 13px;
+  line-height: 1.45;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: brw-status-row-in 220ms ease-out both;
+}
+.brw-status-row-check {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  color: var(--brw-accent, var(--brw-accent-base));
+}
+.brw-status-row-check svg {
+  width: 14px;
+  height: 14px;
+}
+.brw-status-row-label { flex: 1; }
+.brw-status-row--error {
+  color: var(--brw-error-base);
+  border: 1px solid var(--brw-error-base);
+}
+.brw-status-row-retry {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+@keyframes brw-status-row-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-status-row { animation: none; }
+}
+.brw-panel-footer {
+  flex-shrink: 0;
+  padding: 6px 10px 8px;
   text-align: center;
+  background: var(--brw-composer-bg, var(--brw-composer-bg-base));
 }
-.brw-footer a { color: inherit; text-decoration: none; }
-.brw-footer a:hover { text-decoration: underline; }
+.brw-panel-footer-link {
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity 120ms ease-out, color 120ms ease-out;
+}
+.brw-panel-footer-link:hover,
+.brw-panel-footer-link:focus-visible {
+  opacity: 1;
+  color: var(--brw-fg, var(--brw-fg-base));
+  text-decoration: underline;
+}
+@media (prefers-reduced-motion: reduce) {
+  .brw-panel-footer-link { transition: none; }
+}
+.brw-spinner {
+  display: inline-block; width: 14px; height: 14px;
+  border: 2px solid currentColor; border-right-color: transparent;
+  border-radius: 999px;
+  animation: brw-spin 0.7s linear infinite;
+}
+@keyframes brw-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .brw-spinner { animation-duration: 1.6s; }
+}
+.brw-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 `;

--- a/packages/solid/src/use-feedback.ts
+++ b/packages/solid/src/use-feedback.ts
@@ -1,6 +1,17 @@
-import { createSignal, useContext, type Accessor } from 'solid-js';
-import type { FeedbackInput, SubmitResult } from '@tatlacas/brevwick-sdk';
+import {
+  createSignal,
+  onCleanup,
+  onMount,
+  useContext,
+  type Accessor,
+} from 'solid-js';
+import type {
+  FeedbackInput,
+  SubmitError,
+  SubmitResult,
+} from '@tatlacas/brevwick-sdk';
 import { BrevwickContext } from './provider';
+import { getPhaseBus, type PhaseEvent } from './internal-bridge';
 
 /**
  * Submission lifecycle surfaced by {@link useFeedback}.
@@ -13,9 +24,30 @@ import { BrevwickContext } from './provider';
 export type FeedbackStatus = 'idle' | 'submitting' | 'success' | 'error';
 
 /**
+ * Submit-pipeline phase the UI can render staged status against. Driven
+ * by the SDK's internal `phase` bus event:
+ *
+ * - `idle` — initial state and after `reset()`.
+ * - `capturing` — `submit()` has been called but no phase event has fired yet.
+ * - `sanitising` — `capturing-done` event arrived (payload composed).
+ * - `formatting` — `sanitising-done` event arrived (redact complete; the
+ *   ingest POST is in flight). UIs gate any "Formatting with AI" affordance
+ *   on this phase plus the project's `ai_enabled` flag.
+ * - `sent` — `sent` event arrived after a 2xx ingest response.
+ * - `error` — `submit()` resolved with `{ ok: false }` or rejected.
+ */
+export type FeedbackPhase =
+  | 'idle'
+  | 'capturing'
+  | 'sanitising'
+  | 'formatting'
+  | 'sent'
+  | 'error';
+
+/**
  * Return value of {@link useFeedback}. Mirrors the React adapter: `submit` is
- * a plain async function; `status` is a Solid `Accessor` so consumers wire it
- * straight into JSX (`{status() === 'submitting' && ...}`).
+ * a plain async function; `status`/`phase`/`error` are Solid `Accessor`s so
+ * consumers wire them straight into JSX (`{status() === 'submitting' && ...}`).
  */
 export interface UseFeedbackResult {
   /** Submit feedback. Returns the same tagged union the core SDK returns. */
@@ -32,9 +64,34 @@ export interface UseFeedbackResult {
    * across the app is required.
    */
   status: Accessor<FeedbackStatus>;
-  /** Reset `status` back to `'idle'`. Does not cancel an in-flight submit. */
+  /**
+   * Current submit-pipeline phase. Advances on the SDK's internal phase
+   * bus event so adapter UIs can render staged-status rows in step with
+   * the actual pipeline boundaries (compose → redact → ingest).
+   */
+  phase: Accessor<FeedbackPhase>;
+  /**
+   * Tagged error from the last failed `submit()`. `null` until a submit
+   * resolves with `{ ok: false }` or rejects (chunk-load failure surfaces
+   * as `{ code: 'INGEST_RETRY_EXHAUSTED', message: <Error.message> }`).
+   * Cleared back to `null` on the next `submit()` or `reset()`.
+   */
+  error: Accessor<SubmitError | null>;
+  /**
+   * Re-run the most recent `submit()` with the same input. No-op when no
+   * submit has been attempted yet. Returns the same tagged-union result
+   * the underlying `submit()` would.
+   */
+  retry: () => Promise<SubmitResult | undefined>;
+  /** Reset `status` + `phase` back to `'idle'` and clear `error`. */
   reset: () => void;
 }
+
+const PHASE_EVENT_TO_NEXT_PHASE: Record<PhaseEvent['phase'], FeedbackPhase> = {
+  'capturing-done': 'sanitising',
+  'sanitising-done': 'formatting',
+  sent: 'sent',
+};
 
 /**
  * Solid hook that exposes the Brevwick submission primitives against the
@@ -56,6 +113,39 @@ export function useFeedback(): UseFeedbackResult {
   }
 
   const [status, setStatus] = createSignal<FeedbackStatus>('idle');
+  const [phase, setPhase] = createSignal<FeedbackPhase>('idle');
+  const [error, setError] = createSignal<SubmitError | null>(null);
+  // Snapshot of the input passed to the most recent `submit()` so `retry()`
+  // can re-run the exact same payload without forcing the caller to hold
+  // it for us. Cleared on `reset()`.
+  let lastInput: FeedbackInput | null = null;
+  // Whether the bus listener should write into state. Flipped to false on
+  // unmount so an in-flight submit that resolves after teardown can't
+  // setState on a stale tree.
+  let alive = true;
+
+  // Subscribe to the SDK's phase bus once the provider has hydrated. The
+  // Solid context's `brevwick` accessor flips from `null` → SDK on the
+  // client mount; we register / unregister inside `onMount` + `onCleanup`
+  // so the listener never fires post-teardown.
+  onMount(() => {
+    const sdk = ctx.brevwick();
+    if (!sdk) return;
+    const bus = getPhaseBus(sdk);
+    if (!bus) return;
+    const onPhase = (event: PhaseEvent): void => {
+      if (!alive) return;
+      setPhase(PHASE_EVENT_TO_NEXT_PHASE[event.phase]);
+    };
+    bus.on('phase', onPhase);
+    onCleanup(() => {
+      bus.off('phase', onPhase);
+    });
+  });
+
+  onCleanup(() => {
+    alive = false;
+  });
 
   // Resolve the SDK lazily on each call. Callers can mount `<FeedbackButton>`
   // unconditionally — the button's onClick handler runs only after hydration,
@@ -70,32 +160,53 @@ export function useFeedback(): UseFeedbackResult {
     return sdk;
   };
 
-  const submit = async (input: FeedbackInput): Promise<SubmitResult> => {
-    // Resolve the SDK before flipping status so a pre-hydration call still
-    // surfaces an `'error'` end state rather than getting stuck on
-    // `'submitting'`. The status transition lands inside the same async
-    // boundary as the await, keeping `(input) => Promise<SubmitResult>` the
-    // single observable surface.
+  const runSubmit = async (input: FeedbackInput): Promise<SubmitResult> => {
     let sdk;
     try {
       sdk = requireSdk();
-    } catch (error) {
+    } catch (err) {
       setStatus('error');
-      throw error;
+      setPhase('error');
+      throw err;
     }
+    lastInput = input;
     setStatus('submitting');
+    setPhase('capturing');
+    setError(null);
     try {
       const result = await sdk.submit(input);
-      setStatus(result.ok ? 'success' : 'error');
+      if (!alive) return result;
+      if (result.ok) {
+        setStatus('success');
+      } else {
+        setStatus('error');
+        setPhase('error');
+        setError(result.error);
+      }
       return result;
-    } catch (error) {
+    } catch (err) {
       // `sdk.submit` only rejects when the lazy submit chunk itself fails to
       // load (deploy mismatch / offline). Flip to 'error' so the UI is not
       // wedged on 'submitting', then rethrow so callers can distinguish an
       // environmental failure from an ingest-level one.
-      setStatus('error');
-      throw error;
+      if (alive) {
+        setStatus('error');
+        setPhase('error');
+        setError({
+          code: 'INGEST_RETRY_EXHAUSTED',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      throw err;
     }
+  };
+
+  const submit = (input: FeedbackInput): Promise<SubmitResult> =>
+    runSubmit(input);
+
+  const retry = async (): Promise<SubmitResult | undefined> => {
+    if (!lastInput) return undefined;
+    return runSubmit(lastInput);
   };
 
   // Try/catch so a missing-SDK throw from `requireSdk()` surfaces as a
@@ -107,14 +218,25 @@ export function useFeedback(): UseFeedbackResult {
   const captureScreenshot = (): Promise<Blob> => {
     try {
       return requireSdk().captureScreenshot();
-    } catch (error) {
-      return Promise.reject(error);
+    } catch (err) {
+      return Promise.reject(err);
     }
   };
 
   const reset = (): void => {
     setStatus('idle');
+    setPhase('idle');
+    setError(null);
+    lastInput = null;
   };
 
-  return { submit, captureScreenshot, status, reset };
+  return {
+    submit,
+    captureScreenshot,
+    status,
+    phase,
+    error,
+    retry,
+    reset,
+  };
 }

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,36 @@
 # @tatlacas/brevwick-svelte
 
+## 1.0.0-beta.12
+
+### Minor Changes
+
+- [#117](https://github.com/tatlacas-com/brevwick-sdk-js/pull/117) [`72b0d34`](https://github.com/tatlacas-com/brevwick-sdk-js/commit/72b0d3430bcf3634ab4d8aa171fa7d8a045529ae) Thanks [@tatlacas](https://github.com/tatlacas)! - feat(svelte): widget UX parity with React adapter
+
+  `<FeedbackButton>` now ships the full React-adapter UX surface:
+  - Header gains a minimize button (preserves draft) alongside close, and
+    the close affordance routes through an inline discard-confirm whenever
+    the composer is dirty.
+  - Chat-style thread renders assistant + user message bubbles, plus a
+    successful-submit receipt bubble carrying a relative-time stamp.
+  - Expected vs Actual disclosure (`aria-expanded` + `aria-controls`); the
+    trimmed values ride the `FeedbackInput` payload only when filled.
+  - Phase-driven staged-status rows (`Captured`, `PII-sanitised`, AI-gated
+    `Formatting with AI…`) with reduced-motion stagger.
+  - Red retry row carrying the verbatim `SubmitError.message` + a Retry CTA;
+    exposes `data-brw-error-code` for the test suite.
+  - AI toggle (`role="switch"`, Space-to-flip) gated by the project-config
+    render-policy matrix; `use_ai` rides the payload only when the toggle
+    is visible.
+  - Lazy `getConfig()` on first panel open, cached for subsequent opens.
+
+  `getFeedback()` is extended (not the SDK / provider boundary): now
+  returns `phase`, `error`, `retry`, and `getConfig` stores in addition to
+  the existing `submit` / `status` / `reset`. Phase events come off the
+  SDK's `_internal` bus through the same structural probe the React
+  adapter uses; the listener is auto-detached on component destroy.
+
+  Closes [#114](https://github.com/tatlacas-com/brevwick-sdk-js/issues/114)
+
 ## 1.0.0-beta.11
 
 ### Minor Changes

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatlacas/brevwick-svelte",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "Brevwick Svelte bindings — context, FAB, getFeedback. Drop-in for Svelte 5 and SvelteKit apps.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Closes #113. Brings `<FeedbackButton>` in `@tatlacas/brevwick-solid` to UX parity with the React adapter. The Solid widget previously shipped a deliberately-small textarea-only subset; v1 needs the same widget surface every adapter offers.

- **Chat-thread panel**: greeting + user/assistant bubbles with relative-time receipts on successful submits; submit clears the composer + appends the user bubble synchronously, so the staged-status rows carry the wait. Discard-confirm modal on dirty close; Esc / minimize preserves draft.
- **Composer**: autogrow textarea, paperclip multi-file attach, AI toggle (track-and-thumb switch with Space-to-toggle keyboard a11y), and send.
- **Staged-status rows + retry**: `Captured` → `Sanitised` → `Formatting with AI…` driven by the SDK's internal phase bus through a new `packages/solid/src/internal-bridge.ts` (mirrors the React bridge). Tagged retry row on `ok: false` / chunk-load failures with a single Retry CTA that re-runs the original `FeedbackInput`. `data-brw-error-code` matches the SDK's `SubmitError.code`.
- **Project-config gating**: lazy `getConfig()` fetch on first panel open driving the AI toggle's render-policy matrix (`ai_enabled` + `ai_submitter_choice_allowed`) and the AI status row. Expected/actual disclosure piggybacks the submit payload.
- **Reduced-motion gate**: `prefers-reduced-motion: reduce` flattens the staged-row stagger to 0 ms.
- **Theming**: forced palette via `theme="light|dark|system"` data attribute on FAB + panel; CSS injection guarded by the `brevwick-solid-styles` id. Stylesheet ports the React `BREVWICK_CSS` (panel, composer shell, staged-status rows, AI toggle, panel footer, dual-variable theming).
- **Hook surface**: `useFeedback()` grows `phase`, `error`, and `retry` accessors so the widget can drive the staged-status + retry surfaces. Existing `submit`, `captureScreenshot`, `status`, `reset` are unchanged — `captureScreenshot` stays available for direct callers even though the widget no longer surfaces a screenshot button.
- **Bundle budget**: 5 kB → 12 kB gzip in `.size-limit.js` and `CLAUDE.md`. Solid ESM 8.79 kB / CJS 9.11 kB; well under the React adapter's 25 kB ceiling.
- **Tests**: 57 passed + 5 `.skip` (the screenshot capture describe block, kept skipped to match the v1 disable shipped in PR #111). Existing `provider`, `redaction`, `use-feedback`, `chunk-split` suites stay green.

## Out of scope

- **Screenshot UI (disabled in v1 — see PR #111)**: the screenshot button + capture chips + region overlay + preview dialog are intentionally absent. The `useFeedback().captureScreenshot()` hook surface stays exported for direct callers; only the widget UI is gated. Re-enable by reverting PR #111's disable + flipping the `.skip` test blocks back.
- Modifying SDK internals (the new internal-bridge.ts only reads `_internal.bus` the same way the React bridge does).
- Cross-adapter style sharing (each adapter ships its own copy of `BREVWICK_CSS` so `BREVWICK_STYLE_ID` can stay namespaced; intentional, mirrors the React/Vue convention).

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:cover` — Solid 57/5-skip; all other suites green
- [x] `pnpm build` — every package + every example builds
- [x] `pnpm size` — all adapters inside their bundle budget; Solid at 8.79 kB / 12 kB ceiling