### PR TITLE
fix(react,solid,vue,svelte,angular): restyle status rows as checklist

### DIFF
--- a/.changeset/feedback-status-row-checklist.md
+++ b/.changeset/feedback-status-row-checklist.md
@@ -22,5 +22,4 @@ message as bubbles. The per-row stagger now correctly targets
 the cascade is no longer a no-op. The retry row keeps its standalone alert
 chrome — padding, radius, red border, transparent background — because it
 remains a separate failure CTA, not a checklist line. React Native is
-intentionally out of scope (different rendering surface, native StyleSheet
-not CSS).
+excluded — different rendering surface, native `StyleSheet` not CSS.

--- a/.changeset/feedback-status-row-checklist.md
+++ b/.changeset/feedback-status-row-checklist.md
@@ -1,17 +1,26 @@
 ---
 '@tatlacas/brevwick-react': patch
 '@tatlacas/brevwick-solid': patch
+'@tatlacas/brevwick-vue': patch
+'@tatlacas/brevwick-svelte': patch
+'@tatlacas/brevwick-angular': patch
 ---
 
 Re-style the in-widget staged-status rows ("Captured route, console, network,
 device" / "PII-sanitised, packaged" / "Formatting with AI…") to match the
-marketing landing page's `AnimatedDemo` widget mock. Previously the rows
-rendered as assistant-coloured chat bubbles, which read as conversation
-messages rather than progress indicators and conflicted with the
-neutral-checklist treatment users saw on `brevwick.dev` before adopting the
-SDK. The rows now sit under a dashed top divider, render as a compact stacked
-list with small emerald check icons, and live outside the `.brw-bubble` class
-family so screen readers and consumers that count conversation messages still
-see only the greeting + user message as bubbles. The retry row keeps its
-standalone bordered alert chrome because it remains a separate failure CTA,
-not a checklist line.
+marketing landing page's `AnimatedDemo` widget mock across every web-rendered
+adapter — React, Solid, Vue, Svelte, and Angular. Previously the rows rendered
+as assistant-coloured chat bubbles, which read as conversation messages rather
+than progress indicators and conflicted with the neutral-checklist treatment
+users saw on `brevwick.dev` before adopting the SDK. The rows now sit under a
+dashed top divider inside a `.brw-status-rows` (`brw-svelte-status-rows` on
+Svelte) wrapper, render as a compact stacked list with small emerald check
+icons, and live outside the `.brw-bubble` class family so screen readers and
+consumers that count conversation messages still see only the greeting + user
+message as bubbles. The per-row stagger now correctly targets
+`animation-delay` (the entrance is a CSS `@keyframes`, not a transition), so
+the cascade is no longer a no-op. The retry row keeps its standalone alert
+chrome — padding, radius, red border, transparent background — because it
+remains a separate failure CTA, not a checklist line. React Native is
+intentionally out of scope (different rendering surface, native StyleSheet
+not CSS).

--- a/.changeset/feedback-status-row-checklist.md
+++ b/.changeset/feedback-status-row-checklist.md
@@ -1,0 +1,17 @@
+---
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-solid': patch
+---
+
+Re-style the in-widget staged-status rows ("Captured route, console, network,
+device" / "PII-sanitised, packaged" / "Formatting with AI…") to match the
+marketing landing page's `AnimatedDemo` widget mock. Previously the rows
+rendered as assistant-coloured chat bubbles, which read as conversation
+messages rather than progress indicators and conflicted with the
+neutral-checklist treatment users saw on `brevwick.dev` before adopting the
+SDK. The rows now sit under a dashed top divider, render as a compact stacked
+list with small emerald check icons, and live outside the `.brw-bubble` class
+family so screen readers and consumers that count conversation messages still
+see only the greeting + user message as bubbles. The retry row keeps its
+standalone bordered alert chrome because it remains a separate failure CTA,
+not a checklist line.

--- a/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
+++ b/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
@@ -543,7 +543,7 @@ describe('BwFeedbackButtonComponent', () => {
       '[data-brw-row="sanitised"]',
     ) as HTMLElement;
     expect(row).not.toBeNull();
-    expect(row.style.transitionDelay).toBe('0ms');
+    expect(row.style.animationDelay).toBe('0ms');
   });
 
   // ── Async safety ─────────────────────────────────────────────────────────
@@ -966,7 +966,7 @@ describe('BwFeedbackButtonComponent', () => {
       const row = fixture.nativeElement.querySelector(
         '[data-brw-row="sanitised"]',
       ) as HTMLElement;
-      expect(row.style.transitionDelay).toBe('0ms');
+      expect(row.style.animationDelay).toBe('0ms');
       void cmp;
     } finally {
       window.matchMedia = original;

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -1128,6 +1128,14 @@ function formatSize(bytes: number): string {
         width: 12px;
         height: 12px;
       }
+      /* The shared .brw-spinner ships at 14px so it reads at full size in
+         the composer; inside the staged-status checklist it has to match
+         the 12px tick so the third row's indicator sits on the same
+         baseline as the first two. */
+      .brw-status-row .brw-spinner {
+        width: 12px;
+        height: 12px;
+      }
       .brw-status-row-label {
         flex: 1;
       }

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -56,7 +56,8 @@ const COMPOSER_MAX_HEIGHT_PX = 120;
 
 /**
  * Stagger between staged-status rows in milliseconds. Applied as
- * `style.transitionDelay` per row so rows fade in sequentially even when
+ * `style.animationDelay` per row (the rows mount with a CSS @keyframes
+ * entrance, not a transition) so rows fade in sequentially even when
  * the underlying SDK phase events fire microseconds apart on a healthy
  * happy path. Honoured only when the user has not requested reduced motion.
  */
@@ -337,69 +338,76 @@ function formatSize(bytes: number): string {
               <div class="brw-error" role="alert">{{ msg }}</div>
             }
 
-            <!-- Staged status rows: row 1 (Captured) -->
-            @if (showCaptured()) {
-              <div
-                class="brw-status-row"
-                data-brw-row="captured"
-                style="transition-delay: 0ms"
-              >
-                <span class="brw-status-row-check" aria-hidden="true">
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+            <!-- Staged status rows: dashed-divider checklist wrapper -->
+            @if (showCaptured() || showSanitised() || showFormattingRow()) {
+              <div class="brw-status-rows">
+                <!-- Row 1 (Captured) -->
+                @if (showCaptured()) {
+                  <div
+                    class="brw-status-row"
+                    data-brw-row="captured"
+                    style="animation-delay: 0ms"
                   >
-                    <path d="M5 12l5 5L20 7" />
-                  </svg>
-                </span>
-                <span class="brw-status-row-label"
-                  >Captured route, console, network, device</span
-                >
-              </div>
-            }
+                    <span class="brw-status-row-check" aria-hidden="true">
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="M5 12l5 5L20 7" />
+                      </svg>
+                    </span>
+                    <span class="brw-status-row-label"
+                      >Captured route, console, network, device</span
+                    >
+                  </div>
+                }
 
-            <!-- Row 2 (Sanitised) -->
-            @if (showSanitised()) {
-              <div
-                class="brw-status-row"
-                data-brw-row="sanitised"
-                [style.transition-delay.ms]="sanitisedDelayMs()"
-              >
-                <span class="brw-status-row-check" aria-hidden="true">
-                  <svg
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                <!-- Row 2 (Sanitised) -->
+                @if (showSanitised()) {
+                  <div
+                    class="brw-status-row"
+                    data-brw-row="sanitised"
+                    [style.animation-delay.ms]="sanitisedDelayMs()"
                   >
-                    <path d="M5 12l5 5L20 7" />
-                  </svg>
-                </span>
-                <span class="brw-status-row-label"
-                  >PII-sanitised, packaged</span
-                >
-              </div>
-            }
+                    <span class="brw-status-row-check" aria-hidden="true">
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="M5 12l5 5L20 7" />
+                      </svg>
+                    </span>
+                    <span class="brw-status-row-label"
+                      >PII-sanitised, packaged</span
+                    >
+                  </div>
+                }
 
-            <!-- Row 3 (Formatting with AI…) — exact-match formatting + AI on -->
-            @if (showFormattingRow()) {
-              <div
-                class="brw-status-row"
-                data-brw-row="formatting"
-                [style.transition-delay.ms]="formattingDelayMs()"
-              >
-                <span class="brw-spinner" aria-hidden="true"></span>
-                <span class="brw-status-row-label">Formatting with AI…</span>
+                <!-- Row 3 (Formatting with AI…) — exact-match formatting + AI on -->
+                @if (showFormattingRow()) {
+                  <div
+                    class="brw-status-row"
+                    data-brw-row="formatting"
+                    [style.animation-delay.ms]="formattingDelayMs()"
+                  >
+                    <span class="brw-spinner" aria-hidden="true"></span>
+                    <span class="brw-status-row-label"
+                      >Formatting with AI…</span
+                    >
+                  </div>
+                }
               </div>
             }
 
@@ -556,6 +564,13 @@ function formatSize(bytes: number): string {
         --brw-shadow-base:
           0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
         --brw-error-base: #b91c1c;
+        /* Success / check colour for the staged-status checklist. Matches
+           the emerald used in the marketing AnimatedDemo so the in-widget
+           checklist reads as the same affordance the docs preview.
+           Widget-internal: no public --brw-success alias by design —
+           host overrides flow through --brw-accent for chrome and don't
+           need a knob for the green tick. */
+        --brw-success-base: #10b981;
       }
       @media (prefers-color-scheme: dark) {
         :where(:root) {
@@ -574,6 +589,8 @@ function formatSize(bytes: number): string {
           --brw-accent-fg-base: #0f172a;
           --brw-shadow-base:
             0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+          /* Brighter emerald (500→400) keeps the tick legible on dark panels. */
+          --brw-success-base: #34d399;
         }
       }
       .brw-root[data-brw-theme='light'] {
@@ -592,6 +609,7 @@ function formatSize(bytes: number): string {
         --brw-accent-fg-base: #ffffff;
         --brw-shadow-base:
           0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+        --brw-success-base: #10b981;
       }
       .brw-root[data-brw-theme='dark'] {
         --brw-panel-bg-base: #0b1220;
@@ -609,6 +627,7 @@ function formatSize(bytes: number): string {
         --brw-accent-fg-base: #0f172a;
         --brw-shadow-base:
           0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+        --brw-success-base: #34d399;
       }
       .brw-root {
         font-family:
@@ -1066,42 +1085,67 @@ function formatSize(bytes: number): string {
         font-size: 12px;
         align-self: stretch;
       }
+      /* Staged-status rows: progress indicators, not conversation bubbles.
+         They sit under a dashed top divider as a compact stacked checklist,
+         mirroring the marketing AnimatedDemo widget mock — and intentionally
+         stay outside the .brw-bubble class family so message-count queries
+         ignore them. .brw-status-rows is the grouping container that owns
+         the divider + stacking; .brw-status-row is one ticked line. The
+         animation-delay is set inline per row so the three rows fade in
+         sequentially under the shared @keyframes entrance even when the
+         underlying SDK phase events fire microseconds apart. The
+         reduced-motion media query collapses the entrance to an instant
+         fade, pairing with the inline 0ms delay the adapter passes when
+         the user has prefers-reduced-motion: reduce. */
+      .brw-status-rows {
+        align-self: stretch;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-top: 2px;
+        padding-top: 8px;
+        border-top: 1px dashed var(--brw-divider, var(--brw-divider-base));
+      }
       .brw-status-row {
-        align-self: flex-start;
-        max-width: 85%;
-        padding: 10px 12px;
-        border-radius: 14px;
-        border-bottom-left-radius: 4px;
-        background: var(
-          --brw-bubble-assistant-bg,
-          var(--brw-bubble-assistant-bg-base)
-        );
-        color: var(--brw-fg, var(--brw-fg-base));
-        font-size: 13px;
-        line-height: 1.45;
         display: flex;
         align-items: center;
         gap: 8px;
+        font-size: 12px;
+        line-height: 1.4;
+        color: var(--brw-fg-muted, var(--brw-fg-muted-base));
         animation: brw-status-row-in 220ms ease-out both;
       }
       .brw-status-row-check {
         display: inline-flex;
-        width: 14px;
-        height: 14px;
+        width: 12px;
+        height: 12px;
         align-items: center;
         justify-content: center;
-        color: var(--brw-accent, var(--brw-accent-base));
+        color: var(--brw-success-base);
+        flex-shrink: 0;
       }
       .brw-status-row-check svg {
-        width: 14px;
-        height: 14px;
+        width: 12px;
+        height: 12px;
       }
       .brw-status-row-label {
         flex: 1;
       }
+      /* The retry row is a standalone alert that sits outside the
+         checklist container, so it carries its own chrome — padding,
+         radius, border — instead of inheriting the checklist's tick-line
+         minimalism. The background stays transparent so the red border
+         + red label read as an alert overlay rather than a filled bubble
+         surface. */
       .brw-status-row--error {
+        align-self: stretch;
+        padding: 10px 12px;
+        border-radius: 10px;
+        background: transparent;
         color: var(--brw-error-base);
         border: 1px solid var(--brw-error-base);
+        font-size: 13px;
+        line-height: 1.45;
       }
       .brw-status-row-retry {
         margin-left: auto;

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -2857,12 +2857,14 @@ describe('<FeedbackButton> staged-status UX (#74)', () => {
       phaseBus.emit('phase', { phase: 'sanitising-done' });
     });
 
-    // Every visible status row must carry transitionDelay: 0ms — the
+    // Every visible status row must carry animationDelay: 0ms — the
     // adapter folds the 200 ms cascade flat under prefers-reduced-motion.
+    // Reading animationDelay (not transitionDelay) because the entrance
+    // is a CSS @keyframes animation, not a transition.
     const rows = document.querySelectorAll<HTMLElement>('[data-brw-row]');
     expect(rows.length).toBeGreaterThan(0);
     for (const row of rows) {
-      expect(row.style.transitionDelay).toBe('0ms');
+      expect(row.style.animationDelay).toBe('0ms');
     }
   });
 

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -2803,6 +2803,40 @@ describe('<FeedbackButton> staged-status UX (#74)', () => {
     expect(getStatusRow('formatting')).not.toBeNull();
   });
 
+  it('.brw-status-rows wrapper is absent at idle and present once a row mounts', async () => {
+    // Pins the structural contract documented at packages/react/src/styles.ts:533-543:
+    // the dashed-divider checklist wrapper exists only while at least one of
+    // the three staged rows is visible, and the captured row sits inside it.
+    // Without this guard a future refactor could either unmount the wrapper
+    // (losing the divider) or render an empty wrapper at idle (a phantom
+    // checklist) and CI would not catch it.
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+
+    // Negative: panel open, nothing sent yet → no wrapper in the DOM.
+    expect(document.querySelector('.brw-status-rows')).toBeNull();
+
+    typeDraft('wrapper-presence-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await act(async () => {
+      phaseBus.emit('phase', { phase: 'capturing-done' });
+    });
+
+    // Positive: once the first row (captured, fired by capturing-done →
+    // phase === 'sanitising') is visible, the wrapper exists and contains
+    // that row.
+    const wrapper = document.querySelector('.brw-status-rows');
+    expect(wrapper).not.toBeNull();
+    const captured = getStatusRow('captured');
+    expect(captured).not.toBeNull();
+    expect(captured!.closest('.brw-status-rows')).toBe(wrapper);
+  });
+
   it('AI row is suppressed when getConfig().ai_enabled === false', async () => {
     parkSubmit();
     getConfig.mockResolvedValue({
@@ -2894,6 +2928,11 @@ describe('<FeedbackButton> staged-status UX (#74)', () => {
       expect(row).toHaveAttribute('role', 'alert');
       expect(row).toHaveAttribute('data-brw-error-code', code);
       expect(row?.textContent).toContain(message);
+      // The retry row is a standalone alert — it must sit OUTSIDE the
+      // `.brw-status-rows` checklist wrapper so the dashed-divider styling
+      // does not bleed into the failure state. Pins the structural
+      // relationship against an accidental fold-back during future refactors.
+      expect(row!.closest('.brw-status-rows')).toBeNull();
 
       // Retry click re-runs `submit()` with the same FeedbackInput. The
       // second call is mocked to succeed so the assistant receipt lands.

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -683,10 +683,11 @@ const PHASE_RANK: Record<FeedbackPhase, number> = {
 
 /**
  * Stagger between staged-status rows in milliseconds. Applied as
- * `transition-delay` per row so the rows fade in sequentially even when
- * the underlying SDK phase events fire microseconds apart on a healthy
- * happy path. Honoured only when the user has not requested reduced
- * motion — see {@link usePrefersReducedMotion}.
+ * `animation-delay` per row (the rows mount with a CSS @keyframes
+ * entrance, not a transition) so the rows fade in sequentially even
+ * when the underlying SDK phase events fire microseconds apart on a
+ * healthy happy path. Honoured only when the user has not requested
+ * reduced motion — see {@link usePrefersReducedMotion}.
  */
 const STATUS_ROW_STAGGER_MS = 200;
 
@@ -764,7 +765,7 @@ function Thread({
         </div>
       )}
       {(showCaptured || showSanitised || showFormatting) && (
-        <div className="brw-status-rows" data-brw-status-rows="">
+        <div className="brw-status-rows">
           {showCaptured && (
             <StatusRow
               variant="check"
@@ -822,8 +823,8 @@ interface StatusRowProps {
  *
  * The `data-brw-row` attribute exists for the test suite to query rows by
  * their role-in-the-pipeline without coupling to the visible label.
- * Stagger is applied as a `transition-delay` so the rows fade in
- * sequentially under the shared bubble-entrance keyframe.
+ * Stagger is applied as an `animation-delay` so the rows fade in
+ * sequentially under the shared entrance keyframe.
  */
 function StatusRow({
   variant,
@@ -834,7 +835,7 @@ function StatusRow({
   return (
     <div
       className="brw-status-row"
-      style={{ transitionDelay: `${delayMs}ms` }}
+      style={{ animationDelay: `${delayMs}ms` }}
       data-brw-row={dataRow}
     >
       {variant === 'check' ? (

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -763,33 +763,37 @@ function Thread({
           {submitError}
         </div>
       )}
-      {showCaptured && (
-        <StatusRow
-          variant="check"
-          // Row 1 anchors the cascade at 0 ms; rows 2 and 3 stagger off it.
-          delayMs={0}
-          dataRow="captured"
-        >
-          Captured route, console, network, device
-        </StatusRow>
-      )}
-      {showSanitised && (
-        <StatusRow
-          variant="check"
-          delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
-          dataRow="sanitised"
-        >
-          PII-sanitised, packaged
-        </StatusRow>
-      )}
-      {showFormatting && (
-        <StatusRow
-          variant="spinner"
-          delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
-          dataRow="formatting"
-        >
-          Formatting with AI…
-        </StatusRow>
+      {(showCaptured || showSanitised || showFormatting) && (
+        <div className="brw-status-rows" data-brw-status-rows="">
+          {showCaptured && (
+            <StatusRow
+              variant="check"
+              // Row 1 anchors the cascade at 0 ms; rows 2 and 3 stagger off it.
+              delayMs={0}
+              dataRow="captured"
+            >
+              Captured route, console, network, device
+            </StatusRow>
+          )}
+          {showSanitised && (
+            <StatusRow
+              variant="check"
+              delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
+              dataRow="sanitised"
+            >
+              PII-sanitised, packaged
+            </StatusRow>
+          )}
+          {showFormatting && (
+            <StatusRow
+              variant="spinner"
+              delayMs={reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
+              dataRow="formatting"
+            >
+              Formatting with AI…
+            </StatusRow>
+          )}
+        </div>
       )}
       {showRetryRow && submitErrorTagged && (
         <RetryRow error={submitErrorTagged} onRetry={onRetry} />

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -536,11 +536,12 @@ export const BREVWICK_CSS = `
    stay outside the .brw-bubble class family so message-count queries
    ignore them. .brw-status-rows is the grouping container that owns the
    divider + stacking; .brw-status-row is one ticked line. The
-   transition-delay is set inline per row so the three rows fade in
-   sequentially even when the underlying SDK phase events fire
-   microseconds apart. The reduced-motion media query collapses the
-   entrance to an instant fade, pairing with the inline 0ms delay the
-   adapter passes when the user has prefers-reduced-motion: reduce. */
+   animation-delay is set inline per row so the three rows fade in
+   sequentially under the shared @keyframes entrance even when the
+   underlying SDK phase events fire microseconds apart. The
+   reduced-motion media query collapses the entrance to an instant fade,
+   pairing with the inline 0ms delay the adapter passes when the user
+   has prefers-reduced-motion: reduce. */
 .brw-status-rows {
   align-self: stretch;
   display: flex;
@@ -575,7 +576,11 @@ export const BREVWICK_CSS = `
 .brw-status-row-label { flex: 1; }
 /* The retry row is a standalone alert that sits outside the checklist
    container, so it carries its own chrome — padding, radius, border —
-   instead of inheriting the checklist's tick-line minimalism. */
+   instead of inheriting the checklist's tick-line minimalism. The
+   background stays transparent so the red border + red label read as
+   an alert overlay rather than a filled assistant-bubble surface; the
+   parent .brw-panel-bg shows through and the alert sits flush with the
+   surrounding checklist + composer chrome. */
 .brw-status-row--error {
   align-self: stretch;
   padding: 10px 12px;
@@ -584,6 +589,7 @@ export const BREVWICK_CSS = `
   color: var(--brw-error-base);
   border: 1px solid var(--brw-error-base);
   font-size: 13px;
+  line-height: 1.45;
 }
 .brw-status-row-retry {
   margin-left: auto;

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -573,6 +573,14 @@ export const BREVWICK_CSS = `
   width: 12px;
   height: 12px;
 }
+/* The shared .brw-spinner ships at 14px so it reads at full size in the
+   composer; inside the staged-status checklist it has to match the 12px
+   tick so the third row's indicator sits on the same baseline as the
+   first two. */
+.brw-status-row .brw-spinner {
+  width: 12px;
+  height: 12px;
+}
 .brw-status-row-label { flex: 1; }
 /* The retry row is a standalone alert that sits outside the checklist
    container, so it carries its own chrome — padding, radius, border —

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -58,6 +58,12 @@ export const BREVWICK_CSS = `
      the dark --brw-panel-bg); override in the dark block if design ever
      wants a tuned variant. */
   --brw-error-base: #b91c1c;
+  /* Success / check colour for the staged-status checklist. Matches the
+     emerald used in the marketing AnimatedDemo so the in-widget checklist
+     reads as the same affordance the docs preview. Widget-internal: no
+     public --brw-success alias by design — host overrides flow through
+     --brw-accent for chrome and don't need a knob for the green tick. */
+  --brw-success-base: #10b981;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
@@ -82,6 +88,8 @@ export const BREVWICK_CSS = `
     --brw-accent-fg-base: #0f172a;
     /* Shadow — deeper alpha so the panel still reads as lifted over a dark host */
     --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+    /* Brighter emerald (500→400) keeps the tick legible on dark panels. */
+    --brw-success-base: #34d399;
   }
 }
 /* Forced palettes via <FeedbackButton theme="light|dark">. These rewrite
@@ -109,6 +117,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #0f172a;
   --brw-accent-fg-base: #ffffff;
   --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  --brw-success-base: #10b981;
 }
 .brw-root[data-brw-theme='dark'] {
   --brw-panel-bg-base: #0b1220;
@@ -125,6 +134,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #f8fafc;
   --brw-accent-fg-base: #0f172a;
   --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+  --brw-success-base: #34d399;
 }
 .brw-root {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -520,47 +530,60 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
-/* Staged-status rows (issue #74). Visually mirrors the assistant bubble
-   surface (background, padding, radius) but lives outside the
-   .brw-bubble class family so it does not count as a conversation
-   bubble for queries that count messages — the rows are progress
-   indicators, not messages. The transition-delay is set inline per row
-   so the three rows fade in sequentially even when the underlying SDK
-   phase events fire microseconds apart. The reduced-motion media query
-   collapses the entrance to an instant fade, pairing with the inline
-   0ms delay the adapter passes when the user has
-   prefers-reduced-motion: reduce. */
+/* Staged-status rows: progress indicators, not conversation bubbles.
+   They sit under a dashed top divider as a compact stacked checklist,
+   mirroring the marketing AnimatedDemo widget mock — and intentionally
+   stay outside the .brw-bubble class family so message-count queries
+   ignore them. .brw-status-rows is the grouping container that owns the
+   divider + stacking; .brw-status-row is one ticked line. The
+   transition-delay is set inline per row so the three rows fade in
+   sequentially even when the underlying SDK phase events fire
+   microseconds apart. The reduced-motion media query collapses the
+   entrance to an instant fade, pairing with the inline 0ms delay the
+   adapter passes when the user has prefers-reduced-motion: reduce. */
+.brw-status-rows {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--brw-divider, var(--brw-divider-base));
+}
 .brw-status-row {
-  align-self: flex-start;
-  max-width: 85%;
-  padding: 10px 12px;
-  border-radius: 14px;
-  border-bottom-left-radius: 4px;
-  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
-  color: var(--brw-fg, var(--brw-fg-base));
-  font-size: 13px;
-  line-height: 1.45;
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   animation: brw-status-row-in 220ms ease-out both;
 }
 .brw-status-row-check {
   display: inline-flex;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   align-items: center;
   justify-content: center;
-  color: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-success-base);
+  flex-shrink: 0;
 }
 .brw-status-row-check svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 .brw-status-row-label { flex: 1; }
+/* The retry row is a standalone alert that sits outside the checklist
+   container, so it carries its own chrome — padding, radius, border —
+   instead of inheriting the checklist's tick-line minimalism. */
 .brw-status-row--error {
+  align-self: stretch;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: transparent;
   color: var(--brw-error-base);
   border: 1px solid var(--brw-error-base);
+  font-size: 13px;
 }
 .brw-status-row-retry {
   margin-left: auto;

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -398,6 +398,11 @@ describe('<FeedbackButton> — error paths', () => {
     expect(row).toHaveAttribute('role', 'alert');
     expect(row).toHaveAttribute('data-brw-error-code', 'INGEST_REJECTED');
     expect(row.textContent).toContain('quota exceeded');
+    // The retry row is a standalone alert — it must sit OUTSIDE the
+    // `.brw-status-rows` checklist wrapper so the dashed-divider styling
+    // does not bleed into the failure state. Pins the structural
+    // relationship against an accidental fold-back during future refactors.
+    expect(row.closest('.brw-status-rows')).toBeNull();
   });
 
   it('invokes onSubmit with the { ok: false, error } shape on failure', async () => {
@@ -554,6 +559,37 @@ describe('<FeedbackButton> — staged-status rows (#74)', () => {
     phaseBus.emit('phase', { phase: 'sanitising-done' });
     await waitFor(() => expect(getStatusRow('sanitised')).not.toBeNull());
     await waitFor(() => expect(getStatusRow('formatting')).not.toBeNull());
+  });
+
+  it('.brw-status-rows wrapper is absent at idle and present once a row mounts', async () => {
+    // Pins the structural contract documented at packages/solid/src/styles.ts:
+    // the dashed-divider checklist wrapper exists only while at least one of
+    // the three staged rows is visible, and the captured row sits inside it.
+    // Mirrors the React assertion so both adapters stay in lockstep.
+    parkSubmit();
+    getConfig.mockResolvedValue({
+      ai_enabled: true,
+      ai_submitter_choice_allowed: false,
+    });
+    mount();
+    openPanel();
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+
+    // Negative: panel open, nothing sent yet → no wrapper in the DOM.
+    expect(document.querySelector('.brw-status-rows')).toBeNull();
+
+    typeDraft('wrapper-presence-test');
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    phaseBus.emit('phase', { phase: 'capturing-done' });
+    await waitFor(() => expect(getStatusRow('captured')).not.toBeNull());
+
+    // Positive: once the captured row is visible the wrapper exists and
+    // contains that row.
+    const wrapper = document.querySelector('.brw-status-rows');
+    expect(wrapper).not.toBeNull();
+    const captured = getStatusRow('captured');
+    expect(captured).not.toBeNull();
+    expect(captured!.closest('.brw-status-rows')).toBe(wrapper);
   });
 
   it('AI row is suppressed when getConfig().ai_enabled === false', async () => {

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -603,7 +603,7 @@ describe('<FeedbackButton> — staged-status rows (#74)', () => {
     const rows = document.querySelectorAll<HTMLElement>('[data-brw-row]');
     expect(rows.length).toBeGreaterThan(0);
     for (const row of rows) {
-      expect(row.style.transitionDelay).toBe('0ms');
+      expect(row.style.animationDelay).toBe('0ms');
     }
   });
 });

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -717,7 +717,7 @@ function Thread(props: ThreadProps): JSX.Element {
         )}
       </Show>
       <Show when={showCaptured() || showSanitised() || showFormatting()}>
-        <div class="brw-status-rows" data-brw-status-rows="">
+        <div class="brw-status-rows">
           <Show when={showCaptured()}>
             <StatusRow variant="check" delayMs={0} dataRow="captured">
               Captured route, console, network, device
@@ -773,12 +773,14 @@ interface StatusRowProps {
  *
  * The `data-brw-row` attribute exists for the test suite to query rows by
  * their role-in-the-pipeline without coupling to the visible label.
+ * Stagger is applied as an `animation-delay` so the rows fade in
+ * sequentially under the shared entrance keyframe.
  */
 function StatusRow(props: StatusRowProps): JSX.Element {
   return (
     <div
       class="brw-status-row"
-      style={{ 'transition-delay': `${props.delayMs}ms` }}
+      style={{ 'animation-delay': `${props.delayMs}ms` }}
       data-brw-row={props.dataRow}
     >
       <Switch>

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -716,28 +716,32 @@ function Thread(props: ThreadProps): JSX.Element {
           </div>
         )}
       </Show>
-      <Show when={showCaptured()}>
-        <StatusRow variant="check" delayMs={0} dataRow="captured">
-          Captured route, console, network, device
-        </StatusRow>
-      </Show>
-      <Show when={showSanitised()}>
-        <StatusRow
-          variant="check"
-          delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
-          dataRow="sanitised"
-        >
-          PII-sanitised, packaged
-        </StatusRow>
-      </Show>
-      <Show when={showFormatting()}>
-        <StatusRow
-          variant="spinner"
-          delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
-          dataRow="formatting"
-        >
-          Formatting with AI…
-        </StatusRow>
+      <Show when={showCaptured() || showSanitised() || showFormatting()}>
+        <div class="brw-status-rows" data-brw-status-rows="">
+          <Show when={showCaptured()}>
+            <StatusRow variant="check" delayMs={0} dataRow="captured">
+              Captured route, console, network, device
+            </StatusRow>
+          </Show>
+          <Show when={showSanitised()}>
+            <StatusRow
+              variant="check"
+              delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS}
+              dataRow="sanitised"
+            >
+              PII-sanitised, packaged
+            </StatusRow>
+          </Show>
+          <Show when={showFormatting()}>
+            <StatusRow
+              variant="spinner"
+              delayMs={props.reducedMotion ? 0 : STATUS_ROW_STAGGER_MS * 2}
+              dataRow="formatting"
+            >
+              Formatting with AI…
+            </StatusRow>
+          </Show>
+        </div>
       </Show>
       <Show when={showRetryRow() && props.submitErrorTagged()}>
         {(err) => <RetryRow error={err()} onRetry={props.onRetry} />}

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -63,6 +63,10 @@ export const BREVWICK_CSS = `
      contract. No public alias; widget rules consume --brw-error-base
      directly. */
   --brw-error-base: #b91c1c;
+  /* Success / check colour for the staged-status checklist. Matches the
+     emerald used in the marketing AnimatedDemo so the in-widget checklist
+     reads as the same affordance the docs preview. */
+  --brw-success-base: #10b981;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
@@ -80,6 +84,8 @@ export const BREVWICK_CSS = `
     --brw-accent-base: #f8fafc;
     --brw-accent-fg-base: #0f172a;
     --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+    /* Brighter emerald (500→400) keeps the tick legible on dark panels. */
+    --brw-success-base: #34d399;
   }
 }
 .brw-root[data-brw-theme='light'] {
@@ -97,6 +103,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #0f172a;
   --brw-accent-fg-base: #ffffff;
   --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  --brw-success-base: #10b981;
 }
 .brw-root[data-brw-theme='dark'] {
   --brw-panel-bg-base: #0b1220;
@@ -113,6 +120,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #f8fafc;
   --brw-accent-fg-base: #0f172a;
   --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+  --brw-success-base: #34d399;
 }
 .brw-root {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -475,37 +483,52 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
+/* Staged-status rows: progress indicators, not conversation bubbles.
+   They read as a compact stacked checklist under a dashed top divider,
+   matching the marketing AnimatedDemo widget mock. The retry row sits
+   outside the .brw-status-rows wrapper and keeps its own chrome
+   (padding, radius, border) so the failure case still reads as a
+   standalone alert. */
+.brw-status-rows {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--brw-divider, var(--brw-divider-base));
+}
 .brw-status-row {
-  align-self: flex-start;
-  max-width: 85%;
-  padding: 10px 12px;
-  border-radius: 14px;
-  border-bottom-left-radius: 4px;
-  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
-  color: var(--brw-fg, var(--brw-fg-base));
-  font-size: 13px;
-  line-height: 1.45;
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   animation: brw-status-row-in 220ms ease-out both;
 }
 .brw-status-row-check {
   display: inline-flex;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   align-items: center;
   justify-content: center;
-  color: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-success-base);
+  flex-shrink: 0;
 }
 .brw-status-row-check svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 .brw-status-row-label { flex: 1; }
 .brw-status-row--error {
+  align-self: stretch;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: transparent;
   color: var(--brw-error-base);
   border: 1px solid var(--brw-error-base);
+  font-size: 13px;
 }
 .brw-status-row-retry {
   margin-left: auto;

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -521,6 +521,14 @@ export const BREVWICK_CSS = `
   width: 12px;
   height: 12px;
 }
+/* The shared .brw-spinner ships at 14px so it reads at full size in the
+   composer; inside the staged-status checklist it has to match the 12px
+   tick so the third row's indicator sits on the same baseline as the
+   first two. */
+.brw-status-row .brw-spinner {
+  width: 12px;
+  height: 12px;
+}
 .brw-status-row-label { flex: 1; }
 /* The retry row is a standalone alert that sits outside the checklist
    container, so it carries its own chrome — padding, radius, border —

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -485,10 +485,11 @@ export const BREVWICK_CSS = `
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
 /* Staged-status rows: progress indicators, not conversation bubbles.
    They read as a compact stacked checklist under a dashed top divider,
-   matching the marketing AnimatedDemo widget mock. The retry row sits
-   outside the .brw-status-rows wrapper and keeps its own chrome
-   (padding, radius, border) so the failure case still reads as a
-   standalone alert. */
+   matching the marketing AnimatedDemo widget mock. The animation-delay
+   is set inline per row so the rows fade in sequentially under the
+   shared @keyframes entrance. The retry row sits outside the
+   .brw-status-rows wrapper and keeps its own chrome (padding, radius,
+   border) so the failure case still reads as a standalone alert. */
 .brw-status-rows {
   align-self: stretch;
   display: flex;
@@ -521,6 +522,11 @@ export const BREVWICK_CSS = `
   height: 12px;
 }
 .brw-status-row-label { flex: 1; }
+/* The retry row is a standalone alert that sits outside the checklist
+   container, so it carries its own chrome — padding, radius, border —
+   instead of inheriting the checklist's tick-line minimalism. The
+   background stays transparent so the red border + red label read as
+   an alert overlay rather than a filled bubble surface. */
 .brw-status-row--error {
   align-self: stretch;
   padding: 10px 12px;
@@ -529,6 +535,7 @@ export const BREVWICK_CSS = `
   color: var(--brw-error-base);
   border: 1px solid var(--brw-error-base);
   font-size: 13px;
+  line-height: 1.45;
 }
 .brw-status-row-retry {
   margin-left: auto;

--- a/packages/svelte/src/lib/components/FeedbackButton.svelte
+++ b/packages/svelte/src/lib/components/FeedbackButton.svelte
@@ -35,9 +35,12 @@
   // reject downstream.
   const MAX_ATTACHMENTS = 5;
 
-  // Stagger between staged-status rows in milliseconds. Mirrors the React
-  // adapter (#74). Honoured only when the user has not requested reduced
-  // motion — see `prefersReducedMotion` below.
+  // Stagger between staged-status rows in milliseconds. Applied as
+  // `animation-delay` per row (the rows mount with a CSS @keyframes
+  // entrance, not a transition) so the rows fade in sequentially even
+  // when the underlying SDK phase events fire microseconds apart.
+  // Honoured only when the user has not requested reduced motion —
+  // see `prefersReducedMotion` below.
   const STATUS_ROW_STAGGER_MS = 200;
 
   // Phase ordinal mirrored from the React adapter (#74). Row 1 ("Captured")
@@ -632,70 +635,74 @@
             <div class="brw-svelte-error" role="alert">{submitError}</div>
           {/if}
 
-          {#if showCaptured}
-            <div
-              class="brw-svelte-status-row"
-              data-brw-row="captured"
-              style="transition-delay: 0ms; animation-delay: 0ms;"
-            >
-              <span class="brw-svelte-status-row-check" aria-hidden="true">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+          {#if showCaptured || showSanitised || showFormatting}
+            <div class="brw-svelte-status-rows">
+              {#if showCaptured}
+                <div
+                  class="brw-svelte-status-row"
+                  data-brw-row="captured"
+                  style="animation-delay: 0ms;"
                 >
-                  <path d="M5 12l5 5L20 7" />
-                </svg>
-              </span>
-              <span class="brw-svelte-status-row-label"
-                >Captured route, console, network, device</span
-              >
-            </div>
-          {/if}
-          {#if showSanitised}
-            <div
-              class="brw-svelte-status-row"
-              data-brw-row="sanitised"
-              style="transition-delay: {prefersReducedMotion
-                ? 0
-                : STATUS_ROW_STAGGER_MS}ms; animation-delay: {prefersReducedMotion
-                ? 0
-                : STATUS_ROW_STAGGER_MS}ms;"
-            >
-              <span class="brw-svelte-status-row-check" aria-hidden="true">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
+                  <span class="brw-svelte-status-row-check" aria-hidden="true">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M5 12l5 5L20 7" />
+                    </svg>
+                  </span>
+                  <span class="brw-svelte-status-row-label"
+                    >Captured route, console, network, device</span
+                  >
+                </div>
+              {/if}
+              {#if showSanitised}
+                <div
+                  class="brw-svelte-status-row"
+                  data-brw-row="sanitised"
+                  style="animation-delay: {prefersReducedMotion
+                    ? 0
+                    : STATUS_ROW_STAGGER_MS}ms;"
                 >
-                  <path d="M5 12l5 5L20 7" />
-                </svg>
-              </span>
-              <span class="brw-svelte-status-row-label">PII-sanitised, packaged</span>
-            </div>
-          {/if}
-          {#if showFormatting}
-            <div
-              class="brw-svelte-status-row"
-              data-brw-row="formatting"
-              style="transition-delay: {prefersReducedMotion
-                ? 0
-                : STATUS_ROW_STAGGER_MS * 2}ms; animation-delay: {prefersReducedMotion
-                ? 0
-                : STATUS_ROW_STAGGER_MS * 2}ms;"
-            >
-              <span class="brw-svelte-spinner" aria-hidden="true"></span>
-              <span class="brw-svelte-status-row-label">Formatting with AI…</span>
+                  <span class="brw-svelte-status-row-check" aria-hidden="true">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M5 12l5 5L20 7" />
+                    </svg>
+                  </span>
+                  <span class="brw-svelte-status-row-label"
+                    >PII-sanitised, packaged</span
+                  >
+                </div>
+              {/if}
+              {#if showFormatting}
+                <div
+                  class="brw-svelte-status-row"
+                  data-brw-row="formatting"
+                  style="animation-delay: {prefersReducedMotion
+                    ? 0
+                    : STATUS_ROW_STAGGER_MS * 2}ms;"
+                >
+                  <span class="brw-svelte-spinner" aria-hidden="true"></span>
+                  <span class="brw-svelte-status-row-label"
+                    >Formatting with AI…</span
+                  >
+                </div>
+              {/if}
             </div>
           {/if}
           {#if showRetryRow && $submitErrorTagged}
@@ -894,6 +901,12 @@
     --brw-accent: #4f46e5;
     --brw-accent-fg: #ffffff;
     --brw-error: #b91c1c;
+    /* Success / check colour for the staged-status checklist. Matches the
+       emerald used in the marketing AnimatedDemo so the in-widget checklist
+       reads as the same affordance the docs preview. Widget-internal: no
+       public --brw-success alias by design — host overrides flow through
+       --brw-accent for chrome and don't need a knob for the green tick. */
+    --brw-success: #10b981;
     --brw-shadow:
       0 1px 2px rgba(0, 0, 0, 0.06), 0 8px 24px rgba(0, 0, 0, 0.12);
     color: var(--brw-fg);
@@ -922,6 +935,8 @@
     --brw-divider: #2a2b30;
     --brw-accent: #818cf8;
     --brw-accent-fg: #0b0b0c;
+    /* Brighter emerald (500→400) keeps the tick legible on dark panels. */
+    --brw-success: #34d399;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -939,6 +954,7 @@
       --brw-divider: #2a2b30;
       --brw-accent: #818cf8;
       --brw-accent-fg: #0b0b0c;
+      --brw-success: #34d399;
     }
   }
 
@@ -1173,43 +1189,66 @@
     min-height: 34px;
   }
 
-  /* Staged-status rows (#74). Visually mirrors the assistant bubble
-     surface (background, padding, radius) but lives outside the bubble
-     class family so it does not count as a conversation bubble for queries
-     that count messages — the rows are progress indicators, not messages.
-     The transition-delay / animation-delay are set inline per row so the
-     three rows fade in sequentially even when the underlying SDK phase
-     events fire microseconds apart. */
+  /* Staged-status rows: progress indicators, not conversation bubbles.
+     They sit under a dashed top divider as a compact stacked checklist,
+     mirroring the marketing AnimatedDemo widget mock — and intentionally
+     stay outside the bubble class family so message-count queries ignore
+     them. .brw-svelte-status-rows is the grouping container that owns
+     the divider + stacking; .brw-svelte-status-row is one ticked line.
+     The animation-delay is set inline per row so the three rows fade in
+     sequentially under the shared @keyframes entrance even when the
+     underlying SDK phase events fire microseconds apart. The
+     reduced-motion media query collapses the entrance to an instant
+     fade, pairing with the inline 0ms delay the template emits when
+     prefers-reduced-motion: reduce. */
+  .brw-svelte-status-rows {
+    align-self: stretch;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 2px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--brw-divider);
+  }
   .brw-svelte-status-row {
-    align-self: flex-start;
-    max-width: 100%;
-    padding: 8px 12px;
-    border-radius: 12px;
-    border-bottom-left-radius: 4px;
-    background: var(--brw-bubble-assistant-bg);
-    color: var(--brw-fg);
-    font-size: 13px;
-    line-height: 1.45;
     display: flex;
     align-items: center;
     gap: 8px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--brw-fg-muted);
     animation: brw-svelte-status-row-in 220ms ease-out both;
   }
   .brw-svelte-status-row-check {
     display: inline-flex;
-    width: 14px;
-    height: 14px;
+    width: 12px;
+    height: 12px;
     align-items: center;
     justify-content: center;
-    color: var(--brw-accent);
+    color: var(--brw-success);
+    flex-shrink: 0;
+  }
+  .brw-svelte-status-row-check svg {
+    width: 12px;
+    height: 12px;
   }
   .brw-svelte-status-row-label {
     flex: 1;
   }
+  /* The retry row is a standalone alert that sits outside the checklist
+     container, so it carries its own chrome — padding, radius, border —
+     instead of inheriting the checklist's tick-line minimalism. The
+     background stays transparent so the red border + red label read as
+     an alert overlay rather than a filled bubble surface. */
   .brw-svelte-status-row--error {
+    align-self: stretch;
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: transparent;
     color: var(--brw-error);
     border: 1px solid var(--brw-error);
-    background: var(--brw-bubble-assistant-bg);
+    font-size: 13px;
+    line-height: 1.45;
   }
   .brw-svelte-status-row-retry {
     margin-left: auto;

--- a/packages/svelte/src/lib/components/FeedbackButton.svelte
+++ b/packages/svelte/src/lib/components/FeedbackButton.svelte
@@ -1232,6 +1232,14 @@
     width: 12px;
     height: 12px;
   }
+  /* The shared .brw-svelte-spinner ships at 14px so it reads at full size
+     in the composer; inside the staged-status checklist it has to match
+     the 12px tick so the third row's indicator sits on the same baseline
+     as the first two. */
+  .brw-svelte-status-row .brw-svelte-spinner {
+    width: 12px;
+    height: 12px;
+  }
   .brw-svelte-status-row-label {
     flex: 1;
   }

--- a/packages/vue/src/__tests__/feedback-button.test.ts
+++ b/packages/vue/src/__tests__/feedback-button.test.ts
@@ -712,7 +712,7 @@ describe('<FeedbackButton> staged-status UX (#74)', () => {
       const rows = document.querySelectorAll<HTMLElement>('[data-brw-row]');
       expect(rows.length).toBeGreaterThan(0);
       for (const row of rows) {
-        expect(row.style.transitionDelay).toBe('0ms');
+        expect(row.style.animationDelay).toBe('0ms');
       }
     } finally {
       mqSpy?.mockRestore();

--- a/packages/vue/src/components/feedback-button.ts
+++ b/packages/vue/src/components/feedback-button.ts
@@ -93,8 +93,9 @@ const PHASE_RANK: Record<FeedbackPhase, number> = {
 
 /**
  * Stagger between staged-status rows in milliseconds. Applied as
- * `transition-delay` per row so the rows fade in sequentially even when
- * the underlying SDK phase events fire microseconds apart.
+ * `animation-delay` per row (the rows mount with a CSS @keyframes
+ * entrance, not a transition) so the rows fade in sequentially even
+ * when the underlying SDK phase events fire microseconds apart.
  */
 const STATUS_ROW_STAGGER_MS = 200;
 
@@ -609,36 +610,40 @@ export const FeedbackButton = defineComponent({
         );
       }
 
-      if (showCaptured) {
-        children.push(
-          renderStatusRow(
-            'check',
-            // Row 1 anchors the cascade at 0 ms; rows 2 + 3 stagger off it.
-            0,
-            'captured',
-            'Captured route, console, network, device',
-          ),
-        );
-      }
-      if (showSanitised) {
-        children.push(
-          renderStatusRow(
-            'check',
-            reducedMotion.value ? 0 : STATUS_ROW_STAGGER_MS,
-            'sanitised',
-            'PII-sanitised, packaged',
-          ),
-        );
-      }
-      if (showFormatting) {
-        children.push(
-          renderStatusRow(
-            'spinner',
-            reducedMotion.value ? 0 : STATUS_ROW_STAGGER_MS * 2,
-            'formatting',
-            'Formatting with AI…',
-          ),
-        );
+      if (showCaptured || showSanitised || showFormatting) {
+        const rows: Array<VNode> = [];
+        if (showCaptured) {
+          rows.push(
+            renderStatusRow(
+              'check',
+              // Row 1 anchors the cascade at 0 ms; rows 2 + 3 stagger off it.
+              0,
+              'captured',
+              'Captured route, console, network, device',
+            ),
+          );
+        }
+        if (showSanitised) {
+          rows.push(
+            renderStatusRow(
+              'check',
+              reducedMotion.value ? 0 : STATUS_ROW_STAGGER_MS,
+              'sanitised',
+              'PII-sanitised, packaged',
+            ),
+          );
+        }
+        if (showFormatting) {
+          rows.push(
+            renderStatusRow(
+              'spinner',
+              reducedMotion.value ? 0 : STATUS_ROW_STAGGER_MS * 2,
+              'formatting',
+              'Formatting with AI…',
+            ),
+          );
+        }
+        children.push(h('div', { class: 'brw-status-rows' }, rows));
       }
       if (showRetryRow && submitErrorTagged.value) {
         children.push(renderRetryRow(submitErrorTagged.value));
@@ -766,7 +771,7 @@ export const FeedbackButton = defineComponent({
         {
           key: dataRow,
           class: 'brw-status-row',
-          style: { transitionDelay: `${delayMs}ms` },
+          style: { animationDelay: `${delayMs}ms` },
           'data-brw-row': dataRow,
         },
         [indicator, h('span', { class: 'brw-status-row-label' }, label)],

--- a/packages/vue/src/styles.ts
+++ b/packages/vue/src/styles.ts
@@ -64,6 +64,12 @@ export const BREVWICK_CSS = `
      the dark --brw-panel-bg); override in the dark block if design ever
      wants a tuned variant. */
   --brw-error-base: #b91c1c;
+  /* Success / check colour for the staged-status checklist. Matches the
+     emerald used in the marketing AnimatedDemo so the in-widget checklist
+     reads as the same affordance the docs preview. Widget-internal: no
+     public --brw-success alias by design — host overrides flow through
+     --brw-accent for chrome and don't need a knob for the green tick. */
+  --brw-success-base: #10b981;
 }
 @media (prefers-color-scheme: dark) {
   :where(:root) {
@@ -88,6 +94,8 @@ export const BREVWICK_CSS = `
     --brw-accent-fg-base: #0f172a;
     /* Shadow — deeper alpha so the panel still reads as lifted over a dark host */
     --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+    /* Brighter emerald (500→400) keeps the tick legible on dark panels. */
+    --brw-success-base: #34d399;
   }
 }
 /* Forced palettes via <FeedbackButton theme="light|dark">. These rewrite
@@ -115,6 +123,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #0f172a;
   --brw-accent-fg-base: #ffffff;
   --brw-shadow-base: 0 20px 48px rgba(15, 23, 42, 0.18), 0 6px 12px rgba(15, 23, 42, 0.08);
+  --brw-success-base: #10b981;
 }
 .brw-root[data-brw-theme='dark'] {
   --brw-panel-bg-base: #0b1220;
@@ -131,6 +140,7 @@ export const BREVWICK_CSS = `
   --brw-accent-base: #f8fafc;
   --brw-accent-fg-base: #0f172a;
   --brw-shadow-base: 0 20px 48px rgba(0, 0, 0, 0.55), 0 6px 12px rgba(0, 0, 0, 0.35);
+  --brw-success-base: #34d399;
 }
 .brw-root {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -509,37 +519,64 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
+/* Staged-status rows: progress indicators, not conversation bubbles.
+   They sit under a dashed top divider as a compact stacked checklist,
+   mirroring the marketing AnimatedDemo widget mock — and intentionally
+   stay outside the .brw-bubble class family so message-count queries
+   ignore them. .brw-status-rows is the grouping container that owns the
+   divider + stacking; .brw-status-row is one ticked line. The
+   animation-delay is set inline per row so the three rows fade in
+   sequentially under the shared @keyframes entrance even when the
+   underlying SDK phase events fire microseconds apart. The
+   reduced-motion media query collapses the entrance to an instant fade,
+   pairing with the inline 0ms delay the adapter passes when the user
+   has prefers-reduced-motion: reduce. */
+.brw-status-rows {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--brw-divider, var(--brw-divider-base));
+}
 .brw-status-row {
-  align-self: flex-start;
-  max-width: 85%;
-  padding: 10px 12px;
-  border-radius: 14px;
-  border-bottom-left-radius: 4px;
-  background: var(--brw-bubble-assistant-bg, var(--brw-bubble-assistant-bg-base));
-  color: var(--brw-fg, var(--brw-fg-base));
-  font-size: 13px;
-  line-height: 1.45;
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--brw-fg-muted, var(--brw-fg-muted-base));
   animation: brw-status-row-in 220ms ease-out both;
 }
 .brw-status-row-check {
   display: inline-flex;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   align-items: center;
   justify-content: center;
-  color: var(--brw-accent, var(--brw-accent-base));
+  color: var(--brw-success-base);
+  flex-shrink: 0;
 }
 .brw-status-row-check svg {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
 }
 .brw-status-row-label { flex: 1; }
+/* The retry row is a standalone alert that sits outside the checklist
+   container, so it carries its own chrome — padding, radius, border —
+   instead of inheriting the checklist's tick-line minimalism. The
+   background stays transparent so the red border + red label read as
+   an alert overlay rather than a filled bubble surface. */
 .brw-status-row--error {
+  align-self: stretch;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: transparent;
   color: var(--brw-error-base);
   border: 1px solid var(--brw-error-base);
+  font-size: 13px;
+  line-height: 1.45;
 }
 .brw-status-row-retry {
   margin-left: auto;

--- a/packages/vue/src/styles.ts
+++ b/packages/vue/src/styles.ts
@@ -562,6 +562,14 @@ export const BREVWICK_CSS = `
   width: 12px;
   height: 12px;
 }
+/* The shared .brw-spinner ships at 14px so it reads at full size in the
+   composer; inside the staged-status checklist it has to match the 12px
+   tick so the third row's indicator sits on the same baseline as the
+   first two. */
+.brw-status-row .brw-spinner {
+  width: 12px;
+  height: 12px;
+}
 .brw-status-row-label { flex: 1; }
 /* The retry row is a standalone alert that sits outside the checklist
    container, so it carries its own chrome — padding, radius, border —


### PR DESCRIPTION
Closes #146

## Summary
- All five web-rendered feedback adapters — React, Solid, Vue, Svelte, and Angular — rendered the "Captured route…", "PII-sanitised, packaged", and "Formatting with AI…" rows as assistant-coloured chat bubbles. The marketing landing page's `AnimatedDemo` (see `brevwick-web` `src/app/(marketing)/_components/landing/animated-demo.tsx`) shows them as a compact, dashed-top-divided checklist with small emerald ticks — the styling users see before they install the SDK.
- The staged-status rows are now wrapped in a `.brw-status-rows` container (the Svelte adapter uses its scoped `brw-svelte-status-rows` twin) that owns the dashed top divider + stacking, and each row is a compact line (no bubble surface, 12 px text, muted colour, 12 px emerald check). The retry row keeps its own bordered alert chrome because it remains a standalone failure CTA, not a checklist line — and is now pinned by tests as sitting outside the wrapper in both React and Solid.
- The per-row stagger now correctly targets `animation-delay` across all five adapters (the entrance is a CSS `@keyframes` animation, not a transition), so the inline cascade is no longer a no-op.
- Greeting + user message bubbles are unchanged; they were already correct per the AnimatedDemo.
- Added a widget-internal `--brw-success-base` token (light `#10b981`, dark `#34d399`) so the check colour participates in the existing theme system without becoming a public override knob. Svelte continues to use its package-internal `--brw-success` to match its existing convention.
- React Native is excluded — different rendering surface, native `StyleSheet` not CSS.

## Test plan
- [x] `pnpm format:check`, `pnpm lint`, `pnpm type-check`, `pnpm test:cover`, `pnpm build`, `pnpm size` — all green locally
- [x] Adapter budgets honoured: React 10.43 kB / 25 kB, Solid 9.36 kB / 12 kB, Vue 8.93 kB / 10 kB, Svelte SFC 12.6 kB / 14 kB, Angular 15.88 kB / 18 kB, core eager 7.28 kB / 8 kB
- [x] Existing `no hardcoded hex in class rules` guard continues to pass — the new `--brw-success-base` token lives inside the `:where(:root)` / forced-theme blocks only
- [x] New tests pin the `.brw-status-rows` wrapper presence (absent at idle, present once a row mounts) and the retry-row-outside-wrapper invariant in both React and Solid
- [ ] Visually inspect the React, Solid, Vue, Svelte, and Angular example apps after the changeset publishes a beta to confirm the rows match the marketing widget mock