### PR TITLE
chore: align brevwick command and add statusline/pr-link/settings wiring

### DIFF
--- a/.claude/commands/brevwick.md
+++ b/.claude/commands/brevwick.md
@@ -82,7 +82,7 @@ After fetch, if `STATE` is closed/done/cancelled/won't-fix → abort: `Issue is 
 
 ## STEP 3 — Assess (no edits yet)
 
-Read the current repo's `CLAUDE.md` (`git rev-parse --show-toplevel` → `CLAUDE.md`).
+Read the current repo's `CLAUDE.md` (`git rev-parse --show-toplevel` → `CLAUDE.md`). Read any `*-worktree.md` files at the repo root for active-initiative context.
 
 Apply this decision matrix to the fetched issue:
 
@@ -210,7 +210,7 @@ PREOF
 )"
 ```
 
-Print the PR URL. Suggest (do **not** auto-run): `Run /pr-review <PR-url> when ready for review.`
+Print the PR URL. Suggest (do **not** auto-run): offer to launch the **`pr-reviewer` agent** on this PR — it reviews against the issue requirements and this repo's standards in its own isolated context, with project review memory.
 
 ## STEP 9 — Done
 


### PR DESCRIPTION
Brings brevwick-sdk-js's Claude tooling up to the shared canonical:

**brevwick.md command**
- Adds `EnterWorktree` to `allowed-tools` — the command instructs using it but the tool was not granted.
- Replaces the old `cd`-based worktree step with the `EnterWorktree` flow (a shell `cd` cannot relocate the session) plus the corrected literal-absolute-path guidance.
- Adds the `*-worktree.md` active-initiative context line to the assess step.
- PR-review step now offers the `pr-reviewer` agent instead of the stale `/pr-review` slash command.
- STEP 9 wording aligned (do not call `ExitWorktree`; leave the session in the worktree).

**Wiring files (were missing)**
- `.claude/statusline.sh`, `.claude/hooks/pr-link.sh`, `.claude/settings.json` — byte-identical to the shared canonical used across the other repos (statusLine + SessionStart/CwdChanged pr-link hooks).