### PR TITLE
chore: require cross-repo contract verification in review agents

### DIFF
--- a/.claude/agents/pr-review-fixer.md
+++ b/.claude/agents/pr-review-fixer.md
@@ -42,6 +42,18 @@ If the original issue or `worktree.md` called for it, it ships here. If a bug / 
 - `eslint.config.mjs`, `tsconfig.base.json`, `pnpm-workspace.yaml`
 - Per-package `tsup.config.ts`, `tsconfig.json`, `package.json`
 
+### Step 2.5 — Cross-Repo Contract Findings
+
+When a finding concerns an ingest call, request payload, header, or parsed response, ground the fix in what the source repo **actually** ships on its canonical remote branch — never patch from memory. **brevwick-api** (`../brevwick-api`, `origin/main`) is the source of truth for ingest endpoints/headers/payloads; SDD § 12 governs the contract.
+
+```bash
+git -C ../brevwick-api fetch --quiet origin
+git -C ../brevwick-api show origin/main:internal/handler/ingest/handler.go
+git -C ../brevwick-api grep -n 'X-Brevwick' origin/main -- 'internal/handler'
+```
+
+Make this SDK match the verified API contract (field names, headers, endpoint/method) and add/keep a test asserting that shape. If the drift is genuinely the API's bug, that is an upstream fix, not a client-side band-aid — make every correct change here, then surface the upstream gap precisely in your return summary. Remember a wire change here ripples to brevwick-sdk-flutter (which mirrors this SDK byte-for-byte): land the SDD § 12 update in the same PR. This is a real cross-repo block, not a scapegoat.
+
 ### Step 3 — Triage
 
 - **MUST FIX** — rule / bug / completeness / missing test

--- a/.claude/agents/pr-review-validator.md
+++ b/.claude/agents/pr-review-validator.md
@@ -13,6 +13,7 @@ You are the last line of defence before merge on **brevwick-sdk-js**. The review
 1. **Clean architecture compliance** — core framework-agnostic, React-only in `@tatlacas/brevwick-react`, tree-shakeable public API. Any regression → reject.
 2. **Clean code** — no new duplication / dead code / `any` / magic numbers / deep nesting / poor names → reject.
 3. **Completeness** — every item resolved. Every `- [x]` real. Every `~~struck~~` legitimate. Any remaining `- [ ]` → fail.
+4. **Cross-repo contract fidelity** — every ingest call, request payload, header, and parsed response this PR touches is independently re-confirmed against the source-of-truth repo on its canonical remote branch (see _Step 3.5_). A contract you cannot prove matches is a fail — you do not take the fixer's word for it.
 
 ## No-Scapegoating Audit
 
@@ -47,6 +48,20 @@ Reject on any banned phrase in a strike-out / commit / note:
 - Tests: new behaviour covered, error / cancellation / retry paths tested, 80% patch coverage
 - SDD updated if public API changed
 
