### PR TITLE
chore(seo): point each package homepage at brevwick.dev/docs/sdk/<fw>

### DIFF
--- a/.changeset/seo-homepage-backlink.md
+++ b/.changeset/seo-homepage-backlink.md
@@ -1,0 +1,16 @@
+---
+'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-vue': patch
+'@tatlacas/brevwick-svelte': patch
+'@tatlacas/brevwick-solid': patch
+'@tatlacas/brevwick-angular': patch
+'@tatlacas/brevwick-react-native': patch
+---
+
+Point each package's `homepage` field at the framework-specific docs page on
+`brevwick.dev` instead of the GitHub repo. npm renders `homepage` as a
+prominent link on the package page, and Google treats `npmjs.com/package/<x>`
+as a high-authority backlink source — pointing it at `brevwick.dev` gives
+the brand reciprocal-link credit alongside the JSON-LD `sameAs` graph the
+website ships in its marketing layout.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -30,7 +30,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "node scripts/generate-version.mjs && tsc --noEmit -p tsconfig.lib.json"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/angular",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,7 +33,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "node scripts/generate-version.mjs && tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/react-native",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -32,7 +32,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/vanilla",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -40,7 +40,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/solid",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -30,7 +30,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/svelte",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,7 +27,7 @@
     "test:cover": "vitest run --coverage",
     "type-check": "tsc --noEmit"
   },
-  "homepage": "https://github.com/tatlacas-com/brevwick-sdk-js",
+  "homepage": "https://brevwick.dev/docs/sdk/vue",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tatlacas-com/brevwick-sdk-js.git",


### PR DESCRIPTION
## Summary

Every `@tatlacas/brevwick-*` package's `homepage` field currently points at the GitHub repo — change each one to the framework-specific docs page on `brevwick.dev` instead. This is the SDK side of a paired SEO change with [brevwick-web#311](https://github.com/tatlacas-com/brevwick-web/pull/311).

Why:

- npm renders `homepage` as a prominent link on every package page.
- Google treats `npmjs.com/package/<x>` as a high-authority backlink source — currently those backlinks all flow to GitHub, which already has its own SEO weight, instead of `brevwick.dev` which is the brand surface still earning index authority.
- The companion `brevwick-web` PR reciprocally backlinks each package's npm page from `/docs/sdk/<framework>`, plus ships `Organization` JSON-LD listing every package URL in `sameAs`. Together they close the bidirectional-link loop Google weights most heavily.

Per-package routing (per-framework deep links — paired surface lives in the web docs registry, which keeps the URL stable across SDK versions):

| Package | New `homepage` |
| --- | --- |
| `@tatlacas/brevwick-sdk` | `https://brevwick.dev/docs/sdk/vanilla` |
| `@tatlacas/brevwick-react` | `https://brevwick.dev/docs/sdk` (covers nextjs / react-vite / react-cra / remix / astro — they all use the same adapter) |
| `@tatlacas/brevwick-vue` | `https://brevwick.dev/docs/sdk/vue` |
| `@tatlacas/brevwick-svelte` | `https://brevwick.dev/docs/sdk/svelte` |
| `@tatlacas/brevwick-solid` | `https://brevwick.dev/docs/sdk/solid` |
| `@tatlacas/brevwick-angular` | `https://brevwick.dev/docs/sdk/angular` |
| `@tatlacas/brevwick-react-native` | `https://brevwick.dev/docs/sdk/react-native` |

`repository` fields stay pointed at GitHub — that's the correct field for the source-code link, and we don't want to lose the "View on GitHub" UI npm renders from it.

The changeset declares a patch bump on the full linked group, so the next `release-dev.yml` "Version Packages (dev)" PR will bump every package to `1.0.1-beta.X` and publish to the npm `beta` dist-tag.

## Path to `latest`

This PR targets `dev`, so merging it ships `1.0.1-beta.X` to the `beta` dist-tag — installers running plain `npm install @tatlacas/brevwick-*` (the `latest` tag, on `1.0.0`) won't pick up the homepage change until a stable promotion runs.

To get this onto `latest` as `1.0.1`, after this PR + the auto-opened "Version Packages (dev)" PR merge:

```bash
git fetch origin
git checkout -b chore/promote-1.0.1 origin/main
./scripts/promote-stable.sh
```

That script merges `dev`, runs `pnpm changeset pre exit`, and opens the dev → main promotion PR. Merging it lets `release.yml` publish `1.0.1` stable.

## Out of scope

- Exiting changesets pre mode — owned by `scripts/promote-stable.sh`, not this PR.
- The `brevwick` Flutter package on pub.dev — its `homepage` already points at `https://brevwick.dev`, no change needed this round.
- The companion `brevwick-web` changes (JSON-LD + outbound backlinks from `/docs/sdk/<framework>` to each registry page) — that's [brevwick-web#311](https://github.com/tatlacas-com/brevwick-web/pull/311).

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm --filter @tatlacas/brevwick-sdk build && pnpm --filter @tatlacas/brevwick-angular build && pnpm --filter @tatlacas/brevwick-react-native build` — built (CI-mirror prerequisite)
- [x] `pnpm type-check` — clean across all 7 packages + examples
- [x] `pnpm test:cover` — 697 passed across all packages (sdk: 276, react: 80, vue: 54, svelte: 44, solid: 53, angular: 71, react-native: 119)
- [x] `pnpm build` — all packages + examples built
- [ ] After merge: verify `release-dev.yml` opens a "Version Packages (dev)" PR with `1.0.1-beta.0` bumps for all 7 linked packages.
- [ ] After that publishes: `npm view @tatlacas/brevwick-sdk@beta homepage` returns `https://brevwick.dev/docs/sdk/vanilla`.