### PR TITLE
chore(release): invert channels - beta default, main stable

### DIFF
--- a/.github/workflows/guard-deploy-branches.yml
+++ b/.github/workflows/guard-deploy-branches.yml
@@ -2,14 +2,14 @@ name: Guard deploy branches
 
 on:
   pull_request:
-    branches: [beta, stable]
+    branches: [main]
 
 jobs:
   check-source:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow merges from main
-        if: github.head_ref != 'main'
+      - name: Only allow merges from beta
+        if: github.head_ref != 'beta'
         run: |
-          echo "::error::Only the 'main' branch can be merged into '${{ github.base_ref }}'. Got '${{ github.head_ref }}'."
+          echo "::error::Only the 'beta' branch can be merged into 'main'. Got '${{ github.head_ref }}'. Use scripts/promote-stable.sh to open a promotion PR."
           exit 1

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,42 @@
+name: Release (beta)
+
+on:
+  push:
+    branches: [beta]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    if: github.repository == 'tatlacas-com/brevwick-sdk-js'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm install --frozen-lockfile
+      - name: Create Release PR or publish (beta)
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        with:
+          version: pnpm version-packages
+          publish: pnpm release:beta
+          createGithubReleases: true
+          title: 'Version Packages (beta)'
+          commit: 'chore(release): version packages (beta)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Never blindly implement a suggestion. Apply critical thinking — push back when
 
 **No shortcuts or temporary fixes.** Do not implement workarounds or "for now" solutions that paper over a real problem. If the proper fix belongs in a different repo or requires upstream work, say so and stop. Every fix must address the root cause.
 
-**Never commit and push directly to `main`.** `main` is protected — all changes go through a PR. No exceptions.
+**Never commit and push directly to `main` or `beta`.** Both are protected — all changes go through a PR. No exceptions. Day-to-day work targets `beta` (the default branch); `main` only receives promotion PRs from `beta` (see Release Channels below).
 
 **Auto-commit, push, and open PR on branches.** When working on a `feat/fix/chore` branch, commit, push, **and create a PR with `gh pr create`** without asking. Every push to a branch must result in a PR. If a PR already exists, just push.
 
@@ -28,8 +28,8 @@ If CI is failing, **immediately investigate and fix** — do not ask whether to 
 
 ```bash
 git fetch origin
-# Branch from origin/main, not local main (may be stale)
-git worktree add ../brevwick-sdk-js-issue-<N> -b feat/issue-<N>-short-desc origin/main
+# Branch from origin/beta, not local beta (may be stale). beta is the default branch.
+git worktree add ../brevwick-sdk-js-issue-<N> -b feat/issue-<N>-short-desc origin/beta
 cd ../brevwick-sdk-js-issue-<N>
 ```
 
@@ -66,7 +66,7 @@ When the user asks to write or update a worktree.md, follow this convention. Exi
   ```bash
   cd ~/repos/brevwick/<repo>
   git fetch origin
-  git worktree add ../<repo>-wt-<slug> -b <type>/<branch-name> origin/main
+  git worktree add ../<repo>-wt-<slug> -b <type>/<branch-name> origin/beta
   cd ../<repo>-wt-<slug>
 
   claude --dangerously-skip-permissions "
@@ -127,42 +127,62 @@ Every payload that leaves the device runs through `redact()` first. Adding a new
 
 ## Versioning
 
-Both packages move together for now (kept in lockstep). Once Phase 4 ships and the API is stable, they may diverge — at that point introduce changesets.
+All seven packages move together (linked in `.changeset/config.json`). Versions follow SemVer from `1.0.0` onward — the `1.0.0-beta.X` train is the lead-up to the first stable.
 
-Pre-1.0 (`0.x.y`):
+- `feat:` — minor bump
+- `fix:` / `refactor:` — patch bump
+- Breaking change — major bump (call it out in the changeset body)
 
-- patch: bug fixes, internal refactors
-- minor: anything else (no SemVer guarantee in 0.x)
+## Release Channels
 
-## Branching & PR Workflow
+Two long-lived branches map to two npm dist-tags:
 
+| Branch           | npm dist-tag | Purpose                                                            |
+| ---------------- | ------------ | ------------------------------------------------------------------ |
+| `beta` (default) | `beta`       | Day-to-day integration; every merge can publish a new `-beta.N`    |
+| `main`           | `latest`     | Stable releases only, fed exclusively by promotion PRs from `beta` |
+
+### Day-to-day flow (the 99% case)
+
+1. `git fetch origin` then branch from `origin/beta` (the default branch).
+2. Make changes; add a changeset (`pnpm changeset`).
+3. Push branch, open PR into `beta` with `gh pr create`.
+4. CI passes → squash-merge into `beta`.
+5. `release-beta.yml` opens (or updates) a "Version Packages (beta)" PR. Merging it publishes `-beta.N` to the `beta` dist-tag.
+
+### Stable promotion (occasional)
+
+Run from a fresh chore branch off `origin/main`:
+
+```bash
+git fetch origin
+git checkout -b chore/promote-<version> origin/main
+./scripts/promote-stable.sh
 ```
-main (protected)
-  └── feat/<short-description>
-  └── fix/<short-description>
-  └── chore/<short-description>
+
+The script merges `beta` into the branch, exits changesets pre mode, pushes, and opens a `beta → main` PR. After that PR merges, `release.yml` on `main` opens a "Version Packages" PR with stable bumps; merging it publishes to the `latest` dist-tag.
+
+After stable ships, resume the beta channel:
+
+```bash
+git fetch origin
+git checkout -b chore/resume-beta-<version> origin/beta
+./scripts/resume-beta.sh
 ```
-
-### Workflow steps
-
-1. `git fetch origin` then create branch from `origin/main` (never from local `main`).
-2. Make changes, commit with conventional commits.
-3. Push branch, create PR with `gh pr create`.
-4. PR body references the issue (`Closes #<number>`) where applicable; link the SDD § 12 contract for public API changes.
-5. Wait for CI to pass. Squash-merge into `main` (the only allowed merge method).
 
 ### Rules
 
 - Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
 - Subject ≤ 72 chars
 - No `Co-Authored-By` headers — no Claude attribution anywhere
