### PR TITLE
fix(release): run prebuild in version-packages to sync version.ts

### DIFF
--- a/.changeset/release-version-sync.md
+++ b/.changeset/release-version-sync.md
@@ -1,0 +1,12 @@
+---
+---
+
+Tooling: have `pnpm version-packages` run `prebuild` in every workspace that
+defines it, so each package's generated `src/internal/version.ts` literal is
+re-written from the freshly-bumped `package.json#version` and committed into
+the same Changesets release PR. Without this the Solid widget's footer test
+(which compares the live `pkg.version` against the `BREVWICK_SOLID_VERSION`
+literal that the bundler reads from `src/`) failed every release PR. Also
+adds defensive `pretest` / `pretest:cover` hooks to `@tatlacas/brevwick-solid`
+so a developer running tests on a stale tree locally regenerates the literal.
+No published code changes.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "size": "size-limit",
     "test:e2e": "playwright test",
     "changeset": "changeset",
-    "version-packages": "changeset version && pnpm install --lockfile-only",
+    "version-packages": "changeset version && pnpm install --lockfile-only && pnpm -r --if-present run prebuild",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -34,7 +34,9 @@
     "build": "tsup",
     "predev": "node scripts/generate-version.mjs",
     "dev": "tsup --watch",
+    "pretest": "node scripts/generate-version.mjs",
     "test": "vitest run",
+    "pretest:cover": "node scripts/generate-version.mjs",
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary

The `Version Packages (beta)` PR opened by Changesets (#108) currently fails CI on a single Solid test:

```
packages/solid/src/__tests__/feedback-button.test.tsx:154
  Expected: Brevwick v1.0.0-beta.13
  Received: Brevwick v1.0.0-beta.11
```

The Solid widget renders its credit footer from `BREVWICK_SOLID_VERSION` in `packages/solid/src/internal/version.ts:14` — a literal that's regenerated by `packages/solid/scripts/generate-version.mjs` from `package.json#version`. The literal has to live in source (not a tsup `define` substitution) because the package's `"solid"` export condition points at `src/`, so consumers' SolidStart / vite-plugin-solid toolchains compile JSX directly from there and bypass the bundler's `define` pass.

The release flow's `pnpm version-packages` script — which Changesets invokes when opening / updating the release PR — was bumping `package.json` versions but never regenerating those `version.ts` literals. Result: the release PR's `package.json` says `1.0.0-beta.13` while `version.ts` is frozen at the previous release's `1.0.0-beta.11`. The Solid footer test (which compares the rendered text against the live `pkg.version`) catches the drift; every Solid release PR was guaranteed to fail.

The fix is one line:

```jsonc
// package.json (root)
"version-packages": "changeset version && pnpm install --lockfile-only && pnpm -r --if-present run prebuild"
```

`pnpm -r --if-present run prebuild` invokes `prebuild` in every workspace that defines it — currently `@tatlacas/brevwick-{angular,react-native,solid,svelte}`, exactly the four packages with `generate-version.mjs`. The regenerated `version.ts` files are caught by the `changesets/action` commit step and ride into the same release PR.

Once this lands on `main`, `release.yml` re-runs against the unconsumed changesets, force-pushes the corrected tree to `changeset-release/main` (the branch backing #108), and #108's CI re-runs against the synced files. No manual nudge needed.

Defensive secondary fix: `@tatlacas/brevwick-solid` gains `pretest` / `pretest:cover` hooks (matching the pattern angular and react-native already use) so a developer running tests on a stale tree locally regenerates the literal before vitest reads it.

## Out of scope

- `@tatlacas/brevwick-{vue,react,sdk}` don't have `generate-version.mjs` and don't currently render a version literal — adding the script there is a follow-up if/when those packages need the same pattern.
- Adding `pretest:cover` to angular / react-native (their existing `pretest` only fires on bare `pnpm test`, not the `test:cover` CI runs — but neither asserts against `pkg.version` today, so it's latent, not urgent).
- An empty changeset is included so `changeset-check` passes; this is a tooling-only change with no published-code impact, so no package bumps.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean
- [x] `pnpm type-check` clean (after the pre-existing CI sequence of `--filter` builds for sdk + angular + react-native)
- [x] `pnpm test:cover` — full matrix passes; Solid now reports `53 passed | 9 skipped` (was `52 passed | 1 failed | 9 skipped` on PR #108)
- [x] `pnpm build` clean
- [x] `pnpm size` — every package within budget
- [x] `pnpm -r --if-present run prebuild` invokes the four expected workspaces (`packages/{angular,react-native,solid,svelte}`) and writes their `version.ts` files
- [ ] After merge: confirm `release.yml` re-runs and PR #108's diff now also includes the four `version.ts` updates, and #108's `check` job goes green