### PR TITLE
fix(ci): ignore changeset-owned pre.json in prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ notes
 **/next-env.d.ts
 **/.expo/**
 **/CHANGELOG.md
+.changeset/pre.json


### PR DESCRIPTION
## Problem

The auto-generated `Version Packages (dev) (beta)` release PR (e.g. #153) fails CI on the `check` job:

```
[warn] .changeset/pre.json
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

## Root cause

`.changeset/pre.json` is machine-generated and owned by `@changesets/cli`. On every prerelease release PR the bot repopulates its `changesets` array and writes it **multi-line**:

```json
"changesets": [
  "debug-raw-payload",
  "realign-linked-versions"
]
```

Prettier wants short arrays collapsed onto one line, so `pnpm format:check` fails. It passes locally only because `pre.json` on `dev` has an empty `changesets: []` array — it breaks the instant changesets fills it in. This recurs on **every** prerelease release PR, not just #153.

## Fix

Add `.changeset/pre.json` to `.prettierignore`, alongside the already-ignored `**/CHANGELOG.md` (also a changesets-generated artifact). We don't author or control this file's formatting, so it shouldn't be style-checked.

Verified: with the populated `pre.json` from `changeset-release/dev` dropped into the tree, `prettier --check .` now passes.

Once merged into `dev`, the changesets action regenerates #153 on top of this commit and the `check` job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)