+- Squash-merge only on both `beta` and `main`
 
-### Branch protection (`main`)
+### Branch protection
+
+Both `beta` and `main` are protected:
 
 - Squash-merge only; no direct push, no force-push, no deletion.
 - Required status checks: `check`, `codecov/patch`, `codecov/project`.
 - Stale reviews dismissed on new push.
 
-### Deploy branches
-
-- `beta` and `stable` (if/when introduced) are deploy branches. PRs to them must originate from `main` (enforced by `guard-deploy-branches.yml`).
+`main` additionally enforces (via `guard-deploy-branches.yml`) that PRs into it must come from the `beta` branch — use `scripts/promote-stable.sh`, do not open a feature-branch PR straight into `main`.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "playwright test",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only && pnpm -r --if-present run prebuild",
-    "release": "pnpm build && changeset publish"
+    "release": "pnpm build && changeset publish",
+    "release:beta": "pnpm build && changeset publish --tag beta"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",

--- a/scripts/promote-stable.sh
+++ b/scripts/promote-stable.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Open a promotion PR from beta -> main.
+#
+# Run from a clean working tree on a fresh branch off origin/main:
+#   git fetch origin
+#   git checkout -b chore/promote-<version> origin/main
+#   ./scripts/promote-stable.sh
+#
+# What it does:
+#   1. Merges origin/beta into the current branch.
+#   2. Runs `pnpm changeset pre exit` so the next version run produces stable bumps.
+#   3. Commits the result.
+#   4. Pushes and opens a PR titled "chore(release): promote beta -> main".
+#
+# After the PR merges, release.yml on main will open a stable "Version Packages"
+# PR. Merging that publishes to the npm `latest` dist-tag.
+#
+# Once stable has shipped, run scripts/resume-beta.sh to put beta back into pre mode.
+
+set -euo pipefail
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is not clean. Commit or stash first." >&2
+  exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "beta" ]; then
+  echo "Refusing to run on '$current_branch'. Create a chore/promote-* branch first." >&2
+  exit 1
+fi
+
+git fetch origin
+
+echo "==> Merging origin/beta into $current_branch"
+git merge --no-ff origin/beta -m "chore(release): merge beta into main for promotion"
+
+echo "==> Exiting changesets pre mode"
+pnpm changeset pre exit
+
+git add .changeset/
+git commit -m "chore(release): exit pre mode for stable promotion"
+
+echo "==> Pushing branch"
+git push -u origin "$current_branch"
+
+echo "==> Opening PR"
+gh pr create \
+  --base main \
+  --title "chore(release): promote beta -> main" \
+  --body "$(cat <<'PREOF'
+## Summary
+- Merges current `beta` into `main`.
+- Exits changesets pre mode so the next version run on `main` produces stable bumps.
+
+## Next steps
+- Merge this PR.
+- `release.yml` on `main` will open a "Version Packages" PR with stable bumps.
+- Merging that PR publishes to the npm `latest` dist-tag.
+- After stable ships, run `scripts/resume-beta.sh` to put `beta` back into pre mode.
+
+## Test plan
+- [ ] CI passes on this PR.
+- [ ] After merge, the auto-opened "Version Packages" PR shows non-`-beta` versions.
+PREOF
+)"

