### PR TITLE
chore(release): promote beta -> main

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@tatlacas/brevwick-react": "0.1.0-beta.1",

--- a/.github/workflows/guard-deploy-branches.yml
+++ b/.github/workflows/guard-deploy-branches.yml
@@ -8,8 +8,11 @@ jobs:
   check-source:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow merges from beta or a chore/promote-* branch
-        if: github.head_ref != 'beta' && !startsWith(github.head_ref, 'chore/promote-')
+      - name: Only allow merges from beta, chore/promote-*, or changeset-release/main
+        if: |
+          github.head_ref != 'beta' &&
+          github.head_ref != 'changeset-release/main' &&
+          !startsWith(github.head_ref, 'chore/promote-')
         run: |
-          echo "::error::Only 'beta' or a 'chore/promote-*' branch can be merged into 'main'. Got '${{ github.head_ref }}'. Use scripts/promote-stable.sh to open a promotion PR."
+          echo "::error::Only 'beta', 'chore/promote-*', or 'changeset-release/main' branches can be merged into 'main'. Got '${{ github.head_ref }}'. Use scripts/promote-stable.sh to open a promotion PR."
           exit 1

--- a/.github/workflows/guard-deploy-branches.yml
+++ b/.github/workflows/guard-deploy-branches.yml
@@ -8,8 +8,8 @@ jobs:
   check-source:
     runs-on: ubuntu-latest
     steps:
-      - name: Only allow merges from beta
-        if: github.head_ref != 'beta'
+      - name: Only allow merges from beta or a chore/promote-* branch
+        if: github.head_ref != 'beta' && !startsWith(github.head_ref, 'chore/promote-')
         run: |
-          echo "::error::Only the 'beta' branch can be merged into 'main'. Got '${{ github.head_ref }}'. Use scripts/promote-stable.sh to open a promotion PR."
+          echo "::error::Only 'beta' or a 'chore/promote-*' branch can be merged into 'main'. Got '${{ github.head_ref }}'. Use scripts/promote-stable.sh to open a promotion PR."
           exit 1


### PR DESCRIPTION
## Summary
- Merges current `beta` into `main`.
- Exits changesets pre mode so the next version run on `main` produces stable bumps.

## Next steps
- Merge this PR.
- `release.yml` on `main` will open a "Version Packages" PR with stable bumps.
- Merging that PR publishes to the npm `latest` dist-tag.
- After stable ships, run `scripts/resume-beta.sh` to put `beta` back into pre mode.

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, the auto-opened "Version Packages" PR shows non-`-beta` versions.