### PR TITLE
fix(release): drop --tag beta from release:beta (rejected in pre mode)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only && pnpm -r --if-present run prebuild",
     "release": "pnpm build && changeset publish",
-    "release:beta": "pnpm build && changeset publish --tag beta"
+    "release:beta": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",


### PR DESCRIPTION
## Summary

`release-dev.yml` is failing on every push to `dev` with:

```
🦋 error Releasing under custom tag is not allowed in pre mode
🦋 To resolve this exit the pre mode by running `changeset pre exit`
```

The workflow runs `pnpm release:beta` → `changeset publish --tag beta`. In pre-mode, `changesets` automatically tags the published versions with `pre.json.tag` (already `"beta"` here), and explicitly passing `--tag` is rejected.

`dev` is the prerelease channel and is always in pre-mode by design (see CLAUDE.md → Release Channels; `scripts/resume-dev.sh` re-enters pre-mode after each stable promote). So `release:beta` should just be `changeset publish` — the dist-tag is driven by `pre.json`.

See failing run: https://github.com/tatlacas-com/brevwick-sdk-js/actions/runs/25789533263

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, the next push to `dev` runs `release-dev.yml` without the "custom tag" error.
- [ ] Merging PR #136 triggers a successful publish to the npm `beta` dist-tag.