--- a/scripts/resume-beta.sh
+++ b/scripts/resume-beta.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# After a stable release lands on main, put beta back into pre mode.
+#
+# Run from a clean working tree on a fresh branch off origin/beta:
+#   git fetch origin
+#   git checkout -b chore/resume-beta-<version> origin/beta
+#   ./scripts/resume-beta.sh
+#
+# What it does:
+#   1. Merges origin/main into the current branch (brings stable versions in).
+#   2. Runs `pnpm changeset pre enter beta` so future merges produce -beta.N versions.
+#   3. Commits, pushes, opens a PR into beta.
+
+set -euo pipefail
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is not clean. Commit or stash first." >&2
+  exit 1
+fi
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "beta" ]; then
+  echo "Refusing to run on '$current_branch'. Create a chore/resume-beta-* branch first." >&2
+  exit 1
+fi
+
+git fetch origin
+
+echo "==> Merging origin/main into $current_branch"
+git merge --no-ff origin/main -m "chore(release): merge main into beta after stable release"
+
+echo "==> Re-entering changesets pre mode (beta)"
+pnpm changeset pre enter beta
+
+git add .changeset/
+git commit -m "chore(release): re-enter pre mode (beta)"
+
+echo "==> Pushing branch"
+git push -u origin "$current_branch"
+
+echo "==> Opening PR"
+gh pr create \
+  --base beta \
+  --title "chore(release): resume beta channel" \
+  --body "$(cat <<'PREOF'
+## Summary
+- Merges latest stable from `main` into `beta`.
+- Re-enters changesets pre mode (`beta` tag) so subsequent merges produce `-beta.N` versions.
+
+## Test plan
+- [ ] CI passes.
+- [ ] `.changeset/pre.json` exists with `mode: pre`, `tag: beta`.
+PREOF
+)"


### PR DESCRIPTION
## Summary

Sets up the dual-channel release infrastructure so `beta` becomes the default working branch (publishes `-beta.N` to the npm `beta` dist-tag) and `main` becomes the stable promotion target (publishes to `latest`). Inverts the current setup where `main` was running pre mode and accidentally publishing betas to `latest`.

### What this PR changes

- **`package.json`** — adds `release:beta` script (`changeset publish --tag beta`). Existing `release` script stays untagged for stable on main.
- **`.github/workflows/release-beta.yml`** (new) — triggers on push to `beta`, runs `changesets/action` with `release:beta`, opens "Version Packages (beta)" PRs.
- **`.github/workflows/guard-deploy-branches.yml`** — inverted: PRs into `main` must come from `beta` only.
- **`scripts/promote-stable.sh`** (new) — opens a `beta → main` promotion PR with `pnpm changeset pre exit` baked in.
- **`scripts/resume-beta.sh`** (new) — after stable ships, merges `main → beta` and re-enters pre mode.
- **`CLAUDE.md`** — drops pre-1.0 framing (we stay on the 1.0.0 train per existing published versions); documents beta as default branch + the promotion script flow; updates worktree/branching examples to `origin/beta`.

### Bug fixed

Every beta since `1.0.0-beta.3` was published to the npm `latest` dist-tag instead of `beta`, because `changesets publish` does **not** auto-infer the tag from `pre.json`. There was no `--tag` flag anywhere. The new `release:beta` script passes `--tag beta` explicitly.

### Out of scope

- Cutting the `beta` branch itself (operator step post-merge — see Rollout below).
- Setting GitHub default branch to `beta` (operator step).
- Dropping `.changeset/pre.json` from `main` and resetting baselines — happens later via `promote-stable.sh` when we're ready to ship `1.0.0`. Until then, `main` stays in pre mode but no betas will come out of it because day-to-day work moves to `beta`.

### Rollout (after this merges to main)

1. `git push origin main:beta` — create `beta` from current `main` (carries `pre.json` + the new workflows).
2. Apply branch protection to `beta` (same gates as main: squash-only, required `check`/`codecov/patch`/`codecov/project`, no force-push, no delete, dismiss stale reviews).
3. `gh repo edit tatlacas-com/brevwick-sdk-js --default-branch beta`.
4. Repoint stale `beta` dist-tag on npm to actual current beta for all 7 packages: `npm dist-tag add @tatlacas/brevwick-sdk@1.0.0-beta.11 beta` etc. The `latest` tag stays incorrect (still on a beta) until 1.0.0 ships — npm doesn't allow removing it outright.
5. After this, `release.yml` on `main` will be dormant. Day-to-day PRs go to `beta`. When ready for 1.0.0, run `scripts/promote-stable.sh`.

## Test plan

- [ ] CI passes on this PR.
- [ ] `pnpm format:check && pnpm lint && pnpm type-check && pnpm test:cover && pnpm build` all green locally (verified).
- [ ] After merge + rollout: a no-op push to `beta` triggers `release-beta.yml` (no Version Packages PR opens because no new changesets are pending — confirms wiring without publishing).
- [ ] First real changeset merged into `beta` produces a "Version Packages (beta)" PR with `-beta.N+1` versions.
- [ ] Merging that PR publishes to npm with `dist-tag = beta` (verify with `npm view @tatlacas/brevwick-sdk dist-tags`).