### PR TITLE
chore(release): realign linked packages on prerelease channel

### DIFF
--- a/.changeset/realign-linked-versions.md
+++ b/.changeset/realign-linked-versions.md
@@ -1,0 +1,20 @@
+---
+'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-react-native': patch
+'@tatlacas/brevwick-solid': patch
+'@tatlacas/brevwick-svelte': patch
+'@tatlacas/brevwick-vue': patch
+'@tatlacas/brevwick-angular': patch
+---
+
+Re-align the seven linked packages onto a single version on the prerelease
+channel. The stable `1.0.2` release (PR #150) bumped only the five web
+adapters — `react`, `solid`, `vue`, `svelte`, `angular` — because the
+consumed changeset listed only those packages, and `.changeset/config.json`
+uses `linked` (which shares a version-floor across the group but does not
+auto-bump siblings) rather than `fixed`. As a result `@tatlacas/brevwick-sdk`
+and `@tatlacas/brevwick-react-native` were left at `1.0.1` on npm while the
+others moved to `1.0.2`. Listing all seven here brings every package to the
+next prerelease (`1.0.3-beta.0`) together, restoring parity across the
+linked group before further work continues on the dev channel.


### PR DESCRIPTION
## Summary

- The stable `1.0.2` release bumped only the five web adapters (`react`, `solid`, `vue`, `svelte`, `angular`) because the consumed changeset listed only those five packages — `@tatlacas/brevwick-sdk` and `@tatlacas/brevwick-react-native` were left at `1.0.1` on npm.
- `.changeset/config.json` uses `linked`, which shares a version-floor across the group when packages are released together but does **not** auto-bump siblings — so the divergence is the expected behaviour of `linked`, not a bug. (If the project actually wants the "all 7 always move together" guarantee, switch to `fixed` in a separate PR.)
- This changeset lists all seven linked packages so the next prerelease (`1.0.3-beta.0`) restores parity across the group.

## Why now

The dev release workflow is currently failing because no changesets are pending after the resume — every push tries to re-publish the `1.0.2` versions that already exist on npm (`403 You cannot publish over the previously published versions`). Landing a real changeset (this one) unblocks the version-packages PR and lets the beta channel move again.

## Test plan

- [ ] CI green on this PR (`check`, `codecov/patch`, `codecov/project`)
- [ ] After squash-merge into `dev`, the `release-dev.yml` workflow opens a "Version Packages (dev)" PR bumping all seven packages to `1.0.3-beta.0`
- [ ] Merging that PR publishes `1.0.3-beta.0` for all seven `@tatlacas/brevwick-*` packages to the `beta` dist-tag, with `sdk` and `react-native` rejoining the rest of the linked group