### PR TITLE
chore: ignore CHANGELOG.md in prettier (auto-generated)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ notes
 **/.output/**
 **/next-env.d.ts
 **/.expo/**
+**/CHANGELOG.md


### PR DESCRIPTION
## Summary

Add `**/CHANGELOG.md` to `.prettierignore` so changesets-generated changelogs never block CI on prettier formatting.

## Why

PR #125 (the auto-opened "Version Packages" PR for the 1.0.0 release) failed `pnpm format:check` because changesets emitted `packages/angular/CHANGELOG.md` with a trailing space prettier rejects. CHANGELOGs are auto-generated, regenerated on every release, and not meant to be hand-formatted — ignoring them is the standard pattern.

## Test plan

- [x] `pnpm format:check` passes locally with the ignore added.
- [ ] Future Version Packages PRs no longer trip prettier on CHANGELOGs.