### PR TITLE
chore(release): enforce fixed versions across all seven packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,8 +5,7 @@
     { "repo": "tatlacas-com/brevwick-sdk-js" }
   ],
   "commit": false,
-  "fixed": [],
-  "linked": [
+  "fixed": [
     [
       "@tatlacas/brevwick-sdk",
       "@tatlacas/brevwick-react",
@@ -17,6 +16,7 @@
       "@tatlacas/brevwick-react-native"
     ]
   ],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Every payload that leaves the device runs through `redact()` first. Adding a new
 
 ## Versioning
 
-All seven packages move together (linked in `.changeset/config.json`). Versions follow SemVer from `1.0.0` onward — the `1.0.0-beta.X` train is the lead-up to the first stable.
+All seven packages move together (`fixed` group in `.changeset/config.json`) — every release bumps every package to the same version, even if a changeset only mentions one of them, so consumers always install matching versions across the SDK + every adapter. Versions follow SemVer from `1.0.0` onward — the `1.0.0-beta.X` train is the lead-up to the first stable.
 
 - `feat:` — minor bump
 - `fix:` / `refactor:` — patch bump


### PR DESCRIPTION
## Summary

- Switches `.changeset/config.json` from `linked` to `fixed` for the seven `@tatlacas/brevwick-*` packages so every release bumps every package to the same version, even if a changeset only mentions one of them.
- Updates `CLAUDE.md` to describe the new semantics accurately (`linked` shares a version-floor when packages are released together; it does not auto-bump siblings — `fixed` does).

## Why

`linked` is what caused `@tatlacas/brevwick-sdk` and `@tatlacas/brevwick-react-native` to silently fall behind at `1.0.1` while the five web adapters moved to `1.0.2` (PR #150 / #152 conversation). The consumed changeset listed only the five adapters, so `linked` correctly left `sdk` and `react-native` untouched.

Going forward we want "install matching versions of everything" to be a one-decision guarantee, not a per-changeset discipline that depends on contributors remembering to list all seven packages. `fixed` enforces that at the tooling level: any changeset, regardless of which packages it lists, will bump the whole group.

Trade-off accepted: `@tatlacas/brevwick-sdk` will now publish a new version on every adapter-only UI change. Given every adapter depends on the SDK at runtime anyway, consumers were already bumping the SDK at install time — this just makes the version number match what they're actually using.

## Test plan

- [ ] CI green on this PR (`check`, `codecov/patch`, `codecov/project`)
- [ ] After merge, the next changeset that lands on `dev` — even one that lists only a single package — produces a "Version Packages (dev)" PR bumping all seven `@tatlacas/brevwick-*` packages to the same prerelease version
- [ ] No effect on PR #152's pending `1.0.3-beta.0` bump (that changeset already lists all seven packages explicitly)