+### Step 3.5 — Cross-Repo Contract Re-Verification (NON-NEGOTIABLE)
+
+Re-prove every cross-repo touchpoint yourself — independently of the reviewer or fixer. For every ingest call, request payload, header, parsed response, or status/error code this PR touches, read the source of truth on its canonical remote branch:
+
+```bash
+git -C ../brevwick-api fetch --quiet origin
+git -C ../brevwick-api show origin/main:internal/handler/ingest/handler.go
+git -C ../brevwick-api grep -n 'X-Brevwick' origin/main -- 'internal/handler'
+# sibling not checked out? read it from GitHub:
+gh api repos/tatlacas-com/brevwick-api/contents/internal/handler/ingest/handler.go --jq '.content' | base64 -d
+```
+
+Source of truth: **brevwick-api** `ProjectKeyAuth` ingest handlers (`origin/main`) for endpoints/headers/payloads, and the **brevwick-ops** SDD § 12. Confirm field by field: endpoint + method exist; every field/header sent is actually bound; every field read is actually returned (name, JSON casing, type, nullability, enum values); status/error codes match. If any touchpoint diverges or cannot be confirmed against the source repo's canonical branch, that is a regression — **RETURNED TO FIXER**, never APPROVED. (A wire change here also ripples to brevwick-sdk-flutter, which mirrors this SDK byte-for-byte — confirm the SDD § 12 update landed.)
+
 ### Step 4 — Run Tooling
 
 ```bash
@@ -80,6 +95,11 @@ Any failure invalidates the pass.
 
 - [ ] ...
 
+### Cross-Repo Contracts
+
+- [x] <touchpoint> — confirmed against `<repo>` `<canonical branch>`:`<source file>`
+- [ ] <touchpoint> — DRIFT / unverifiable: <detail> → returned to fixer
+
 ### Tooling
 
 - pnpm lint / type-check / test / build / coverage: pass | fail
@@ -107,6 +127,7 @@ Subagents in Claude Code cannot dispatch other subagents — the `Agent`/`Task` 
 - You never merge
 - You never approve with unchecked items
 - You never accept a banned-phrase strike-out
+- You never approve while a cross-repo contract is unconfirmed or drifting from the source repo's canonical branch — you re-verify it yourself, never on the fixer's word
 - Adversarial to the fixer by design
 
 ## Persistent Agent Memory

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -15,6 +15,7 @@ HARD blockers. Any violation → **CHANGES REQUIRED**.
 1. **Clean architecture compliance** — `@tatlacas/brevwick-sdk` stays framework-agnostic. React types / hooks / JSX belong ONLY in `@tatlacas/brevwick-react`. No leaking React, DOM, or Node-only APIs into the core. Public API surface is intentional and tree-shakeable. Module boundaries in `CLAUDE.md` are absolute.
 2. **Clean code** — SOLID, DRY, KISS, meaningful names, single responsibility, small functions, no dead code, no commented-out code, no `any`, no stale TODOs, no deep nesting.
 3. **Completeness** — every acceptance criterion implemented. No stubs / placeholders / "follow-up" work.
+4. **Cross-repo contract fidelity** — every ingest call, request payload, header, and parsed response is verified against the source-of-truth repo as it actually exists on its canonical remote branch (see _Step 2.5 — Cross-Repo Contract Verification_). An unverified or drifting contract is a HARD blocker, not a nit.
 
 ## Process
 
@@ -29,6 +30,44 @@ HARD blockers. Any violation → **CHANGES REQUIRED**.
 - Repo `CLAUDE.md`, parent `CLAUDE.md`
 - `eslint.config.mjs`, `tsconfig.base.json`, `pnpm-workspace.yaml`
 - Per-package `package.json`, `tsup.config.ts`, `tsconfig.json`
+
+### Step 2.5 — Cross-Repo Contract Verification (NON-NEGOTIABLE)
+
+Most production incidents on this project trace to a contract drifting out of sync. Any code in this PR that crosses a repo boundary — an ingest call, a request payload, a header, a parsed response, a status/error code, an enum value — MUST be validated against the **source-of-truth repo as it actually exists on its canonical remote branch**: never against memory, never against the author's assumption, never against a possibly-stale local checkout.
+
+**Source-of-truth map for brevwick-sdk-js:**
+
+- **brevwick-api** (`../brevwick-api`) is the source of truth for the ingest + backend contract this SDK calls. Validate request payloads, headers (`pk_live_*` project keys, `X-Brevwick-*`), endpoint paths/methods, and parsed responses against the actual ingest handlers (`internal/handler/*`, the `ProjectKeyAuth` routes) on `origin/main`.
+- **brevwick-ops** (`../brevwick-ops`) `docs/brevwick-sdd.md` § 12 is the source of truth for the client SDK contract.
+- This repo's `packages/sdk/src/types.ts` + `core/validate.ts` are themselves the byte-for-byte source of truth that **brevwick-sdk-flutter** mirrors — a wire change here ripples there; flag it so the SDD update lands in the same change.
+
+**How to verify — read the canonical remote, never the dirty local tree:**
+
+The sibling repos sit next to this one in the workspace (`../<repo>`). Fetch and read the canonical branch directly; a local working copy may be a stale checkout or an in-progress worktree.
+
+```bash
+# Refresh the remote ref, then read the contract straight from origin/main
+git -C ../brevwick-api fetch --quiet origin
+git -C ../brevwick-api show origin/main:internal/handler/ingest/handler.go
+git -C ../brevwick-api grep -n 'X-Brevwick' origin/main -- 'internal/handler'
+```
+
+If a sibling repo is not checked out locally, read it from GitHub — still the canonical default branch, never a feature branch:
+
+```bash
+gh api repos/tatlacas-com/brevwick-api/contents/internal/handler/ingest/handler.go --jq '.content' | base64 -d
+gh search code --repo tatlacas-com/brevwick-api X-Brevwick
+```
+
+**For every cross-repo touchpoint, confirm field by field:**
+
+- The ingest endpoint path and HTTP method exist on the API exactly as called.
+- Every request field/header this SDK sends is one the API actually binds and validates; every field the API requires is sent.
+- Every response field this SDK reads is one the API actually returns on `origin/main` — name, JSON casing, type, nullability, enum/string values all match.
+- Status codes and error codes handled here match what the API actually returns.
+- Where SDD § 12 governs the contract, the implementation matches the SDD too.
+
+**Verdict gate:** if any cross-repo touchpoint cannot be confirmed against the source repo's canonical branch — the field/header/endpoint does not exist there, the shapes diverge, or the source repo could not be read — the item is a **CRITICAL** failure and the verdict is **CHANGES REQUIRED**. "Probably matches" is not confirmation. Never approve an unverified contract.
 
 ### Step 3 — Review Every Changed File
 
@@ -121,6 +160,10 @@ Save to `notes/reviews/pr-<N>-claude-review.md`:
 
 - [ ] ...
 
+## Cross-Repo Contracts (NON-NEGOTIABLE)
+
+- [ ] `<pkg>/<file:line>` — <touchpoint> verified against `<repo>` `<canonical branch>`:`<source file>` | DRIFT: <what diverges>
+
 ## Clean Architecture (NON-NEGOTIABLE)
 
 - [ ] `<pkg>/<file:line>` — ...
@@ -179,7 +222,8 @@ The parent session is responsible for the chain. A review without a fix pass is 
 
 - Specific package + file:line for every finding
 - No "consider" / "maybe"
-- Verdict `APPROVED` only on a fully clean PR
+- Verdict `APPROVED` only on a fully clean PR with every cross-repo contract confirmed against the source repo's canonical branch
+- Never approve a cross-repo contract you could not verify against the source repo — unverifiable equals CHANGES REQUIRED
 
 ## Persistent Agent Memory
 


### PR DESCRIPTION
## Why

Contract drift between this SDK and brevwick-api causes runtime bugs. The review agents could approve a PR without confirming what the ingest API actually accepts and returns.

## What changed

Docs-only change to `.claude/agents/pr-reviewer.md`, `pr-review-validator.md`, `pr-review-fixer.md`:

- **Reviewer** — new `Step 2.5 — Cross-Repo Contract Verification` + a non-negotiable: every ingest call, request payload, header, and parsed response is verified against brevwick-api's `ProjectKeyAuth` handlers **as they exist on `origin/main`**. Unverifiable ⇒ CHANGES REQUIRED.
- **Validator** — new `Step 3.5` that independently re-confirms each touchpoint against the source repo's canonical branch. Drift ⇒ RETURNED TO FIXER, never on the fixer's word.
- **Fixer** — new `Step 2.5` grounding contract fixes in the real upstream shape.

## Source-of-truth map

- brevwick-api (`../brevwick-api`, `origin/main`) — `internal/handler/*` ingest (`ProjectKeyAuth`) handlers
- brevwick-ops — `docs/brevwick-sdd.md` § 12
- Note: this repo's `packages/sdk/src/types.ts` + `core/validate.ts` are themselves the wire source of truth mirrored byte-for-byte by brevwick-sdk-flutter — wire changes here ripple there, so the agents flag the SDD § 12 update.

Verification reads the canonical remote branch directly (`git -C ../brevwick-api show/grep origin/main`), never a dirty local checkout, and falls back to `gh api` when a sibling isn't checked out. PR targets \`dev\` (this repo's default branch).