### PR TITLE
chore: show branch PR link on session start + statusline

### DIFF
--- a/.claude/hooks/pr-link.sh
+++ b/.claude/hooks/pr-link.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SessionStart / CwdChanged hook: surface the GitHub PR for the current branch.
+# Emits hook JSON with a user-visible `systemMessage` (clickable PR URL) and
+# `additionalContext` for Claude, and caches the PR for the statusline. No-ops
+# silently when gh/jq are missing, the dir is not a git repo, or the branch has
+# no PR. Always exits 0 so the JSON output is honored.
+set -uo pipefail
+
+# Hooks pass JSON on stdin; read it only when stdin is piped (not a TTY) so a
+# bare manual run never hangs. Use it to label the event correctly.
+event="SessionStart"
+if [ ! -t 0 ]; then
+  input=$(cat)
+  ev=$(printf '%s' "$input" | jq -r '.hook_event_name // empty' 2>/dev/null)
+  [ -n "$ev" ] && event="$ev"
+fi
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+cache="$gitdir/claude-pr.cache"
+
+info=$(gh pr view --json number,state,url,title 2>/dev/null) || info=""
+if [ -z "$info" ]; then
+  : > "$cache" 2>/dev/null || true
+  exit 0
+fi
+
+# Cache a statusline-friendly line: NUMBER<TAB>STATE<TAB>URL
+printf '%s' "$info" | jq -r '"\(.number)\t\(.state)\t\(.url)"' > "$cache" 2>/dev/null || true
+
+# Emit hook JSON: systemMessage (user-visible) + additionalContext (for Claude).
+printf '%s' "$info" | jq -c --arg event "$event" '{
+  systemMessage: ("PR #\(.number) [\(.state)]  \(.title)\n  \(.url)"),
+  hookSpecificOutput: {
+    hookEventName: $event,
+    additionalContext: ("The current git branch has an associated GitHub PR: #\(.number) (\(.state)) \(.url) Title: \(.title). When the user refers to \"the PR\" in this worktree, this is it.")
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash -c 'i=$(cat); d=$(printf \"%s\" \"$i\" | jq -r \".workspace.project_dir // .cwd // empty\"); [ -n \"$d\" ] && [ -f \"$d/.claude/statusline.sh\" ] && printf \"%s\" \"$i\" | bash \"$d/.claude/statusline.sh\"'"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-link.sh\""
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-link.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Custom status line: shows dir | branch | model and pins the PR for the branch.
+# Reads the PR from the cache written by the SessionStart hook; refreshes at most
+# once every 5 minutes so a status redraw never hammers the GitHub API.
+set -uo pipefail
+
+input=$(cat)
+model=$(printf '%s' "$input" | jq -r '.model.display_name // empty' 2>/dev/null)
+dir=$(printf '%s' "$input" | jq -r '.workspace.current_dir // .cwd // empty' 2>/dev/null)
+[ -n "$dir" ] && cd "$dir" 2>/dev/null
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+base=$(basename "${dir:-$PWD}")
+
+pr=""
+gitdir=$(git rev-parse --absolute-git-dir 2>/dev/null || true)
+if [ -n "$gitdir" ]; then
+  cache="$gitdir/claude-pr.cache"
+  if command -v gh >/dev/null 2>&1; then
+    if [ ! -f "$cache" ] || [ -n "$(find "$cache" -mmin +5 2>/dev/null)" ]; then
+      info=$(gh pr view --json number,state,url 2>/dev/null) || info=""
+      if [ -n "$info" ]; then
+        printf '%s' "$info" | jq -r '"\(.number)\t\(.state)\t\(.url)"' > "$cache" 2>/dev/null || true
+      else
+        : > "$cache" 2>/dev/null || true
+      fi
+    fi
+  fi
+  if [ -s "$cache" ]; then
+    num=$(cut -f1 "$cache"); state=$(cut -f2 "$cache")
+    pr="PR #${num} ${state}"
+  fi
+fi
+
+out="${base}"
+[ -n "$branch" ] && out="${out} | ${branch}"
+[ -n "$model" ] && out="${out} | ${model}"
+[ -n "$pr" ] && out="${out} | ${pr}"
+printf '%s' "$out"


### PR DESCRIPTION
## Summary
Adds per-repo Claude Code config so a Claude session surfaces the GitHub PR for the current branch:

- **`.claude/hooks/pr-link.sh`** — `SessionStart` + `CwdChanged` hook. Looks up the branch's PR via `gh pr view`, emits a user-visible `systemMessage` with the clickable PR URL, injects the PR into Claude's context (`additionalContext`), and caches the result in the worktree's private git dir. No-ops silently when `gh`/`jq` are missing, the dir is not a git repo, or the branch has no PR.
- **`.claude/statusline.sh`** — status line showing `dir | branch | model | PR #N STATE`. Reads the cached PR and refreshes at most once every 5 min so a redraw never hammers the GitHub API.
- **`.claude/settings.json`** — wires the `SessionStart` (startup|resume|clear) + `CwdChanged` hooks and the `statusLine` (derives project dir from stdin, since `$CLAUDE_PROJECT_DIR` is unavailable to statusLine commands).

Mirrors brevwick-api#297. Committed tracked files, so every worktree branched from `origin/main` inherits it.

## Test plan
- [ ] Fresh session inside a worktree whose branch has an open PR -> banner shows the PR link, status line shows `PR #N OPEN`.
- [ ] Session on a branch with no PR -> no PR shown, status line still renders dir/branch/model.
- [ ] `gh`/`jq` absent or non-git dir -> graceful no-op.