### PR TITLE
feat(launcher): side tab variant + compact icon-only mode

### DIFF
--- a/.changeset/launcher-tab-compact.md
+++ b/.changeset/launcher-tab-compact.md
@@ -1,0 +1,19 @@
+---
+'@tatlacas/brevwick-react': minor
+'@tatlacas/brevwick-solid': minor
+'@tatlacas/brevwick-vue': minor
+'@tatlacas/brevwick-svelte': minor
+'@tatlacas/brevwick-angular': minor
+'@tatlacas/brevwick-react-native': minor
+---
+
+feat: launcher `variant` (vertical edge tab is the new default) + `compact` icon-only mode
+
+The FeedbackButton launcher now supports two presentations across every adapter (React, Solid, Vue, Svelte, Angular, React Native):
+
+- `variant="tab"` — **the new default**: a vertical tab flush against the right viewport edge (right edge of the host view on React Native), vertically centered. A new `offset` prop nudges the tab up/down from center in px.
+- `variant="bubble"` — the legacy floating corner pill.
+- `compact` — icon-only mode for either variant (circular bubble / square edge tab); the `label` is not rendered but becomes the launcher's `aria-label`.
+- `position` gains the edge sides `'right' | 'left'` alongside the legacy corners. Defaults: `'right'` for the tab, `'bottom-right'` for the bubble.
+
+Backwards compatibility: passing a legacy corner `position` (`'bottom-right'` / `'bottom-left'` — or the offset-object form on React Native) without an explicit `variant` keeps the corner bubble, so existing call sites render exactly as before. When both are set, `variant` wins and `position` contributes only its horizontal side.

--- a/.changeset/launcher-tab-compact.md
+++ b/.changeset/launcher-tab-compact.md
@@ -1,4 +1,5 @@
 ---
+'@tatlacas/brevwick-sdk': minor
 '@tatlacas/brevwick-react': minor
 '@tatlacas/brevwick-solid': minor
 '@tatlacas/brevwick-vue': minor
@@ -17,3 +18,7 @@ The FeedbackButton launcher now supports two presentations across every adapter 
 - `position` gains the edge sides `'right' | 'left'` alongside the legacy corners. Defaults: `'right'` for the tab, `'bottom-right'` for the bubble.
 
 Backwards compatibility: passing a legacy corner `position` (`'bottom-right'` / `'bottom-left'` — or the offset-object form on React Native) without an explicit `variant` keeps the corner bubble, so existing call sites render exactly as before. When both are set, `variant` wins and `position` contributes only its horizontal side.
+
+The framework-agnostic placement resolver is now exported from the core package at `@tatlacas/brevwick-sdk/launcher` (`resolveLauncherPlacement`, `FeedbackButtonVariant`, `FeedbackButtonPosition`). Every adapter consumes this single tree-shakeable copy instead of carrying its own (the React Native adapter composes it for its offset-object form).
+
+Fixes a bug where the left-edge tab (`position="left"`) rendered well below vertical center: the standalone CSS `rotate: 180deg` was applied after `transform` and inverted the centering `translateY(-50%)`. The 180° flip is now composed inside `transform`, so the left tab is correctly centered while keeping its mirrored radii, flat edge, and hover behavior. The Svelte compact bubble is also aligned to 48px to match the other adapters.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Ship feedback from any browser app straight into clean, AI-formatted GitHub issu
 
 ## Packages
 
-| Package                                                      | Description                                                                                                   | API reference                                                        |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [`@tatlacas/brevwick-sdk`](./packages/sdk)                   | Framework-agnostic core: submit, screenshot, rings.                                                           | [packages/sdk/README.md](./packages/sdk/README.md)                   |
-| [`@tatlacas/brevwick-react`](./packages/react)               | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19.                                       | [packages/react/README.md](./packages/react/README.md)               |
-| [`@tatlacas/brevwick-solid`](./packages/solid)               | Provider, floating FAB widget, and `useFeedback` hook for Solid 1.8+.                                         | [packages/solid/README.md](./packages/solid/README.md)               |
-| [`@tatlacas/brevwick-vue`](./packages/vue)                   | Plugin, floating FAB component, and `useFeedback` composable for Vue 3.4+.                                    | [packages/vue/README.md](./packages/vue/README.md)                   |
-| [`@tatlacas/brevwick-svelte`](./packages/svelte)             | Context setter, FAB, and `getFeedback()` for Svelte 5 and SvelteKit.                                          | [packages/svelte/README.md](./packages/svelte/README.md)             |
-| [`@tatlacas/brevwick-angular`](./packages/angular)           | `provideBrevwick`, `BrevwickService`, and `bw-feedback-button` standalone component for Angular 17+.          | [packages/angular/README.md](./packages/angular/README.md)           |
-| [`@tatlacas/brevwick-react-native`](./packages/react-native) | Provider, `useFeedback` hook, route-ring helper, and native screenshot path for Expo SDK 51+ / bare RN 0.72+. | [packages/react-native/README.md](./packages/react-native/README.md) |
+| Package                                                      | Description                                                                                                                              | API reference                                                        |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`@tatlacas/brevwick-sdk`](./packages/sdk)                   | Framework-agnostic core: submit, screenshot, rings.                                                                                      | [packages/sdk/README.md](./packages/sdk/README.md)                   |
+| [`@tatlacas/brevwick-react`](./packages/react)               | Provider, floating FAB widget, and `useFeedback` hook for React 18+/19.                                                                  | [packages/react/README.md](./packages/react/README.md)               |
+| [`@tatlacas/brevwick-solid`](./packages/solid)               | Provider, floating FAB widget, and `useFeedback` hook for Solid 1.8+.                                                                    | [packages/solid/README.md](./packages/solid/README.md)               |
+| [`@tatlacas/brevwick-vue`](./packages/vue)                   | Plugin, floating FAB component, and `useFeedback` composable for Vue 3.4+.                                                               | [packages/vue/README.md](./packages/vue/README.md)                   |
+| [`@tatlacas/brevwick-svelte`](./packages/svelte)             | Context setter, FAB, and `getFeedback()` for Svelte 5 and SvelteKit.                                                                     | [packages/svelte/README.md](./packages/svelte/README.md)             |
+| [`@tatlacas/brevwick-angular`](./packages/angular)           | `provideBrevwick`, `BrevwickService`, and `bw-feedback-button` standalone component for Angular 17+.                                     | [packages/angular/README.md](./packages/angular/README.md)           |
+| [`@tatlacas/brevwick-react-native`](./packages/react-native) | Provider, drop-in feedback launcher, `useFeedback` hook, route-ring helper, and native screenshot path for Expo SDK 51+ / bare RN 0.72+. | [packages/react-native/README.md](./packages/react-native/README.md) |
 
 ## Install
 
@@ -52,6 +52,8 @@ Works with `pnpm add`, `yarn add`, `bun add` — same package names.
 
 ## Quick start
 
+> **Launcher default changed:** the feedback launcher now renders as a vertical tab flush against the right viewport edge (vertically centered) instead of the old bottom-corner bubble. Every adapter accepts `variant: 'bubble' | 'tab'`, `position` (edge sides `'right' | 'left'` plus the legacy corners), `compact` for an icon-only launcher, and `offset` to nudge the tab from vertical center. **Migrating?** Pass `position="bottom-right"` (or your previous corner) to keep the old look — a legacy corner without an explicit `variant` still renders the bubble.
+
 ### React
 
 ```tsx
@@ -67,7 +69,7 @@ export default function App() {
 }
 ```
 
-That's it. A floating action button appears in the bottom-right; clicking it opens a feedback dialog with file attachments and your project's AI formatting (if enabled).
+That's it. A vertical feedback tab appears on the right edge of the viewport; clicking it opens a feedback dialog with file attachments and your project's AI formatting (if enabled).
 
 Full API and theming → [packages/react/README.md](./packages/react/README.md).
 
@@ -168,7 +170,7 @@ export default function App() {
 }
 ```
 
-Build a custom feedback UI with `useFeedback()` (the drop-in `<FeedbackButton />` lands with #88) and wire the React Navigation route ring by rendering `useRouteRing()` inside the provider.
+Drop `<FeedbackButton />` inside the provider for the launcher + modal form (right-edge tab by default, same `variant` / `position` / `compact` / `offset` API as the web adapters, plus an RN-only `{ bottom?, right?, left? }` position form), or build a custom feedback UI with `useFeedback()`. Wire the React Navigation route ring by rendering `useRouteRing()` inside the provider.
 
 Full API → [packages/react-native/README.md](./packages/react-native/README.md).
 

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -10,7 +10,7 @@ pnpm --filter @tatlacas/brevwick-sdk --filter @tatlacas/brevwick-angular build
 pnpm --filter brevwick-example-angular start
 ```
 
-Open http://localhost:4200. The Feedback FAB pins to the bottom-right.
+Open http://localhost:4200. The Feedback launcher renders as a vertical tab on the right edge (pass `position="bottom-right"` for the legacy corner bubble).
 
 ## Configure your project key
 

--- a/examples/astro/src/components/BrevwickIsland.tsx
+++ b/examples/astro/src/components/BrevwickIsland.tsx
@@ -22,7 +22,9 @@ export function BrevwickIsland(): ReactElement | null {
   if (!keyIsReady) return null;
   return (
     <BrevwickProvider config={config}>
-      <FeedbackButton position="bottom-right" />
+      {/* Right-edge tab by default; pass position="bottom-right" to keep
+          the legacy corner bubble. */}
+      <FeedbackButton />
     </BrevwickProvider>
   );
 }

--- a/examples/cra/src/configured-widget.tsx
+++ b/examples/cra/src/configured-widget.tsx
@@ -25,7 +25,9 @@ export function ConfiguredWidget({
   return (
     <BrevwickErrorBoundary>
       <BrevwickProvider config={config}>
-        <FeedbackButton position="bottom-right" />
+        {/* Right-edge tab by default; pass position="bottom-right" to keep
+            the legacy corner bubble. */}
+        <FeedbackButton />
       </BrevwickProvider>
     </BrevwickErrorBoundary>
   );

--- a/examples/next/src/app/configured-widget.tsx
+++ b/examples/next/src/app/configured-widget.tsx
@@ -32,7 +32,9 @@ export function ConfiguredWidget({
   return (
     <BrevwickErrorBoundary>
       <BrevwickProvider config={config}>
-        <FeedbackButton position="bottom-right" />
+        {/* Right-edge tab by default; pass position="bottom-right" to keep
+            the legacy corner bubble. */}
+        <FeedbackButton />
       </BrevwickProvider>
     </BrevwickErrorBoundary>
   );

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -64,9 +64,10 @@ else stays server-side and is `undefined` at runtime.
   network, route via stack push), the fourth opens the feedback FAB.
 - `Details` is a trivial second screen that exists so the route ring
   records `Home → Details → Home` transitions.
-- The floating <kbd>Feedback</kbd> button at the bottom-right opens a
-  modal, calls `useFeedback().submit({ description })`, and surfaces the
-  staged success / error states inline.
+- The vertical <kbd>Feedback</kbd> tab on the right edge (the launcher's
+  new default; pass `position="bottom-right"` for the legacy corner
+  bubble) opens a modal, calls `useFeedback().submit({ description })`,
+  and surfaces the staged success / error states inline.
 
 ## Why `@types/react@19` with React 18.2 runtime?
 

--- a/examples/remix/app/configured-widget.tsx
+++ b/examples/remix/app/configured-widget.tsx
@@ -78,7 +78,9 @@ function ConfiguredProvider({
   return (
     <BrevwickProvider config={config}>
       {children}
-      <FeedbackButton position="bottom-right" />
+      {/* Right-edge tab by default; pass position="bottom-right" to keep
+          the legacy corner bubble. */}
+      <FeedbackButton />
     </BrevwickProvider>
   );
 }

--- a/examples/solid/src/configured-widget.tsx
+++ b/examples/solid/src/configured-widget.tsx
@@ -61,7 +61,9 @@ export const ConfiguredWidget: Component = () => {
         )}
       >
         <BrevwickProvider config={config}>
-          <FeedbackButton position="bottom-right" />
+          {/* Right-edge tab by default; pass position="bottom-right" to
+              keep the legacy corner bubble. */}
+          <FeedbackButton />
         </BrevwickProvider>
       </ErrorBoundary>
     </Show>

--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -13,7 +13,7 @@ cp examples/svelte/.env.example examples/svelte/.env
 pnpm --filter brevwick-example-svelte dev
 ```
 
-Open http://localhost:5173 — the floating Feedback FAB is bottom-right.
+Open http://localhost:5173 — the vertical Feedback tab sits on the right edge (pass `position="bottom-right"` for the legacy corner bubble).
 
 ## Files
 

--- a/examples/vite-react/src/configured-widget.tsx
+++ b/examples/vite-react/src/configured-widget.tsx
@@ -29,7 +29,9 @@ export function ConfiguredWidget({
   return (
     <BrevwickErrorBoundary>
       <BrevwickProvider config={config}>
-        <FeedbackButton position="bottom-right" />
+        {/* Right-edge tab by default; pass position="bottom-right" to keep
+            the legacy corner bubble. */}
+        <FeedbackButton />
       </BrevwickProvider>
     </BrevwickErrorBoundary>
   );

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -11,7 +11,7 @@ cp .env.example .env.local        # then seed your real pk_test_* key
 pnpm --filter brevwick-example-vue dev
 ```
 
-Open http://localhost:3001 — the FAB renders bottom-right. Click it, type a description, optionally capture a screenshot, hit **Send**.
+Open http://localhost:3001 — the launcher renders as a vertical tab on the right edge (pass `position="bottom-right"` for the legacy corner bubble). Click it, type a description, optionally capture a screenshot, hit **Send**.
 
 ## Env vars
 

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -41,6 +41,8 @@ defineProps<{ configError: ConfigError }>();
         instance) in <code>.env.local</code>.
       </p>
     </section>
-    <FeedbackButton v-if="configError === null" position="bottom-right" />
+    <!-- Right-edge tab by default; pass position="bottom-right" to keep
+         the legacy corner bubble. -->
+    <FeedbackButton v-if="configError === null" />
   </main>
 </template>

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -107,23 +107,36 @@ Single instance per Angular app. SSR-safe via `inject(PLATFORM_ID)` + `isPlatfor
 
 ### `<bw-feedback-button>` (`BwFeedbackButtonComponent`)
 
-Standalone component — import it directly into any `@Component({ standalone: true, imports: [BwFeedbackButtonComponent] })`. Renders a FAB plus a minimal text-only panel (textarea + send button); the component does not capture screenshots — apps that need that fidelity wrap `BrevwickService.captureScreenshot()` themselves and pass the resulting `Blob` through `submit()`'s `attachments` field. Submission goes through `BrevwickService` automatically.
+Standalone component — import it directly into any `@Component({ standalone: true, imports: [BwFeedbackButtonComponent] })`. Renders a launcher (a vertical tab on the right viewport edge by default; a floating corner bubble via `variant="bubble"`) plus a minimal text-only panel (textarea + send button); the component does not capture screenshots — apps that need that fidelity wrap `BrevwickService.captureScreenshot()` themselves and pass the resulting `Blob` through `submit()`'s `attachments` field. Submission goes through `BrevwickService` automatically.
 
 ```ts
+// Default: vertical tab on the right edge, vertically centered.
 <bw-feedback-button
-  position="bottom-right"
   label="Report a bug"
   (submit)="onResult($event)"
 />
+
+// Legacy floating corner bubble.
+<bw-feedback-button variant="bubble" position="bottom-right" />
+
+// Icon-only tab, nudged 120px above the vertical center. The label
+// becomes the launcher's aria-label.
+<bw-feedback-button [compact]="true" [offset]="-120" label="Report a bug" />
 ```
 
-| Input / Output | Type                              | Default          | Description                                           |
-| -------------- | --------------------------------- | ---------------- | ----------------------------------------------------- |
-| `position`     | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Which corner the FAB pins to.                         |
-| `disabled`     | `boolean`                         | `false`          | FAB renders as disabled and cannot open the panel.    |
-| `hidden`       | `boolean`                         | `false`          | Component renders nothing — useful for feature flags. |
-| `label`        | `string`                          | `'Feedback'`     | FAB label.                                            |
-| `(submit)`     | `EventEmitter<SubmitResult>`      | —                | Fired after every submit (success or failure).        |
+> **Migration:** the default presentation changed from the corner bubble to the right-edge tab. Pass `position="bottom-right"` (or your previous corner) to keep the old look — a legacy corner `position` without an explicit `variant` still renders the bubble, so existing call sites are unaffected.
+
+| Input / Output | Type                                                   | Default                                     | Description                                                                                                                                                                          |
+| -------------- | ------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`      | `'tab' \| 'bubble'`                                    | `'tab'`                                     | Launcher presentation — vertical edge tab (the new default) or the legacy floating corner pill. A legacy corner `position` without an explicit `variant` implies `'bubble'`.         |
+| `position`     | `'right' \| 'left' \| 'bottom-right' \| 'bottom-left'` | `'right'` (tab) / `'bottom-right'` (bubble) | Where the launcher sits. Edge sides are the tab's home, corners the bubble's. When `variant` and `position` disagree, `variant` wins and `position` contributes its horizontal side. |
+| `compact`      | `boolean`                                              | `false`                                     | Icon-only launcher (circular bubble / square edge tab). The `label` is not rendered but becomes the launcher's `aria-label`.                                                         |
+| `offset`       | `number`                                               | `0`                                         | Tab only: vertical offset in px from the viewport's vertical center. Positive moves the tab down, negative up. Ignored for the bubble.                                               |
+| `disabled`     | `boolean`                                              | `false`                                     | Launcher renders as disabled and cannot open the panel.                                                                                                                              |
+| `hidden`       | `boolean`                                              | `false`                                     | Component renders nothing — useful for feature flags.                                                                                                                                |
+| `label`        | `string`                                               | `'Feedback'`                                | Launcher label. Hidden visually when `compact`.                                                                                                                                      |
+| `theme`        | `'system' \| 'light' \| 'dark'`                        | `'system'`                                  | Force a palette regardless of OS `prefers-color-scheme`.                                                                                                                             |
+| `(submit)`     | `EventEmitter<SubmitResult>`                           | —                                           | Fired after every submit (success or failure).                                                                                                                                       |
 
 > The Angular component is a deliberately lean baseline. The full chat-style panel — multi-screenshot, region-select capture, AI toggle, etc. — currently lives in `@tatlacas/brevwick-react`. Apps that need that fidelity in Angular today should wrap `BrevwickService` with their own component using whichever Angular UI library they already use.
 

--- a/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
+++ b/packages/angular/src/lib/__tests__/feedback-button.component.spec.ts
@@ -102,6 +102,12 @@ describe('BwFeedbackButtonComponent', () => {
     ) as HTMLButtonElement | null;
     expect(button).not.toBeNull();
     expect(button?.textContent?.trim()).toContain('Feedback');
+    expect(button?.getAttribute('data-brevwick-skip')).not.toBeNull();
+    // Zero-config default changed in vNEXT: right-edge vertical tab, not
+    // the legacy bottom-right bubble.
+    expect(button?.classList.contains('brw-fab--tab')).toBe(true);
+    expect(button?.classList.contains('brw-fab-r')).toBe(true);
+    expect(button?.getAttribute('data-brw-variant')).toBe('tab');
   });
 
   it('renders nothing when [hidden] is set', () => {
@@ -1162,6 +1168,182 @@ describe('BwFeedbackButtonComponent', () => {
     fab.click();
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.brw-panel')).toBeNull();
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner without a
+ * variant keeps the bubble. The zero-config default — right-edge tab —
+ * is asserted in the main describe block above.
+ */
+describe('BwFeedbackButtonComponent — launcher presentation (variant + position)', () => {
+  interface PresentationInputs {
+    variant?: 'bubble' | 'tab';
+    position?: 'right' | 'left' | 'bottom-right' | 'bottom-left';
+    compact?: boolean;
+    offset?: number;
+    label?: string;
+  }
+
+  const mountFab = (inputs: PresentationInputs = {}) => {
+    TestBed.configureTestingModule({
+      imports: [BwFeedbackButtonComponent],
+      providers: [provideBrevwick({ projectKey: 'pk_test_presentation' })],
+    });
+    const fixture = TestBed.createComponent(BwFeedbackButtonComponent);
+    for (const [key, value] of Object.entries(inputs)) {
+      fixture.componentRef.setInput(key, value);
+    }
+    fixture.detectChanges();
+    const fab = fixture.nativeElement.querySelector(
+      'button.brw-fab',
+    ) as HTMLButtonElement;
+    return { fixture, fab };
+  };
+
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', () => {
+    // Legacy compat: an explicit corner without a `variant` must keep the
+    // pre-vNEXT presentation — the bubble at that corner, not a tab.
+    const { fixture, fab } = mountFab({ position: 'bottom-left' });
+    expect(fab.classList.contains('brw-fab--bubble')).toBe(true);
+    expect(fab.classList.contains('brw-fab-bl')).toBe(true);
+    expect(fab.classList.contains('brw-fab-br')).toBe(false);
+    expect(fab.getAttribute('data-brw-variant')).toBe('bubble');
+    fab.click();
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.brw-panel') as Element;
+    expect(panel.classList.contains('brw-panel-bl')).toBe(true);
+    expect(panel.classList.contains('brw-panel-br')).toBe(false);
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', () => {
+    const { fixture, fab } = mountFab({ position: 'bottom-right' });
+    expect(fab.classList.contains('brw-fab--bubble')).toBe(true);
+    expect(fab.classList.contains('brw-fab-br')).toBe(true);
+    expect(fab.classList.contains('brw-fab-bl')).toBe(false);
+    expect(fab.getAttribute('data-brw-variant')).toBe('bubble');
+    fab.click();
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.brw-panel') as Element;
+    expect(panel.classList.contains('brw-panel-br')).toBe(true);
+  });
+
+  it('variant="bubble" without a position renders the bottom-right bubble', () => {
+    const { fab } = mountFab({ variant: 'bubble' });
+    expect(fab.classList.contains('brw-fab--bubble')).toBe(true);
+    expect(fab.classList.contains('brw-fab-br')).toBe(true);
+    expect(fab.getAttribute('data-brw-variant')).toBe('bubble');
+  });
+
+  it('position="left" renders the tab on the left edge', () => {
+    const { fab } = mountFab({ position: 'left' });
+    expect(fab.classList.contains('brw-fab--tab')).toBe(true);
+    expect(fab.classList.contains('brw-fab-l')).toBe(true);
+    expect(fab.getAttribute('data-brw-variant')).toBe('tab');
+  });
+
+  it('position="right" renders the tab on the right edge', () => {
+    const { fab } = mountFab({ position: 'right' });
+    expect(fab.classList.contains('brw-fab--tab')).toBe(true);
+    expect(fab.classList.contains('brw-fab-r')).toBe(true);
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    const { fab } = mountFab({ variant: 'tab', position: 'bottom-left' });
+    expect(fab.classList.contains('brw-fab--tab')).toBe(true);
+    expect(fab.classList.contains('brw-fab-l')).toBe(true);
+    expect(fab.classList.contains('brw-fab-bl')).toBe(false);
+  });
+
+  it('variant="tab" + position="bottom-right" resolves to the right-edge tab', () => {
+    const { fab } = mountFab({ variant: 'tab', position: 'bottom-right' });
+    expect(fab.classList.contains('brw-fab--tab')).toBe(true);
+    expect(fab.classList.contains('brw-fab-r')).toBe(true);
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', () => {
+    const { fab } = mountFab({ variant: 'bubble', position: 'left' });
+    expect(fab.classList.contains('brw-fab--bubble')).toBe(true);
+    expect(fab.classList.contains('brw-fab-bl')).toBe(true);
+  });
+
+  it('variant="bubble" + position="right" renders the bubble at the bottom-right corner', () => {
+    const { fab } = mountFab({ variant: 'bubble', position: 'right' });
+    expect(fab.classList.contains('brw-fab--bubble')).toBe(true);
+    expect(fab.classList.contains('brw-fab-br')).toBe(true);
+  });
+
+  it('left-edge tab opens the panel anchored bottom-left', () => {
+    const { fixture, fab } = mountFab({ position: 'left' });
+    fab.click();
+    fixture.detectChanges();
+    const panel = fixture.nativeElement.querySelector('.brw-panel') as Element;
+    expect(panel.classList.contains('brw-panel-bl')).toBe(true);
+    expect(panel.classList.contains('brw-panel-br')).toBe(false);
+  });
+
+  it('compact drops the visible label and promotes the label to aria-label', () => {
+    const { fixture, fab } = mountFab({
+      compact: true,
+      label: 'Report a bug',
+    });
+    expect(fab.classList.contains('brw-fab--compact')).toBe(true);
+    // The label text must not render — compact is icon-only.
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+    expect(fab.textContent?.trim()).toBe('');
+    expect(fab.getAttribute('aria-label')).toBe('Report a bug');
+    void fixture;
+  });
+
+  it('compact with the default label falls back to aria-label="Feedback"', () => {
+    const { fab } = mountFab({ compact: true });
+    expect(fab.getAttribute('aria-label')).toBe('Feedback');
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+  });
+
+  it('non-compact keeps aria-label="Open feedback form" and the visible label span', () => {
+    const { fab } = mountFab({ label: 'Report a bug' });
+    expect(fab.getAttribute('aria-label')).toBe('Open feedback form');
+    const labelSpan = fab.querySelector('.brw-fab-label');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan?.textContent).toBe('Report a bug');
+  });
+
+  it('offset sets --brw-fab-tab-offset inline on the tab only when non-zero', () => {
+    const { fab } = mountFab({ offset: 120 });
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('120px');
+  });
+
+  it('offset=0 sets no inline custom property on the tab', () => {
+    const { fab } = mountFab({ offset: 0 });
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('offset is ignored for the bubble (no inline custom property)', () => {
+    const { fab } = mountFab({ variant: 'bubble', offset: 120 });
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('emitted stylesheet declares the vertical tab + keeps the launcher chrome contract', () => {
+    // ViewEncapsulation.None — the component's stylesheet is injected into
+    // document.head verbatim when the component renders.
+    mountFab();
+    const css = Array.from(document.head.querySelectorAll('style'))
+      .map((style) => style.textContent ?? '')
+      .join('\n');
+    // Tab geometry: writing-mode flips the inline axis vertical.
+    expect(css).toMatch(/\.brw-fab--tab\s*\{[^}]*writing-mode:\s*vertical-rl/);
+    // Shared launcher chrome keeps the max-ish stacking contract.
+    expect(css).toMatch(/\.brw-fab\s*\{[^}]*z-index:\s*2147483000/);
+    // Bubble keeps the legacy pill geometry under its own class.
+    expect(css).toMatch(/\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/);
+    // Reduced-motion still disables the launcher transition for both variants.
+    expect(css).toMatch(
+      /prefers-reduced-motion[\s\S]*?\.brw-fab\s*\{[^}]*transition:\s*none/,
+    );
   });
 });
 

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -28,9 +28,40 @@ import { BrevwickService, type FeedbackPhase } from '../brevwick.service';
 import { BREVWICK_ANGULAR_VERSION } from '../internal/version';
 
 /**
- * Pin corner for the FAB. Mirrors the React adapter's `FeedbackButtonProps.position`.
+ * Launcher presentation: `'tab'` (new default, vertical edge button) or
+ * `'bubble'` (legacy corner pill). Mirrors the React adapter.
  */
-export type BwFeedbackButtonPosition = 'bottom-right' | 'bottom-left';
+export type BwFeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement. `'right' | 'left'` are edge sides (tab); the legacy
+ * corners are the bubble's home — passing one WITHOUT an explicit `variant`
+ * opts into the bubble, preserving pre-2.x call sites. Mirrors React.
+ */
+export type BwFeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — single source of truth shared by the FAB
+ * class derivation and the panel anchor (mirrored in every adapter).
+ * Explicit `variant` wins and `position` then only contributes its
+ * horizontal side; with `variant` unset, a legacy corner implies the
+ * bubble, everything else is the tab. Total — no throws, no dead states.
+ */
+function resolveLauncherPlacement(
+  variant?: BwFeedbackButtonVariant,
+  position?: BwFeedbackButtonPosition,
+): { variant: BwFeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}
 
 /**
  * Forced-palette choice. `'system'` defers to the OS-level
@@ -40,26 +71,21 @@ export type BwFeedbackButtonPosition = 'bottom-right' | 'bottom-left';
 export type BwFeedbackButtonTheme = 'light' | 'dark' | 'system';
 
 /**
- * Combined screenshot + file cap. Mirrored from the SDK's `MAX_ATTACHMENT_COUNT`
- * in `packages/sdk/src/submit.ts`. Enforced in the UI by disabling the
- * file-attach button once the combined total reaches this ceiling — that way
- * the user cannot queue an attachment the SDK would reject downstream.
+ * Combined screenshot + file cap. Mirrored from the SDK's
+ * `MAX_ATTACHMENT_COUNT` in `packages/sdk/src/submit.ts`; enforced in the
+ * UI by disabling the file-attach button at the ceiling.
  */
 const MAX_ATTACHMENTS = 5;
 
 /**
- * Maximum autogrow height of the composer textarea in pixels. Single source
- * of truth for both the JS effect (sets `style.height` against `scrollHeight`
- * bounded by this) and the CSS `max-height` rule.
+ * Max autogrow height of the composer textarea (px). Single source of
+ * truth for the JS effect and the CSS `max-height` rule.
  */
 const COMPOSER_MAX_HEIGHT_PX = 120;
 
 /**
- * Stagger between staged-status rows in milliseconds. Applied as
- * `style.animationDelay` per row (the rows mount with a CSS @keyframes
- * entrance, not a transition) so rows fade in sequentially even when
- * the underlying SDK phase events fire microseconds apart on a healthy
- * happy path. Honoured only when the user has not requested reduced motion.
+ * Per-row `animation-delay` stagger (ms) so the staged-status rows fade in
+ * sequentially; skipped under prefers-reduced-motion.
  */
 const STATUS_ROW_STAGGER_MS = 200;
 
@@ -78,10 +104,8 @@ interface Message {
   readonly issueSent?: boolean;
   readonly sentAt?: number;
   /**
-   * The exact, post-redaction payload the SDK POSTed for this message — set
-   * only when the host enabled `config.debug`. When present, the bubble
-   * renders a "copy raw payload" affordance so a developer can inspect
-   * everything that left the device (rings/context the widget never shows).
+   * Exact post-redaction payload the SDK POSTed — set only under
+   * `config.debug`; renders a "copy raw payload" affordance.
    */
   readonly rawPayload?: Record<string, unknown>;
 }
@@ -176,12 +200,25 @@ function formatSize(bytes: number): string {
       <button
         type="button"
         class="brw-root brw-fab"
-        [class.brw-fab-bl]="position === 'bottom-left'"
-        [class.brw-fab-br]="position !== 'bottom-left'"
+        [class.brw-fab--tab]="launcherVariant === 'tab'"
+        [class.brw-fab--bubble]="launcherVariant === 'bubble'"
+        [class.brw-fab-r]="
+          launcherVariant === 'tab' && launcherSide === 'right'
+        "
+        [class.brw-fab-l]="launcherVariant === 'tab' && launcherSide === 'left'"
+        [class.brw-fab-br]="
+          launcherVariant === 'bubble' && launcherSide === 'right'
+        "
+        [class.brw-fab-bl]="
+          launcherVariant === 'bubble' && launcherSide === 'left'
+        "
+        [class.brw-fab--compact]="compact"
         [attr.data-brevwick-skip]="''"
         [attr.data-brw-theme]="theme"
+        [attr.data-brw-variant]="launcherVariant"
+        [style.--brw-fab-tab-offset.px]="tabOffset"
         [disabled]="disabled || isSubmitting()"
-        aria-label="Open feedback form"
+        [attr.aria-label]="ariaLabel"
         (click)="toggle()"
       >
         <svg
@@ -196,14 +233,16 @@ function formatSize(bytes: number): string {
         >
           <path d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z" />
         </svg>
-        {{ label }}
+        @if (!compact) {
+          <span class="brw-fab-label">{{ label }}</span>
+        }
       </button>
 
       @if (open()) {
         <div
           class="brw-root brw-panel"
-          [class.brw-panel-bl]="position === 'bottom-left'"
-          [class.brw-panel-br]="position !== 'bottom-left'"
+          [class.brw-panel-bl]="launcherSide === 'left'"
+          [class.brw-panel-br]="launcherSide !== 'left'"
           role="dialog"
           aria-label="Send feedback"
           [attr.data-brevwick-skip]="''"
@@ -659,14 +698,10 @@ function formatSize(bytes: number): string {
           'Helvetica Neue', Arial, sans-serif;
         color: var(--brw-fg, var(--brw-fg-base));
       }
+      /* Shared launcher chrome — variant-independent. */
       .brw-fab {
         position: fixed;
         z-index: 2147483000;
-        bottom: 24px;
-        height: 48px;
-        min-width: 48px;
-        padding: 0 18px;
-        border-radius: 999px;
         border: 1px solid var(--brw-border, var(--brw-border-base));
         background: var(--brw-accent, var(--brw-accent-base));
         color: var(--brw-accent-fg, var(--brw-accent-fg-base));
@@ -677,24 +712,90 @@ function formatSize(bytes: number): string {
         gap: 8px;
         cursor: pointer;
         box-shadow: var(--brw-shadow, var(--brw-shadow-base));
+        /* Only transform animates; box-shadow intentionally static. */
         transition: transform 120ms ease-out;
-      }
-      .brw-fab:hover:not(:disabled) {
-        transform: translateY(-1px);
       }
       .brw-fab:disabled {
         cursor: not-allowed;
         opacity: 0.5;
       }
-      .brw-fab-br {
-        right: 24px;
-      }
-      .brw-fab-bl {
-        left: 24px;
+      .brw-fab:focus-visible {
+        outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+        outline-offset: 2px;
       }
       .brw-fab-icon {
         width: 18px;
         height: 18px;
+        flex-shrink: 0;
+      }
+      /* ── Bubble (legacy corner pill) ───────────────────────────────────── */
+      .brw-fab--bubble {
+        bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+        height: 48px;
+        min-width: 48px;
+        padding: 0 18px;
+        border-radius: 999px;
+      }
+      .brw-fab--bubble:hover:not(:disabled) {
+        transform: translateY(-1px);
+      }
+      .brw-fab-br {
+        right: calc(24px + env(safe-area-inset-right, 0px));
+      }
+      .brw-fab-bl {
+        left: calc(24px + env(safe-area-inset-left, 0px));
+      }
+      /* Compact bubble: 48px circle, icon only. */
+      .brw-fab--bubble.brw-fab--compact {
+        width: 48px;
+        min-width: 48px;
+        padding: 0;
+        justify-content: center;
+      }
+      /* ── Tab (NEW DEFAULT: vertical edge tab) ──────────────────────────── */
+      /* writing-mode flips the inline axis vertical: the flex row (icon,
+         label) stacks top→bottom and the label glyphs read top→bottom,
+         rotated 90° cw. The left tab adds \`rotate: 180deg\` (the standalone
+         property, NOT transform, so it composes with the hover translateX)
+         — flat edge stays against the viewport edge, radii mirror
+         automatically, and the label reads bottom→top, Userback-style. */
+      .brw-fab--tab {
+        top: calc(50% + var(--brw-fab-tab-offset, 0px));
+        transform: translateY(-50%);
+        writing-mode: vertical-rl;
+        min-height: 48px;
+        width: 40px;
+        padding: 16px 0;
+        justify-content: center;
+        /* Rounded on the page-facing side, flat against the edge (right-tab
+           orientation; the left tab's rotate mirrors it). */
+        border-radius: 10px 0 0 10px;
+      }
+      .brw-fab-r {
+        right: env(safe-area-inset-right, 0px);
+        /* flat edge: no hairline against the viewport */
+        border-right: none;
+      }
+      .brw-fab-l {
+        left: env(safe-area-inset-left, 0px);
+        /* pre-rotation right edge IS the viewport edge */
+        border-right: none;
+        rotate: 180deg;
+      }
+      /* Hover pulls the tab 2px out of the edge (translateY(-50%) must be
+         restated — transform is overwritten, not merged). For .brw-fab-l the
+         180° rotate flips -2px into +2px visually: also away from its edge. */
+      .brw-fab--tab:hover:not(:disabled) {
+        transform: translateY(-50%) translateX(-2px);
+      }
+      .brw-fab-label {
+        letter-spacing: 0.02em;
+      }
+      /* Compact tab: square-ish icon-only edge chip. */
+      .brw-fab--tab.brw-fab--compact {
+        width: 44px;
+        min-height: 44px;
+        padding: 0;
       }
       .brw-panel {
         position: fixed;
@@ -1269,13 +1370,34 @@ function formatSize(bytes: number): string {
   ],
 })
 export class BwFeedbackButtonComponent {
-  /** Corner the FAB pins to. Default `'bottom-right'`. */
-  @Input() position: BwFeedbackButtonPosition = 'bottom-right';
-  /** When true, the FAB renders as disabled and cannot open the panel. */
+  /**
+   * Launcher presentation. Default `'tab'` (new default). Intentionally no
+   * eager default — the corner-implies-bubble compat rule in
+   * `resolveLauncherPlacement` needs to see "unset".
+   */
+  @Input() variant?: BwFeedbackButtonVariant;
+  /**
+   * Launcher placement. Defaults: `'right'` (tab), `'bottom-right'`
+   * (bubble). A legacy corner without an explicit `variant` keeps the
+   * bubble; when both are set, `variant` wins and `position` contributes
+   * only its horizontal side.
+   */
+  @Input() position?: BwFeedbackButtonPosition;
+  /**
+   * Icon-only mode (circular bubble / square edge tab). The `label` is not
+   * rendered but becomes the `aria-label`. Default `false`.
+   */
+  @Input() compact = false;
+  /**
+   * Tab-only: vertical offset in px from the viewport's vertical center
+   * (positive = down). Ignored for the bubble. Default `0`.
+   */
+  @Input() offset = 0;
+  /** When true, the launcher renders as disabled and cannot open the panel. */
   @Input() disabled = false;
   /** When true, the component renders nothing. Useful for feature-flagging. */
   @Input() hidden = false;
-  /** FAB label. Default `'Feedback'`. */
+  /** Launcher label. Default `'Feedback'`. Hidden visually when `compact`. */
   @Input() label = 'Feedback';
   /**
    * Forced palette. `'system'` defers to the OS-level `prefers-color-scheme`
@@ -1289,6 +1411,38 @@ export class BwFeedbackButtonComponent {
    * failure). Mirrors React adapter's `onSubmit` prop.
    */
   @Output() submit = new EventEmitter<SubmitResult>();
+
+  // Launcher presentation. Plain getters (not signals): classic @Input
+  // fields re-derive every change-detection pass — cheap and OnPush-safe.
+
+  /** Resolved presentation: `'tab'` (new default) or `'bubble'` (legacy). */
+  protected get launcherVariant(): BwFeedbackButtonVariant {
+    return resolveLauncherPlacement(this.variant, this.position).variant;
+  }
+
+  /** Resolved horizontal side — also anchors the panel (`brw-panel-bl/br`). */
+  protected get launcherSide(): 'right' | 'left' {
+    return resolveLauncherPlacement(this.variant, this.position).side;
+  }
+
+  /**
+   * Compact removes the visible text, so `label` becomes the aria-label;
+   * non-compact keeps the established accessible name.
+   */
+  protected get ariaLabel(): string {
+    return this.compact ? this.label : 'Open feedback form';
+  }
+
+  /**
+   * Inline `--brw-fab-tab-offset` value — a positioning input, not part of
+   * the public `--brw-*` theming contract. Set only when it has an effect;
+   * `null` removes the binding entirely.
+   */
+  protected get tabOffset(): number | null {
+    return this.launcherVariant === 'tab' && this.offset !== 0
+      ? this.offset
+      : null;
+  }
 
   protected readonly version = BREVWICK_ANGULAR_VERSION;
   private static idSeq = 0;

--- a/packages/angular/src/lib/components/feedback-button.component.ts
+++ b/packages/angular/src/lib/components/feedback-button.component.ts
@@ -24,6 +24,7 @@ import type {
   SubmitError,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
+import { resolveLauncherPlacement } from '@tatlacas/brevwick-sdk/launcher';
 import { BrevwickService, type FeedbackPhase } from '../brevwick.service';
 import { BREVWICK_ANGULAR_VERSION } from '../internal/version';
 
@@ -45,23 +46,11 @@ export type BwFeedbackButtonPosition =
   | 'bottom-left';
 
 /**
- * Resolved launcher placement — single source of truth shared by the FAB
- * class derivation and the panel anchor (mirrored in every adapter).
- * Explicit `variant` wins and `position` then only contributes its
- * horizontal side; with `variant` unset, a legacy corner implies the
- * bubble, everything else is the tab. Total — no throws, no dead states.
+ * The variant/position resolution table (`resolveLauncherPlacement`) is a
+ * pure, framework-agnostic function shared by every adapter, so it lives in
+ * `@tatlacas/brevwick-sdk/launcher` rather than being copied here. See the
+ * resolution semantics in that module (mirrored in SDD § 12).
  */
-function resolveLauncherPlacement(
-  variant?: BwFeedbackButtonVariant,
-  position?: BwFeedbackButtonPosition,
-): { variant: BwFeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner without a variant keeps the bubble.
-  const isCorner = position === 'bottom-right' || position === 'bottom-left';
-  return { variant: isCorner ? 'bubble' : 'tab', side };
-}
 
 /**
  * Forced-palette choice. `'system'` defers to the OS-level

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -13,6 +13,7 @@ export {
 export {
   BwFeedbackButtonComponent,
   type BwFeedbackButtonPosition,
+  type BwFeedbackButtonVariant,
 } from './lib/components/feedback-button.component';
 export { BREVWICK_ANGULAR_VERSION } from './lib/internal/version';
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,6 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 
 React Native bindings for [Brevwick](https://brevwick.dev) — a provider, a
+drop-in `<FeedbackButton />` launcher + modal feedback form, a
 `useFeedback` hook, a `useRouteRing` helper for React Navigation / Expo
 Router, a `BrevwickSkip` wrapper, and a native screenshot path that
 gracefully falls back to a placeholder when the optional
@@ -59,11 +60,11 @@ import {
 import { createStackNavigator } from '@react-navigation/stack';
 import {
   BrevwickProvider,
+  FeedbackButton,
   type BrevwickConfig,
 } from '@tatlacas/brevwick-react-native';
 import { Home } from './screens/Home';
 import { Details } from './screens/Details';
-import { FeedbackFab } from './FeedbackFab';
 
 const Stack = createStackNavigator();
 
@@ -85,11 +86,16 @@ export default function App() {
           <Stack.Screen name="Details" component={Details} />
         </Stack.Navigator>
       </NavigationContainer>
-      <FeedbackFab />
+      <FeedbackButton />
     </BrevwickProvider>
   );
 }
 ```
+
+`<FeedbackButton />` renders a vertical feedback tab flush against the
+right edge of the host view by default — see
+[`FeedbackButton`](#feedbackbutton) for the bubble variant, placement,
+and compact mode.
 
 End-to-end runnable app:
 [`examples/react-native`](https://github.com/tatlacas-com/brevwick-sdk-js/tree/main/examples/react-native).
@@ -148,12 +154,58 @@ outside the provider tree, pass an explicit ref:
 useRouteRing(navigationRef);
 ```
 
-The drop-in `<FeedbackButton />` (#88) will own this wiring once it lands.
+The drop-in `<FeedbackButton />` does not own this wiring — keep the
+bridge mounted alongside it when you want route breadcrumbs in submits.
 Under the hood the hook composes `attachRouteRing(navigationRef, push)`
 with a captured `Brevwick._internal.push` — the lockstep coupling that
 the SDK + adapters version together. Consumers should prefer the hook
 over reaching into `_internal` directly so the documented-private surface
 crosses the adapter boundary in exactly one place.
+
+## `FeedbackButton`
+
+Drop-in feedback launcher + modal feedback form. The launcher renders as
+a vertical tab flush against the right edge of the host view by default
+(vertically centered), or as the classic floating corner bubble via
+`variant="bubble"`. The label tracks the submit lifecycle
+(`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`).
+
+```tsx
+// Default: vertical tab on the right edge, vertically centered.
+<FeedbackButton />
+
+// Icon-only tab, nudged 120 logical px above the vertical center. The
+// label becomes the launcher's accessibilityLabel.
+<FeedbackButton compact offset={-120} label="Report a bug" />
+
+// Legacy floating corner bubble (24px inset), or with explicit offsets
+// to clear a tab bar / safe area — both imply the bubble:
+<FeedbackButton position="bottom-right" />
+<FeedbackButton position={{ bottom: 96, right: 16 }} />
+```
+
+> **Migration:** the default presentation changed from the corner bubble
+> to the right-edge tab. Pass `position="bottom-right"` (or your previous
+> corner / offset object) to keep the old look — a legacy corner or
+> offset-object `position` without an explicit `variant` still renders
+> the bubble, so existing call sites are unaffected.
+
+### Props
+
+| Prop       | Type                                                                                 | Default                                     | Description                                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`  | `'tab' \| 'bubble'`                                                                  | `'tab'`                                     | Launcher presentation — vertical edge tab (the new default) or the legacy floating corner pill. A legacy corner / offset-object `position` without an explicit `variant` implies `'bubble'`.                                   |
+| `position` | `'right' \| 'left' \| 'bottom-right' \| 'bottom-left' \| { bottom?, right?, left? }` | `'right'` (tab) / `'bottom-right'` (bubble) | Where the launcher sits. The offset-object form is RN-only (safe areas / tab bars have no DOM analogue) and applies to the bubble; when `variant` and `position` disagree, `variant` wins and `position` contributes its side. |
+| `compact`  | `boolean`                                                                            | `false`                                     | Icon-only launcher (circular bubble / square edge tab). The label — including the phase-tracking copy — is not rendered; `label` (or `'Feedback'`) becomes the `accessibilityLabel`.                                           |
+| `offset`   | `number`                                                                             | `0`                                         | Tab only: vertical offset in logical px from the host view's vertical center. Positive moves the tab down, negative up. Ignored for the bubble.                                                                                |
+| `label`    | `string`                                                                             | phase-driven                                | Label override. Default copy advances by submission phase, so most apps leave it unset. Hidden visually when `compact`.                                                                                                        |
+| `theme`    | `'system' \| 'light' \| 'dark'`                                                      | `'system'`                                  | Forced palette. `'system'` follows the host color scheme.                                                                                                                                                                      |
+| `style`    | `StyleProp<ViewStyle>`                                                               | —                                           | Style overrides applied last to the launcher Pressable, so consumer entries win.                                                                                                                                               |
+| `hidden`   | `boolean`                                                                            | `false`                                     | Renders nothing — useful for feature flags.                                                                                                                                                                                    |
+| `disabled` | `boolean`                                                                            | `false`                                     | Launcher renders disabled and cannot open the modal.                                                                                                                                                                           |
+
+Must be rendered inside `<BrevwickProvider>` — `useFeedback()` throws
+synchronously otherwise.
 
 ## `useFeedback`
 
@@ -276,11 +328,12 @@ so orientation / locale changes show up on the next submit.
 
 ## Theming
 
-A `theme` prop on the eventual `<FeedbackButton />` (lands with #88) will
-accept `'system' | 'light' | 'dark'` matching the React (web) widget. The
-underlying token surface (accent / panel / chip / border) is shared with
-`@tatlacas/brevwick-react`; until the RN button lands you control your
-own surface in custom UIs (see the `useFeedback` snippet above).
+The `theme` prop on `<FeedbackButton />` accepts
+`'system' | 'light' | 'dark'`, matching the React (web) widget —
+`'system'` (the default) follows the host's color scheme. The underlying
+token surface (accent / panel / chip / border) is shared with
+`@tatlacas/brevwick-react`; custom UIs built on `useFeedback` control
+their own surface (see the snippet above).
 
 ## Hiding sensitive content from screenshots
 

--- a/packages/react-native/src/__tests__/feedback-button.test.tsx
+++ b/packages/react-native/src/__tests__/feedback-button.test.tsx
@@ -9,7 +9,16 @@
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Linking, Modal, Pressable, Text, TextInput } from 'react-native';
+import {
+  Linking,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  type ViewStyle,
+} from 'react-native';
 import type {
   Brevwick,
   BrevwickConfig,
@@ -94,6 +103,7 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
 import { BrevwickProvider } from '../provider';
 import { FeedbackButton } from '../feedback-button';
 import { FeedbackModal } from '../feedback-modal';
+import { ChatIcon } from '../icons';
 
 // ---- Helpers ------------------------------------------------------------
 const renderTree = async (ui: ReactElement): Promise<ReactTestRenderer> => {
@@ -192,6 +202,16 @@ describe('FeedbackButton', () => {
       true,
     );
 
+    // Zero-config default changed in vNEXT: vertically-centered tab flush
+    // against the RIGHT edge of the host view, not the legacy bottom-right
+    // corner pill.
+    const computed = fab!.props.style({ pressed: false }) as ViewStyle;
+    expect(computed.top).toBe('50%');
+    expect(computed.right).toBe(0);
+    expect(computed.left).toBeUndefined();
+    expect(computed.bottom).toBeUndefined();
+    expect(computed.transform).toEqual([{ translateY: '-50%' }]);
+
     // Modal starts closed.
     const modal = renderer.root.findByType(Modal);
     expect(modal.props.visible).toBe(false);
@@ -230,7 +250,7 @@ describe('FeedbackButton', () => {
     expect(renderer.root.findAllByType(Pressable)).toHaveLength(0);
   });
 
-  it('honours an explicit `position` offset object', async () => {
+  it('honours an explicit `position` offset object (still the bubble)', async () => {
     const renderer = await renderTree(
       <FeedbackButton position={{ bottom: 80, left: 16 }} />,
     );
@@ -240,9 +260,14 @@ describe('FeedbackButton', () => {
     expect(computed.bottom).toBe(80);
     expect(computed.left).toBe(16);
     expect(computed.right).toBeUndefined();
+    // Legacy compat: the offset-object form without a `variant` keeps the
+    // pre-vNEXT bubble — no tab geometry rides along.
+    expect(computed.top).toBeUndefined();
+    expect(computed.transform).toBeUndefined();
+    expect(computed.borderRadius).toBe(24);
   });
 
-  it('pins the FAB to bottom-left when position="bottom-left"', async () => {
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', async () => {
     const renderer = await renderTree(
       <FeedbackButton position="bottom-left" />,
     );
@@ -253,6 +278,23 @@ describe('FeedbackButton', () => {
     expect(computed.bottom).toBe(24);
     expect(computed.left).toBe(24);
     expect(computed.right).toBeUndefined();
+    // An explicit corner without a `variant` must keep the pre-vNEXT
+    // presentation — the bubble at that corner, not a tab.
+    expect(computed.top).toBeUndefined();
+    expect(computed.transform).toBeUndefined();
+    expect(computed.borderRadius).toBe(24);
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton position="bottom-right" />,
+    );
+    const computed = findFab(renderer)!.props.style({ pressed: false });
+    expect(computed.bottom).toBe(24);
+    expect(computed.right).toBe(24);
+    expect(computed.left).toBeUndefined();
+    expect(computed.top).toBeUndefined();
+    expect(computed.borderRadius).toBe(24);
   });
 
   it('renders the dark scrim colour when theme="dark"', async () => {
@@ -276,6 +318,192 @@ describe('FeedbackButton', () => {
     );
     expect(darkScrimNodes.length).toBeGreaterThan(0);
     expect(modal.props.visible).toBe(true);
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner (or the
+ * RN-only offset object) without a variant keeps the bubble. The
+ * zero-config default — right-edge tab — is asserted in the main describe
+ * block above.
+ */
+describe('FeedbackButton — launcher presentation (variant + position)', () => {
+  const fabStyle = (renderer: ReactTestRenderer): ViewStyle =>
+    findFab(renderer)!.props.style({ pressed: false }) as ViewStyle;
+
+  // The tab's vertical label is the Text whose style carries a `rotate`
+  // transform entry; returns that rotation (or undefined when no rotated
+  // label is mounted — bubble / compact renders).
+  const labelRotation = (renderer: ReactTestRenderer): string | undefined => {
+    for (const t of findFab(renderer)!.findAllByType(Text)) {
+      const flat = StyleSheet.flatten(t.props.style) as {
+        transform?: readonly Record<string, unknown>[];
+      };
+      const entry = flat.transform?.find((e) => 'rotate' in e);
+      if (entry) return entry['rotate'] as string;
+    }
+    return undefined;
+  };
+
+  it('rotates the default right-edge tab label 90° (reads top→bottom) with page-side radii', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    expect(labelRotation(renderer)).toBe('90deg');
+    const computed = fabStyle(renderer);
+    // Rounded on the page-facing side, flat against the right edge —
+    // mirrors the web `.brw-fab--tab` one-sided `border-radius: 10px 0 0 10px`.
+    expect(computed.borderTopLeftRadius).toBe(10);
+    expect(computed.borderBottomLeftRadius).toBe(10);
+    expect(computed.borderTopRightRadius).toBeUndefined();
+    expect(computed.width).toBe(40);
+  });
+
+  it('position="left" renders the tab on the left edge with the mirrored rotation', async () => {
+    const renderer = await renderTree(<FeedbackButton position="left" />);
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.left).toBe(0);
+    expect(computed.right).toBeUndefined();
+    expect(computed.bottom).toBeUndefined();
+    // Label reads bottom→top on the left edge (Userback-style), and the
+    // radii mirror to the page-facing right side.
+    expect(labelRotation(renderer)).toBe('-90deg');
+    expect(computed.borderTopRightRadius).toBe(10);
+    expect(computed.borderBottomRightRadius).toBe(10);
+    expect(computed.borderTopLeftRadius).toBeUndefined();
+  });
+
+  it('position="right" renders the tab on the right edge', async () => {
+    const renderer = await renderTree(<FeedbackButton position="right" />);
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.right).toBe(0);
+    expect(computed.left).toBeUndefined();
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', async () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    const renderer = await renderTree(
+      <FeedbackButton variant="tab" position="bottom-left" />,
+    );
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.left).toBe(0);
+    expect(computed.bottom).toBeUndefined();
+    expect(computed.right).toBeUndefined();
+  });
+
+  it('variant="tab" + offset object takes only the horizontal side and drops the pixel values', async () => {
+    // RN-only corner of the conflict rule: the object's `left` (set
+    // without `right`) selects the left edge; its pixel values apply to
+    // the bubble only.
+    const renderer = await renderTree(
+      <FeedbackButton variant="tab" position={{ bottom: 80, left: 16 }} />,
+    );
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.left).toBe(0);
+    expect(computed.bottom).toBeUndefined();
+  });
+
+  it('variant="bubble" without a position renders the bottom-right bubble', async () => {
+    const renderer = await renderTree(<FeedbackButton variant="bubble" />);
+    const computed = fabStyle(renderer);
+    expect(computed.bottom).toBe(24);
+    expect(computed.right).toBe(24);
+    expect(computed.top).toBeUndefined();
+    expect(computed.transform).toBeUndefined();
+    expect(computed.borderRadius).toBe(24);
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton variant="bubble" position="left" />,
+    );
+    const computed = fabStyle(renderer);
+    expect(computed.bottom).toBe(24);
+    expect(computed.left).toBe(24);
+    expect(computed.right).toBeUndefined();
+  });
+
+  it('offset nudges the tab with a second composed translate', async () => {
+    const renderer = await renderTree(<FeedbackButton offset={120} />);
+    const computed = fabStyle(renderer);
+    expect(computed.transform).toEqual([
+      { translateY: '-50%' },
+      { translateY: 120 },
+    ]);
+  });
+
+  it('offset is ignored for the bubble (no transform)', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton variant="bubble" offset={120} />,
+    );
+    expect(fabStyle(renderer).transform).toBeUndefined();
+  });
+
+  it('compact renders the icon-only tab chip with the "Feedback" fallback accessibilityLabel', async () => {
+    const renderer = await renderTree(<FeedbackButton compact />);
+    const fab = findFab(renderer)!;
+    expect(fab.props.accessibilityLabel).toBe('Feedback');
+    // No visible label — including the phase-tracking copy.
+    expect(fab.findAllByType(Text)).toHaveLength(0);
+    expect(fab.findAllByType(ChatIcon)).toHaveLength(1);
+    const computed = fabStyle(renderer);
+    expect(computed.width).toBe(44);
+    expect(computed.minHeight).toBe(44);
+  });
+
+  it('compact promotes the explicit string label to the accessibilityLabel', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton compact label="Report a bug" />,
+    );
+    const fab = findFab(renderer)!;
+    expect(fab.props.accessibilityLabel).toBe('Report a bug');
+    expect(fab.findAllByType(Text)).toHaveLength(0);
+  });
+
+  it('compact bubble renders the 48px icon-only circle', async () => {
+    const renderer = await renderTree(
+      <FeedbackButton variant="bubble" compact />,
+    );
+    const fab = findFab(renderer)!;
+    expect(fab.findAllByType(Text)).toHaveLength(0);
+    expect(fab.findAllByType(ChatIcon)).toHaveLength(1);
+    const computed = fabStyle(renderer);
+    expect(computed.width).toBe(48);
+    expect(computed.paddingHorizontal).toBe(0);
+    expect(computed.borderRadius).toBe(24);
+  });
+
+  it('sizes the vertical label wrapper to the rotated extents after onLayout', async () => {
+    const renderer = await renderTree(<FeedbackButton />);
+    const labelText = findFab(renderer)!
+      .findAllByType(Text)
+      .find((t) => {
+        const flat = StyleSheet.flatten(t.props.style) as {
+          transform?: readonly Record<string, unknown>[];
+        };
+        return flat.transform?.some((e) => 'rotate' in e) ?? false;
+      })!;
+
+    // Drive the measurement callback the way RN's layout pass would —
+    // the unrotated text box is 96×18, so the wrapper must swap to 18×96
+    // (rotation is paint-only; layout uses the pre-transform box).
+    await act(async () => {
+      labelText.props.onLayout({
+        nativeEvent: { layout: { x: 0, y: 0, width: 96, height: 18 } },
+      });
+    });
+
+    const wrapper = findFab(renderer)!
+      .findAllByType(View)
+      .find((v) => {
+        const flat = StyleSheet.flatten(v.props.style) as ViewStyle;
+        return flat.width === 18 && flat.height === 96;
+      });
+    expect(wrapper).toBeDefined();
   });
 });
 

--- a/packages/react-native/src/__tests__/feedback-button.test.tsx
+++ b/packages/react-native/src/__tests__/feedback-button.test.tsx
@@ -427,6 +427,40 @@ describe('FeedbackButton — launcher presentation (variant + position)', () => 
     expect(computed.right).toBeUndefined();
   });
 
+  it('tolerates a null position from JS consumers without crashing (defaults to the tab)', async () => {
+    // `typeof null === 'object'`, so an unguarded object branch would
+    // dereference `null.left` and throw. A JS consumer passing
+    // `position={null}` must fall through to the right-edge tab default.
+    const renderer = await renderTree(
+      <FeedbackButton position={null as never} />,
+    );
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.right).toBe(0);
+    expect(computed.left).toBeUndefined();
+  });
+
+  it('tolerates a null position on the bubble without crashing (default corner)', async () => {
+    // Same guard on the bubble path: `resolveBubblePositionStyle(null)`
+    // must not dereference `null.bottom` and instead default to the
+    // bottom-right corner.
+    const renderer = await renderTree(
+      <FeedbackButton variant="bubble" position={null as never} />,
+    );
+    const computed = fabStyle(renderer);
+    expect(computed.bottom).toBe(24);
+    expect(computed.right).toBe(24);
+    expect(computed.top).toBeUndefined();
+  });
+
+  it('treats an undefined position as the zero-config right-edge tab', async () => {
+    const renderer = await renderTree(<FeedbackButton position={undefined} />);
+    const computed = fabStyle(renderer);
+    expect(computed.top).toBe('50%');
+    expect(computed.right).toBe(0);
+    expect(computed.left).toBeUndefined();
+  });
+
   it('offset nudges the tab with a second composed translate', async () => {
     const renderer = await renderTree(<FeedbackButton offset={120} />);
     const computed = fabStyle(renderer);

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -22,6 +22,7 @@ import {
   resolvePalette,
   type BrevwickTheme,
 } from './styles';
+import { resolveLauncherPlacement as resolveBasePlacement } from '@tatlacas/brevwick-sdk/launcher';
 
 /** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
  *  against an edge of the absolute-positioned host view; `'bubble'` is the
@@ -55,18 +56,17 @@ export type FeedbackButtonPosition =
   | { bottom?: number; right?: number; left?: number };
 
 /**
- * Resolved launcher placement — the single source of truth shared by the
- * FAB style derivation. See the resolution table in the design spec
- * (mirrored in every adapter):
+ * RN superset of the shared placement resolver. The named-string matrix is
+ * the framework-agnostic `resolveLauncherPlacement` in
+ * `@tatlacas/brevwick-sdk/launcher` (one home for the logic, per CLAUDE.md).
+ * This wrapper only adds the RN-only `{ bottom?, right?, left? }` offset
+ * object — a platform safe-area/tab-bar inset with no DOM analogue — then
+ * delegates the named-string cases to core:
  *
- * - Explicit `variant` always wins; `position` then only contributes its
- *   horizontal side (a corner's vertical component — or an offset
- *   object's pixel values — is ignored for the tab, which is always
- *   vertically centered, ± `offset`).
- * - With `variant` unset, an explicit legacy corner (or the RN-only
- *   offset-object form) implies the bubble so pre-existing call sites
- *   keep their corner pill; everything else is the tab (the new
- *   default), on the right edge unless `position` says otherwise.
+ * - Object form: `left` set without `right` → left edge, otherwise right;
+ *   its pixel values apply to the bubble only. Like a legacy corner, an
+ *   offset object without an explicit `variant` implies the bubble.
+ * - Everything else is resolved by the shared core function.
  *
  * Every combination is total — no throws, no dead states.
  */
@@ -74,22 +74,15 @@ function resolveLauncherPlacement(
   variant?: FeedbackButtonVariant,
   position?: FeedbackButtonPosition,
 ): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' ||
-    position === 'bottom-left' ||
-    (typeof position === 'object' &&
-      position.left !== undefined &&
-      position.right === undefined)
-      ? 'left'
-      : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner (or offset object) without a
-  // variant keeps the bubble.
-  const impliesBubble =
-    position === 'bottom-right' ||
-    position === 'bottom-left' ||
-    typeof position === 'object';
-  return { variant: impliesBubble ? 'bubble' : 'tab', side };
+  if (typeof position === 'object') {
+    const side: 'right' | 'left' =
+      position.left !== undefined && position.right === undefined
+        ? 'left'
+        : 'right';
+    // An offset object without a variant keeps the bubble (like a corner).
+    return { variant: variant ?? 'bubble', side };
+  }
+  return resolveBasePlacement(variant, position);
 }
 
 /**

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -4,7 +4,10 @@ import {
   StyleSheet,
   Text,
   useColorScheme,
+  View,
+  type LayoutChangeEvent,
   type StyleProp,
+  type TextStyle,
   type ViewStyle,
 } from 'react-native';
 import {
@@ -13,31 +16,81 @@ import {
   type FeedbackStatus,
 } from './use-feedback';
 import { FeedbackModal } from './feedback-modal';
+import { ChatIcon } from './icons';
 import {
   createWidgetStyles,
   resolvePalette,
   type BrevwickTheme,
 } from './styles';
 
+/** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
+ *  against an edge of the absolute-positioned host view; `'bubble'` is the
+ *  legacy floating corner pill. */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
 /**
- * Where the FAB pins itself within its absolute-positioned parent. Either
- * one of the two named corners (default 24px inset, 24px from the bottom)
- * or an explicit `{ bottom?, right?, left? }` triplet for callers that
- * need to clear a custom safe-area / tab-bar.
+ * Launcher placement.
+ * - `'right' | 'left'`        — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble; default 24px inset on both axes). Passing one of these WITHOUT
+ *   an explicit `variant` opts into the bubble, preserving pre-2.x call
+ *   sites byte-for-byte.
+ * - `{ bottom?, right?, left? }` — explicit offset triplet for callers that
+ *   need to clear a custom safe-area / tab-bar. Like the named corners,
+ *   the object form implies the bubble when `variant` is unset.
  *
  * @remarks
  * **Web parity divergence.** The web React adapter restricts `position` to
- * the `'bottom-right' | 'bottom-left'` named corners. The RN adapter
- * widens the type with the `{ bottom?, right?, left? }` object form to
- * accommodate the platform-specific safe-area / tab-bar / notch insets
- * that have no analogue in the DOM. This widening is RN-only — consumers
- * porting code between adapters must use the named-corner form for
- * portable call sites.
+ * the four named strings. The RN adapter widens the type with the
+ * `{ bottom?, right?, left? }` object form to accommodate the
+ * platform-specific safe-area / tab-bar / notch insets that have no
+ * analogue in the DOM. This widening is RN-only — consumers porting code
+ * between adapters must use the named-string forms for portable call sites.
  */
 export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
   | 'bottom-right'
   | 'bottom-left'
   | { bottom?: number; right?: number; left?: number };
+
+/**
+ * Resolved launcher placement — the single source of truth shared by the
+ * FAB style derivation. See the resolution table in the design spec
+ * (mirrored in every adapter):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component — or an offset
+ *   object's pixel values — is ignored for the tab, which is always
+ *   vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner (or the RN-only
+ *   offset-object form) implies the bubble so pre-existing call sites
+ *   keep their corner pill; everything else is the tab (the new
+ *   default), on the right edge unless `position` says otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' ||
+    position === 'bottom-left' ||
+    (typeof position === 'object' &&
+      position.left !== undefined &&
+      position.right === undefined)
+      ? 'left'
+      : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner (or offset object) without a
+  // variant keeps the bubble.
+  const impliesBubble =
+    position === 'bottom-right' ||
+    position === 'bottom-left' ||
+    typeof position === 'object';
+  return { variant: impliesBubble ? 'bubble' : 'tab', side };
+}
 
 /**
  * Props for {@link FeedbackButton}. Mirrors the React adapter's prop shape
@@ -45,10 +98,43 @@ export type FeedbackButtonPosition =
  */
 export interface FeedbackButtonProps {
   /**
-   * Corner the FAB pins to, or an explicit offset object. Default
-   * `'bottom-right'`.
+   * Launcher presentation. Default `'tab'` — **this changed in vNEXT**:
+   * the zero-config launcher is now a vertical tab on the right edge of
+   * the host view. Pass `variant="bubble"` (or a legacy corner / offset
+   * `position`) to keep the floating corner pill.
+   */
+  variant?: FeedbackButtonVariant;
+  /**
+   * Where the launcher sits. Defaults: `'right'` for the tab,
+   * `'bottom-right'` for the bubble.
+   *
+   * Compatibility: passing a legacy corner (`'bottom-right'` /
+   * `'bottom-left'`) or the `{ bottom?, right?, left? }` offset object
+   * without an explicit `variant` renders the BUBBLE at that position —
+   * existing call sites keep their pre-vNEXT presentation. When `variant`
+   * and `position` disagree (e.g. `variant="tab"` +
+   * `position="bottom-left"`), `variant` wins and `position` contributes
+   * only its horizontal side (for the offset object: `left` set without
+   * `right` → left edge, otherwise right; its pixel values apply to the
+   * bubble only).
    */
   position?: FeedbackButtonPosition;
+  /**
+   * Icon-only mode. Bubble → 48px circular icon button; tab → compact
+   * square edge chip with just the chat icon. The visible label is not
+   * rendered — including the phase-tracking copy (`Capturing…` /
+   * `Sending…` / `Sent ✓`), so the FAB surfaces no submit progress in
+   * compact mode (the modal still shows it). The `label` (or
+   * `'Feedback'` when unset) becomes the launcher's
+   * `accessibilityLabel`. Default `false`.
+   */
+  compact?: boolean;
+  /**
+   * Tab-only: vertical offset in logical px from the vertical center of
+   * the host view. Positive moves the tab down, negative up. Ignored for
+   * the bubble. Default `0`.
+   */
+  offset?: number;
   /**
    * Forced palette. `'system'` (default) follows the host's color scheme;
    * `'light'`/`'dark'` override it.
@@ -65,7 +151,8 @@ export interface FeedbackButtonProps {
    * FAB label override. The default copy advances by submission phase
    * (`Send feedback` → `Capturing…` → `Sending…` → `Sent ✓` / `Try again`),
    * so most consumers should leave this unset; pass an explicit label only
-   * when the brand voice demands different copy.
+   * when the brand voice demands different copy. Hidden visually when
+   * `compact` — the string then becomes the launcher's `accessibilityLabel`.
    */
   label?: string;
   /** When true, the FAB renders nothing. Useful for feature-flagging. */
@@ -103,35 +190,127 @@ function fabLabelForState(
   return fallback;
 }
 
-function resolvePositionStyle(position: FeedbackButtonPosition): ViewStyle {
-  if (position === 'bottom-right') {
-    return { bottom: DEFAULT_INSET, right: DEFAULT_INSET };
+/**
+ * Pin style for the bubble. The offset-object form keeps its pre-vNEXT
+ * semantics (only the provided keys are spread); every other input —
+ * named corners, edge sides (`'right'`/`'left'` → the bottom corner of
+ * that side, matching the web `variant="bubble" position="left"` rule),
+ * or no position at all — collapses to the resolved `side`'s default
+ * 24px-inset bottom corner.
+ */
+function resolveBubblePositionStyle(
+  position: FeedbackButtonPosition | undefined,
+  side: 'right' | 'left',
+): ViewStyle {
+  if (typeof position === 'object') {
+    // Explicit offsets — only spread the keys that were provided so we
+    // don't overwrite a `right` that the caller intentionally omitted in
+    // favour of `left`.
+    const out: ViewStyle = {};
+    if (typeof position.bottom === 'number') out.bottom = position.bottom;
+    if (typeof position.right === 'number') out.right = position.right;
+    if (typeof position.left === 'number') out.left = position.left;
+    if (
+      out.bottom !== undefined ||
+      out.right !== undefined ||
+      out.left !== undefined
+    ) {
+      return out;
+    }
+    // Empty object — same fallthrough as no position at all.
   }
-  if (position === 'bottom-left') {
-    return { bottom: DEFAULT_INSET, left: DEFAULT_INSET };
-  }
-  // Explicit offsets — only spread the keys that were provided so we don't
-  // overwrite a `right` that the caller intentionally omitted in favour of
-  // `left`.
-  const out: ViewStyle = {};
-  if (typeof position.bottom === 'number') out.bottom = position.bottom;
-  if (typeof position.right === 'number') out.right = position.right;
-  if (typeof position.left === 'number') out.left = position.left;
-  if (
-    out.bottom === undefined &&
-    out.right === undefined &&
-    out.left === undefined
-  ) {
-    return { bottom: DEFAULT_INSET, right: DEFAULT_INSET };
-  }
-  return out;
+  return side === 'left'
+    ? { bottom: DEFAULT_INSET, left: DEFAULT_INSET }
+    : { bottom: DEFAULT_INSET, right: DEFAULT_INSET };
 }
 
 /**
- * Drop-in floating-action button + modal feedback form for React Native.
+ * Pin style for the edge tab: flush against the resolved side, vertically
+ * centered via `top: '50%'` + `translateY: '-50%'` (percentage translate
+ * is relative to the FAB's own height, mirroring the CSS
+ * `transform: translateY(-50%)` the web adapter uses), then nudged by the
+ * caller's `offset`. The second `translateY` composes with the first —
+ * RN applies transform entries in order — and is emitted only when it has
+ * an effect, matching the web adapter's conditional
+ * `--brw-fab-tab-offset` inline variable.
+ */
+function tabPlacementStyle(side: 'right' | 'left', offset: number): ViewStyle {
+  const transform: ViewStyle['transform'] =
+    offset !== 0
+      ? [{ translateY: '-50%' }, { translateY: offset }]
+      : [{ translateY: '-50%' }];
+  return side === 'left'
+    ? { top: '50%', left: 0, transform }
+    : { top: '50%', right: 0, transform };
+}
+
+/**
+ * Rotated label for the tab variant. RN has no `writing-mode`, so the
+ * vertical text is a plain `<Text>` rotated ±90° — `'90deg'` on the right
+ * edge (reads top→bottom) and `'-90deg'` on the left (reads bottom→top),
+ * matching the web adapter's `vertical-rl` + `rotate: 180deg` pair.
  *
- * Renders an absolute-positioned FAB pinned to the configured corner. The
- * label tracks the SDK's submit lifecycle so users see real progress
+ * RN transforms are paint-only (layout still uses the unrotated box) and
+ * rotate around the center, so the wrapper `View` is sized to the rotated
+ * extents — width/height swapped from the `onLayout`-measured text box —
+ * and the absolutely-positioned text is centered inside it. Until the
+ * first layout callback lands the wrapper is unsized for one frame;
+ * re-measures (e.g. when the phase label advances `Send feedback` →
+ * `Capturing…`) resize the wrapper automatically because the absolute
+ * text is never width-constrained by its parent.
+ */
+function VerticalTabLabel({
+  text,
+  side,
+  textStyle,
+}: {
+  text: string;
+  side: 'right' | 'left';
+  textStyle: StyleProp<TextStyle>;
+}): ReactElement {
+  const [box, setBox] = useState<{ width: number; height: number } | null>(
+    null,
+  );
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setBox((prev) =>
+      prev && prev.width === width && prev.height === height
+        ? prev
+        : { width, height },
+    );
+  }, []);
+  return (
+    <View
+      style={[
+        { alignItems: 'center', justifyContent: 'center' },
+        box ? { width: box.height, height: box.width } : null,
+      ]}
+    >
+      <Text
+        numberOfLines={1}
+        onLayout={handleLayout}
+        style={[
+          textStyle,
+          {
+            position: 'absolute',
+            transform: [{ rotate: side === 'right' ? '90deg' : '-90deg' }],
+          },
+        ]}
+      >
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Drop-in feedback launcher + modal feedback form for React Native.
+ *
+ * Renders an absolute-positioned launcher — by default (vNEXT) a vertical
+ * tab flush against the right edge of the host view; legacy corner
+ * `position` call sites keep the floating corner pill (see
+ * {@link FeedbackButtonProps.position}). The label tracks the SDK's
+ * submit lifecycle so users see real progress
  * (`Capturing…` → `Sending…` → `Sent ✓` / `Try again`) when the modal is
  * open or minimized. Tapping the FAB opens {@link FeedbackModal}; the
  * modal owns the form draft and survives a Cancel + reopen cycle.
@@ -148,7 +327,10 @@ function resolvePositionStyle(position: FeedbackButtonPosition): ViewStyle {
  * development.
  */
 export function FeedbackButton({
-  position = 'bottom-right',
+  variant,
+  position,
+  compact = false,
+  offset = 0,
   theme = 'system',
   style,
   label,
@@ -169,9 +351,19 @@ export function FeedbackButton({
   );
   const styles = useMemo(() => createWidgetStyles(palette), [palette]);
 
-  const positionStyle = useMemo(
-    () => resolvePositionStyle(position),
-    [position],
+  // Resolution happens here — never default `variant` at the prop layer,
+  // or the corner-implies-bubble compat rule could no longer see "unset".
+  const { variant: resolvedVariant, side } = useMemo(
+    () => resolveLauncherPlacement(variant, position),
+    [variant, position],
+  );
+
+  const placementStyle = useMemo(
+    () =>
+      resolvedVariant === 'tab'
+        ? tabPlacementStyle(side, offset)
+        : resolveBubblePositionStyle(position, side),
+    [resolvedVariant, side, offset, position],
   );
 
   const handleOpen = useCallback(() => {
@@ -198,31 +390,62 @@ export function FeedbackButton({
 
   const resolvedLabel =
     label ?? fabLabelForState(status, phase, 'Send feedback');
+  // Compact removes the visible text, so the explicit `label` (or the
+  // 'Feedback' fallback — same rule in every adapter) becomes the
+  // accessible name. Non-compact keeps the established behavior: track
+  // the visible label so VoiceOver/TalkBack announce the post-submit
+  // terminal copy (`Sent ✓` / `Try again`) instead of a stale static
+  // "Send feedback". `accessibilityLabel` overrides the child Text for
+  // screen readers in RN, so a static value here would silently disagree
+  // with what the user sees on screen.
+  const accessibilityLabel = compact ? (label ?? 'Feedback') : resolvedLabel;
 
   return (
     <>
       <Pressable
         onPress={handleOpen}
         disabled={disabled}
-        // Track the visible label so VoiceOver/TalkBack announce the
-        // post-submit terminal copy (`Sent ✓` / `Try again`) instead of a
-        // stale static "Send feedback". `accessibilityLabel` overrides the
-        // child Text for screen readers in RN, so a static value here
-        // would silently disagree with what the user sees on screen.
-        accessibilityLabel={resolvedLabel}
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ disabled }}
         style={({ pressed }) =>
           StyleSheet.flatten([
-            styles.fab,
-            positionStyle,
+            resolvedVariant === 'tab' ? styles.fabTab : styles.fab,
+            resolvedVariant === 'tab' &&
+              (side === 'left' ? styles.fabTabLeft : styles.fabTabRight),
+            resolvedVariant === 'tab' && compact && styles.fabTabCompact,
+            resolvedVariant === 'bubble' && compact && styles.fabCompact,
+            placementStyle,
             pressed && styles.fabPressed,
             disabled && styles.fabDisabled,
             style,
           ]) as ViewStyle
         }
       >
-        <Text style={styles.fabLabel}>{resolvedLabel}</Text>
+        {compact ? (
+          // Icon-only chip — no phase feedback on the FAB surface (the
+          // modal still shows submit progress).
+          <ChatIcon color={palette.accentFg} size={18} />
+        ) : resolvedVariant === 'tab' ? (
+          // Column order mirrors the web tab: icon above the label on the
+          // right edge (label reads top→bottom), below it on the left
+          // (label reads bottom→top, Userback-style).
+          <>
+            {side === 'right' ? (
+              <ChatIcon color={palette.accentFg} size={18} />
+            ) : null}
+            <VerticalTabLabel
+              text={resolvedLabel}
+              side={side}
+              textStyle={styles.fabLabel}
+            />
+            {side === 'left' ? (
+              <ChatIcon color={palette.accentFg} size={18} />
+            ) : null}
+          </>
+        ) : (
+          <Text style={styles.fabLabel}>{resolvedLabel}</Text>
+        )}
       </Pressable>
       <FeedbackModal
         visible={modalOpen}

--- a/packages/react-native/src/feedback-button.tsx
+++ b/packages/react-native/src/feedback-button.tsx
@@ -74,7 +74,10 @@ function resolveLauncherPlacement(
   variant?: FeedbackButtonVariant,
   position?: FeedbackButtonPosition,
 ): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  if (typeof position === 'object') {
+  // `typeof null === 'object'`, so guard `null` explicitly — a JS consumer
+  // passing `position={null}` must fall through to the core string resolver,
+  // not dereference `null.left`.
+  if (typeof position === 'object' && position !== null) {
     const side: 'right' | 'left' =
       position.left !== undefined && position.right === undefined
         ? 'left'
@@ -195,7 +198,10 @@ function resolveBubblePositionStyle(
   position: FeedbackButtonPosition | undefined,
   side: 'right' | 'left',
 ): ViewStyle {
-  if (typeof position === 'object') {
+  // `typeof null === 'object'`, so guard `null` explicitly — a JS consumer
+  // passing `position={null}` must hit the default-corner fallthrough, not
+  // dereference `null.bottom`.
+  if (typeof position === 'object' && position !== null) {
     // Explicit offsets — only spread the keys that were provided so we
     // don't overwrite a `right` that the caller intentionally omitted in
     // favour of `left`.

--- a/packages/react-native/src/icons.tsx
+++ b/packages/react-native/src/icons.tsx
@@ -24,6 +24,26 @@ interface IconProps {
 const STROKE_WIDTH = 2;
 
 /**
+ * Speech-bubble chat glyph for the launcher. Path from the React adapter's
+ * `ChatIcon` (`.brw-fab-icon`) — shared by the compact bubble and both
+ * orientations of the edge tab so the launcher reads identically across
+ * the web and native adapters.
+ */
+export function ChatIcon({ color, size = 18 }: IconProps): ReactElement {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z"
+        stroke={color}
+        strokeWidth={STROKE_WIDTH}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}
+
+/**
  * Paperclip icon used by the file-attach button in the composer. Path from
  * the React adapter's `PaperclipIcon`.
  */

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -53,6 +53,7 @@ export { FeedbackButton } from './feedback-button';
 export type {
   FeedbackButtonProps,
   FeedbackButtonPosition,
+  FeedbackButtonVariant,
 } from './feedback-button';
 export { FeedbackModal } from './feedback-modal';
 export type { FeedbackModalProps } from './feedback-modal';

--- a/packages/react-native/src/styles.ts
+++ b/packages/react-native/src/styles.ts
@@ -104,6 +104,50 @@ export function createWidgetStyles(palette: BrevwickPalette) {
       shadowRadius: 12,
       elevation: 6,
     },
+    // Compact bubble: 48px circle, icon only — visual twin of the web
+    // adapter's `.brw-fab--bubble.brw-fab--compact`.
+    fabCompact: {
+      width: 48,
+      minWidth: 48,
+      paddingHorizontal: 0,
+    },
+    // Tab (NEW DEFAULT): vertical edge tab — visual twin of the web
+    // adapter's `.brw-fab--tab` (40px wide, 16px vertical padding, 8px gap
+    // between icon and rotated label). The chrome (accent fill, shadow,
+    // elevation) mirrors `fab` above; geometry diverges because the tab is
+    // a column hugging an edge rather than a corner pill.
+    fabTab: {
+      position: 'absolute',
+      width: 40,
+      minHeight: 48,
+      paddingVertical: 16,
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      backgroundColor: palette.accent,
+      shadowColor: palette.shadow,
+      shadowOffset: { width: 0, height: 6 },
+      shadowOpacity: 1,
+      shadowRadius: 12,
+      elevation: 6,
+    },
+    // Rounded on the page-facing side, flat against the edge — same
+    // one-sided radii as the web `.brw-fab--tab` / `.brw-fab-l` pair.
+    fabTabRight: {
+      borderTopLeftRadius: 10,
+      borderBottomLeftRadius: 10,
+    },
+    fabTabLeft: {
+      borderTopRightRadius: 10,
+      borderBottomRightRadius: 10,
+    },
+    // Compact tab: square-ish icon-only edge chip (`.brw-fab--tab.brw-fab--compact`).
+    fabTabCompact: {
+      width: 44,
+      minHeight: 44,
+      paddingVertical: 0,
+    },
     fabPressed: {
       opacity: 0.85,
     },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -270,7 +270,7 @@ Top-level provider. Creates a single SDK instance, installs rings on mount, unin
 
 ## `FeedbackButton`
 
-A floating action button + chat-style feedback dialog. Opens to a composer with:
+A feedback launcher + chat-style feedback dialog. The launcher renders as a vertical tab flush against the right viewport edge by default, or as the classic floating corner bubble via `variant="bubble"`. Opens to a composer with:
 
 - **Textarea** with Enter-to-send (Shift+Enter for newline).
 - **File attachments** via paperclip icon.
@@ -279,20 +279,33 @@ A floating action button + chat-style feedback dialog. Opens to a composer with:
 - **Success / error** inline states with "Send another" reset.
 
 ```tsx
-<FeedbackButton position="bottom-right" label="Report a bug" />
+// Default: vertical tab on the right edge, vertically centered.
+<FeedbackButton label="Report a bug" />
+
+// Legacy floating corner bubble.
+<FeedbackButton variant="bubble" position="bottom-right" label="Report a bug" />
+
+// Icon-only tab, nudged 120px above the vertical center. The string
+// `label` becomes the launcher's aria-label.
+<FeedbackButton compact offset={-120} label="Report a bug" />
 ```
+
+> **Migration:** the default presentation changed from the corner bubble to the right-edge tab. Pass `position="bottom-right"` (or your previous corner) to keep the old look — a legacy corner `position` without an explicit `variant` still renders the bubble, so existing call sites are unaffected.
 
 ### Props
 
-| Prop        | Type                              | Default          | Description                                                                        |
-| ----------- | --------------------------------- | ---------------- | ---------------------------------------------------------------------------------- |
-| `position`  | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Which corner the FAB pins to.                                                      |
-| `disabled`  | `boolean`                         | `false`          | FAB renders as disabled and cannot open the dialog.                                |
-| `hidden`    | `boolean`                         | `false`          | Component renders nothing — useful for feature flags.                              |
-| `className` | `string`                          | —                | Appended to the FAB and dialog root for styling overrides.                         |
-| `label`     | `ReactNode`                       | `'Feedback'`     | FAB label (can be a string or any React node).                                     |
-| `theme`     | `'system' \| 'light' \| 'dark'`   | `'system'`       | Force a palette regardless of OS `prefers-color-scheme`.                           |
-| `onSubmit`  | `(result: SubmitResult) => void`  | —                | Fired after every submit (success or failure). Use for analytics or custom toasts. |
+| Prop        | Type                                                   | Default                                     | Description                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`   | `'tab' \| 'bubble'`                                    | `'tab'`                                     | Launcher presentation — vertical edge tab (the new default) or the legacy floating corner pill. A legacy corner `position` without an explicit `variant` implies `'bubble'`.         |
+| `position`  | `'right' \| 'left' \| 'bottom-right' \| 'bottom-left'` | `'right'` (tab) / `'bottom-right'` (bubble) | Where the launcher sits. Edge sides are the tab's home, corners the bubble's. When `variant` and `position` disagree, `variant` wins and `position` contributes its horizontal side. |
+| `compact`   | `boolean`                                              | `false`                                     | Icon-only launcher (circular bubble / square edge tab). The `label` is not rendered but (when a string) becomes the launcher's `aria-label`.                                         |
+| `offset`    | `number`                                               | `0`                                         | Tab only: vertical offset in px from the viewport's vertical center. Positive moves the tab down, negative up. Ignored for the bubble.                                               |
+| `disabled`  | `boolean`                                              | `false`                                     | Launcher renders as disabled and cannot open the dialog.                                                                                                                             |
+| `hidden`    | `boolean`                                              | `false`                                     | Component renders nothing — useful for feature flags.                                                                                                                                |
+| `className` | `string`                                               | —                                           | Appended to the launcher and dialog root for styling overrides.                                                                                                                      |
+| `label`     | `ReactNode`                                            | `'Feedback'`                                | Launcher label (can be a string or any React node). Hidden visually when `compact`.                                                                                                  |
+| `theme`     | `'system' \| 'light' \| 'dark'`                        | `'system'`                                  | Force a palette regardless of OS `prefers-color-scheme`.                                                                                                                             |
+| `onSubmit`  | `(result: SubmitResult) => void`                       | —                                           | Fired after every submit (success or failure). Use for analytics or custom toasts.                                                                                                   |
 
 ### Theming via CSS custom properties
 

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -153,6 +153,11 @@ describe('<FeedbackButton>', () => {
     const fab = screen.getByRole('button', { name: /open feedback form/i });
     expect(fab).toHaveAttribute('data-brevwick-skip');
     expect(fab.className).toMatch(/brw-fab/);
+    // Zero-config default changed in vNEXT: right-edge vertical tab, not
+    // the legacy bottom-right bubble.
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
 
     openPanel();
 
@@ -197,15 +202,30 @@ describe('<FeedbackButton>', () => {
     );
   });
 
-  it('applies the bottom-left position class to FAB and panel', () => {
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', () => {
+    // Legacy compat: an explicit corner without a `variant` must keep the
+    // pre-vNEXT presentation — the bubble at that corner, not a tab.
     mount({ position: 'bottom-left' });
     const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab--bubble/);
     expect(fab.className).toMatch(/brw-fab-bl/);
     expect(fab.className).not.toMatch(/brw-fab-br/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
     openPanel();
     const dialog = screen.getByRole('dialog');
     expect(dialog.className).toMatch(/brw-panel-bl/);
     expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', () => {
+    mount({ position: 'bottom-right' });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+    expect(fab.className).not.toMatch(/brw-fab-bl/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+    openPanel();
+    expect(screen.getByRole('dialog').className).toMatch(/brw-panel-br/);
   });
 
   it('Enter submits, Shift+Enter inserts a newline', async () => {
@@ -1065,6 +1085,140 @@ describe('<FeedbackButton>', () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner without a
+ * variant keeps the bubble. The zero-config default — right-edge tab —
+ * is asserted in the main describe block above.
+ */
+describe('<FeedbackButton> — launcher presentation (variant + position)', () => {
+  function getFab(name: RegExp | string = /open feedback form/i): HTMLElement {
+    return screen.getByRole('button', { name });
+  }
+
+  it('variant="bubble" without a position renders the bottom-right bubble', () => {
+    mount({ variant: 'bubble' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+  });
+
+  it('position="left" renders the tab on the left edge', () => {
+    mount({ position: 'left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
+  });
+
+  it('position="right" renders the tab on the right edge', () => {
+    mount({ position: 'right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    mount({ variant: 'tab', position: 'bottom-left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab.className).not.toMatch(/brw-fab-bl/);
+  });
+
+  it('variant="tab" + position="bottom-right" resolves to the right-edge tab', () => {
+    mount({ variant: 'tab', position: 'bottom-right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', () => {
+    mount({ variant: 'bubble', position: 'left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-bl/);
+  });
+
+  it('variant="bubble" + position="right" renders the bubble at the bottom-right corner', () => {
+    mount({ variant: 'bubble', position: 'right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+  });
+
+  it('left-edge tab opens the panel anchored bottom-left', () => {
+    mount({ position: 'left' });
+    openPanel();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/brw-panel-bl/);
+    expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('compact drops the visible label and promotes the string label to aria-label', () => {
+    mount({ compact: true, label: 'Report a bug' });
+    const fab = getFab('Report a bug');
+    expect(fab.className).toMatch(/brw-fab--compact/);
+    // The label text must not render — compact is icon-only.
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+    expect(screen.queryByText('Report a bug')).toBeNull();
+  });
+
+  it('compact with a non-string ReactNode label falls back to aria-label="Feedback"', () => {
+    mount({ compact: true, label: <strong>Fancy</strong> });
+    const fab = getFab('Feedback');
+    expect(fab).toHaveAttribute('aria-label', 'Feedback');
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+  });
+
+  it('non-compact keeps aria-label="Open feedback form" and the visible label span', () => {
+    mount({ label: 'Report a bug' });
+    const fab = getFab();
+    expect(fab).toHaveAttribute('aria-label', 'Open feedback form');
+    const labelSpan = fab.querySelector('.brw-fab-label');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan!.textContent).toBe('Report a bug');
+  });
+
+  it('offset sets --brw-fab-tab-offset inline on the tab only when non-zero', () => {
+    mount({ offset: 120 });
+    const fab = getFab();
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('120px');
+  });
+
+  it('offset=0 sets no inline custom property on the tab', () => {
+    mount({ offset: 0 });
+    expect(getFab().style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('offset is ignored for the bubble (no inline custom property)', () => {
+    mount({ variant: 'bubble', offset: 120 });
+    expect(getFab().style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('emitted stylesheet declares the vertical tab + keeps the launcher chrome contract', () => {
+    // Tab geometry: writing-mode flips the inline axis vertical.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*writing-mode:\s*vertical-rl/,
+    );
+    // Shared launcher chrome keeps the max-ish stacking contract.
+    expect(BREVWICK_CSS).toMatch(/\.brw-fab\s*\{[^}]*z-index:\s*2147483000/);
+    // Bubble keeps the legacy pill geometry under its own class.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
+    );
+  });
+
+  it('vitest-axe is clean on a tab-variant launcher', async () => {
+    mount();
+    const results = await axe(getFab());
+    expect(results).toHaveNoViolations();
   });
 });
 

--- a/packages/react/src/__tests__/feedback-button.test.tsx
+++ b/packages/react/src/__tests__/feedback-button.test.tsx
@@ -1215,6 +1215,32 @@ describe('<FeedbackButton> — launcher presentation (variant + position)', () =
     );
   });
 
+  // Regression: the left-edge tab must stay vertically centred. The earlier
+  // shape used the standalone `rotate: 180deg` property on `.brw-fab-l`,
+  // which CSS Transforms L2 applies AFTER the `transform` property — flipping
+  // the centering `translateY(-50%)` into `+50%` and dropping the left tab a
+  // full tab-height below centre. jsdom cannot compute composed transforms,
+  // so we assert the stylesheet shape that keeps the fix:
+  //   - no standalone `rotate:` declaration (the inverting form), and
+  //   - the 180° flip composed INSIDE `transform`, AFTER `translateY(-50%)`,
+  //     via the `--brw-fab-tab-flip` custom property set on `.brw-fab-l`.
+  it('left-edge tab composes its 180° flip inside transform so centering survives', () => {
+    // The inverting standalone `rotate` property must be gone everywhere.
+    expect(BREVWICK_CSS).not.toMatch(/rotate:\s*180deg/);
+    // translateY(-50%) stays the outermost transform; the flip follows it.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip/,
+    );
+    // The left tab drives the flip purely through the custom property.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab-l\s*\{[^}]*--brw-fab-tab-flip:\s*180deg/,
+    );
+    // Hover keeps translateX innermost so the flip turns -2px into +2px.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab:hover[^{]*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip[^)]*\)\)\s*translateX\(-2px\)/,
+    );
+  });
+
   it('vitest-axe is clean on a tab-variant launcher', async () => {
     mount();
     const results = await axe(getFab());

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -10,6 +10,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent,
   type ReactElement,
   type ReactNode,
@@ -94,19 +95,93 @@ const ASSISTANT_RECEIPT_TEXT = 'Thanks — your issue is on its way.';
  */
 export type BrevwickTheme = 'light' | 'dark' | 'system';
 
+/** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
+ *  against a viewport edge; `'bubble'` is the legacy floating corner pill. */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement.
+ * - `'right' | 'left'`        — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble). Passing one of these WITHOUT an explicit `variant` opts into
+ *   the bubble, preserving pre-2.x call sites byte-for-byte.
+ */
+export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — the single source of truth shared by the
+ * FAB class derivation and the panel anchor. See the resolution table in
+ * the design spec (mirrored in every adapter):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component is ignored for the tab
+ *   — tabs are always vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner implies the bubble so
+ *   pre-existing call sites keep their corner pill; everything else is
+ *   the tab (the new default), on the right edge unless `position` says
+ *   otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}
+
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.
  */
 export interface FeedbackButtonProps {
-  /** Corner the FAB pins to. Default `'bottom-right'`. */
-  position?: 'bottom-right' | 'bottom-left';
-  /** When true, the FAB renders as disabled and cannot open the dialog. */
+  /**
+   * Launcher presentation. Default `'tab'` — **this changed in vNEXT**:
+   * the zero-config launcher is now a vertical tab on the right viewport
+   * edge. Pass `variant="bubble"` (or a legacy corner `position`) to keep
+   * the floating corner pill.
+   */
+  variant?: FeedbackButtonVariant;
+  /**
+   * Where the launcher sits. Defaults: `'right'` for the tab,
+   * `'bottom-right'` for the bubble.
+   *
+   * Compatibility: passing a legacy corner (`'bottom-right'` /
+   * `'bottom-left'`) without an explicit `variant` renders the BUBBLE at
+   * that corner — existing call sites keep their pre-vNEXT presentation.
+   * When `variant` and `position` disagree (e.g. `variant="tab"` +
+   * `position="bottom-left"`), `variant` wins and `position` contributes
+   * only its horizontal side.
+   */
+  position?: FeedbackButtonPosition;
+  /**
+   * Icon-only mode. Bubble → 48px circular icon button; tab → compact
+   * square edge tab with just the icon. The `label` is not rendered but
+   * (when it is a string) becomes the launcher's `aria-label`. Default
+   * `false`.
+   */
+  compact?: boolean;
+  /**
+   * Tab-only: vertical offset in px from the vertical center of the
+   * viewport. Positive moves the tab down, negative up. Ignored for the
+   * bubble. Default `0`.
+   */
+  offset?: number;
+  /** When true, the launcher renders as disabled and cannot open the dialog. */
   disabled?: boolean;
   /** When true, the component renders nothing. Useful for feature-flagging. */
   hidden?: boolean;
-  /** Additional class appended to the FAB and dialog root for styling overrides. */
+  /** Additional class appended to the launcher and dialog root for styling overrides. */
   className?: string;
-  /** FAB label. Default `'Feedback'`. */
+  /** Launcher label. Default `'Feedback'`. Hidden visually when `compact`. */
   label?: ReactNode;
   /**
    * Force a palette regardless of the OS `prefers-color-scheme` setting.
@@ -248,7 +323,10 @@ interface FileAttachment {
  * @see SDD § 12 for the React contract.
  */
 export function FeedbackButton({
-  position = 'bottom-right',
+  variant,
+  position,
+  compact = false,
+  offset = 0,
   disabled = false,
   hidden = false,
   className,
@@ -546,10 +624,33 @@ export function FeedbackButton({
 
   if (hidden) return null;
 
-  const fabPosClass = position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
-  const panelPosClass =
-    position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
   const rootClassName = ['brw-root', className].filter(Boolean).join(' ');
+  const { variant: v, side } = resolveLauncherPlacement(variant, position);
+  const fabClasses = [
+    rootClassName,
+    'brw-fab',
+    v === 'tab' ? 'brw-fab--tab' : 'brw-fab--bubble',
+    v === 'tab'
+      ? side === 'left'
+        ? 'brw-fab-l'
+        : 'brw-fab-r'
+      : side === 'left'
+        ? 'brw-fab-bl'
+        : 'brw-fab-br',
+    compact ? 'brw-fab--compact' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const panelPosClass = side === 'left' ? 'brw-panel-bl' : 'brw-panel-br';
+  // Non-compact keeps the established accessible name (the visible label
+  // still supplements it). Compact removes the visible text, so the string
+  // `label` becomes the aria-label; a non-string ReactNode label falls
+  // back to 'Feedback'.
+  const ariaLabel = compact
+    ? typeof label === 'string'
+      ? label
+      : 'Feedback'
+    : 'Open feedback form';
 
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
@@ -558,12 +659,21 @@ export function FeedbackButton({
           type="button"
           data-brevwick-skip=""
           data-brw-theme={theme}
-          className={`${rootClassName} brw-fab ${fabPosClass}`}
+          data-brw-variant={v}
+          className={fabClasses}
           disabled={disabled}
-          aria-label="Open feedback form"
+          aria-label={ariaLabel}
+          /* `--brw-fab-tab-offset` is a positioning input (like the inline
+             animation-delay on status rows), not part of the public
+             --brw-* theming contract — set only when it has an effect. */
+          style={
+            v === 'tab' && offset !== 0
+              ? ({ '--brw-fab-tab-offset': `${offset}px` } as CSSProperties)
+              : undefined
+          }
         >
           <ChatIcon />
-          {label}
+          {!compact && <span className="brw-fab-label">{label}</span>}
         </button>
       </Dialog.Trigger>
       <Dialog.Portal>

--- a/packages/react/src/feedback-button.tsx
+++ b/packages/react/src/feedback-button.tsx
@@ -22,6 +22,7 @@ import type {
   SubmitError,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
+import { resolveLauncherPlacement } from '@tatlacas/brevwick-sdk/launcher';
 import { useBrevwickInternal } from './context';
 import { useFeedback, type FeedbackPhase } from './use-feedback';
 import {
@@ -113,31 +114,11 @@ export type FeedbackButtonPosition =
   | 'bottom-left';
 
 /**
- * Resolved launcher placement — the single source of truth shared by the
- * FAB class derivation and the panel anchor. See the resolution table in
- * the design spec (mirrored in every adapter):
- *
- * - Explicit `variant` always wins; `position` then only contributes its
- *   horizontal side (a corner's vertical component is ignored for the tab
- *   — tabs are always vertically centered, ± `offset`).
- * - With `variant` unset, an explicit legacy corner implies the bubble so
- *   pre-existing call sites keep their corner pill; everything else is
- *   the tab (the new default), on the right edge unless `position` says
- *   otherwise.
- *
- * Every combination is total — no throws, no dead states.
+ * The variant/position resolution table (`resolveLauncherPlacement`) is a
+ * pure, framework-agnostic function shared by every adapter, so it lives in
+ * `@tatlacas/brevwick-sdk/launcher` rather than being copied here. See the
+ * resolution semantics in that module (mirrored in SDD § 12).
  */
-function resolveLauncherPlacement(
-  variant?: FeedbackButtonVariant,
-  position?: FeedbackButtonPosition,
-): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner without a variant keeps the bubble.
-  const isCorner = position === 'bottom-right' || position === 'bottom-left';
-  return { variant: isCorner ? 'bubble' : 'tab', side };
-}
 
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the React contract.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,7 +21,12 @@ export type {
 } from './use-feedback';
 
 export { FeedbackButton } from './feedback-button';
-export type { BrevwickTheme, FeedbackButtonProps } from './feedback-button';
+export type {
+  BrevwickTheme,
+  FeedbackButtonPosition,
+  FeedbackButtonProps,
+  FeedbackButtonVariant,
+} from './feedback-button';
 
 export type {
   BrevwickConfig,

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -186,20 +186,25 @@ export const BREVWICK_CSS = `
 /* ── Tab (NEW DEFAULT: vertical edge tab) ──────────────────────────── */
 /* writing-mode flips the inline axis vertical: the flex row (icon, label)
    stacks top→bottom and the label glyphs read top→bottom, rotated 90° cw.
-   The left tab adds \`rotate: 180deg\` (the standalone property, NOT
-   transform, so it composes with the hover translateX) — flat edge stays
-   against the viewport edge, radii mirror automatically, and the label
-   reads bottom→top, Userback-style. */
+   The left tab mirrors the flat edge / radii by rotating 180° — composed
+   INSIDE \`transform\` (after the centering translateY), via the
+   \`--brw-fab-tab-flip\` custom property, so the rotation never inverts the
+   centering. (The standalone \`rotate\` property applies AFTER \`transform\`
+   per CSS Transforms L2, which flipped \`translateY(-50%)\` into \`+50%\` and
+   dropped the left tab a full tab-height below centre — see the launcher
+   placement test.) translateY(-50%) stays the outermost transform, so the
+   tab is centred for both edges; the 180° rotate still mirrors the radii,
+   the flat edge, and the label (which reads bottom→top, Userback-style). */
 .brw-fab--tab {
   top: calc(50% + var(--brw-fab-tab-offset, 0px));
-  transform: translateY(-50%);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg));
   writing-mode: vertical-rl;
   min-height: 48px;
   width: 40px;
   padding: 16px 0;
   justify-content: center;
   /* Rounded on the page-facing side, flat against the edge (right-tab
-     orientation; the left tab's rotate mirrors it). */
+     orientation; the left tab's flip mirrors it). */
   border-radius: 10px 0 0 10px;
 }
 .brw-fab-r {
@@ -208,14 +213,15 @@ export const BREVWICK_CSS = `
 }
 .brw-fab-l {
   left: env(safe-area-inset-left, 0px);
-  border-right: none;            /* pre-rotation right edge IS the viewport edge */
-  rotate: 180deg;
+  border-right: none;            /* pre-flip right edge IS the viewport edge */
+  --brw-fab-tab-flip: 180deg;
 }
-/* Hover pulls the tab 2px out of the edge (translateY(-50%) must be
-   restated — transform is overwritten, not merged). For .brw-fab-l the
-   180° rotate flips -2px into +2px visually: also away from its edge. */
+/* Hover pulls the tab 2px out of the edge (the whole transform is restated —
+   transform is overwritten, not merged). translateX(-2px) is innermost so
+   the left tab's 180° flip turns it into +2px visually: also away from its
+   edge. */
 .brw-fab--tab:hover:not(:disabled) {
-  transform: translateY(-50%) translateX(-2px);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg)) translateX(-2px);
 }
 .brw-fab-label { letter-spacing: 0.02em; }
 /* Compact tab: square-ish icon-only edge chip. */

--- a/packages/react/src/styles.ts
+++ b/packages/react/src/styles.ts
@@ -140,14 +140,10 @@ export const BREVWICK_CSS = `
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   color: var(--brw-fg, var(--brw-fg-base));
 }
+/* Shared launcher chrome — variant-independent. */
 .brw-fab {
   position: fixed;
   z-index: 2147483000;
-  bottom: 24px;
-  height: 48px;
-  min-width: 48px;
-  padding: 0 18px;
-  border-radius: 999px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-accent, var(--brw-accent-base));
   color: var(--brw-accent-fg, var(--brw-accent-fg-base));
@@ -158,17 +154,76 @@ export const BREVWICK_CSS = `
   gap: 8px;
   cursor: pointer;
   box-shadow: var(--brw-shadow, var(--brw-shadow-base));
-  /* Only transform animates on hover; box-shadow is static so it is
-     intentionally excluded from the transition list. */
+  /* Only transform animates; box-shadow intentionally static. */
   transition: transform 120ms ease-out;
 }
-.brw-fab:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
 .brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
-.brw-fab-br { right: 24px; }
-.brw-fab-bl { left: 24px; }
-.brw-fab-icon { width: 18px; height: 18px; }
+.brw-fab:focus-visible {
+  outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+  outline-offset: 2px;
+}
+.brw-fab-icon { width: 18px; height: 18px; flex-shrink: 0; }
+
+/* ── Bubble (legacy corner pill) ───────────────────────────────────── */
+.brw-fab--bubble {
+  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  height: 48px;
+  min-width: 48px;
+  padding: 0 18px;
+  border-radius: 999px;
+}
+.brw-fab--bubble:hover:not(:disabled) { transform: translateY(-1px); }
+.brw-fab-br { right: calc(24px + env(safe-area-inset-right, 0px)); }
+.brw-fab-bl { left: calc(24px + env(safe-area-inset-left, 0px)); }
+/* Compact bubble: 48px circle, icon only. */
+.brw-fab--bubble.brw-fab--compact {
+  width: 48px;
+  min-width: 48px;
+  padding: 0;
+  justify-content: center;
+}
+
+/* ── Tab (NEW DEFAULT: vertical edge tab) ──────────────────────────── */
+/* writing-mode flips the inline axis vertical: the flex row (icon, label)
+   stacks top→bottom and the label glyphs read top→bottom, rotated 90° cw.
+   The left tab adds \`rotate: 180deg\` (the standalone property, NOT
+   transform, so it composes with the hover translateX) — flat edge stays
+   against the viewport edge, radii mirror automatically, and the label
+   reads bottom→top, Userback-style. */
+.brw-fab--tab {
+  top: calc(50% + var(--brw-fab-tab-offset, 0px));
+  transform: translateY(-50%);
+  writing-mode: vertical-rl;
+  min-height: 48px;
+  width: 40px;
+  padding: 16px 0;
+  justify-content: center;
+  /* Rounded on the page-facing side, flat against the edge (right-tab
+     orientation; the left tab's rotate mirrors it). */
+  border-radius: 10px 0 0 10px;
+}
+.brw-fab-r {
+  right: env(safe-area-inset-right, 0px);
+  border-right: none;            /* flat edge: no hairline against the viewport */
+}
+.brw-fab-l {
+  left: env(safe-area-inset-left, 0px);
+  border-right: none;            /* pre-rotation right edge IS the viewport edge */
+  rotate: 180deg;
+}
+/* Hover pulls the tab 2px out of the edge (translateY(-50%) must be
+   restated — transform is overwritten, not merged). For .brw-fab-l the
+   180° rotate flips -2px into +2px visually: also away from its edge. */
+.brw-fab--tab:hover:not(:disabled) {
+  transform: translateY(-50%) translateX(-2px);
+}
+.brw-fab-label { letter-spacing: 0.02em; }
+/* Compact tab: square-ish icon-only edge chip. */
+.brw-fab--tab.brw-fab--compact {
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
+}
 .brw-panel {
   position: fixed;
   z-index: 2147483002;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,6 +17,21 @@
       "types": "./dist/testing.d.ts",
       "import": "./dist/testing.js",
       "require": "./dist/testing.cjs"
+    },
+    "./launcher": {
+      "types": "./dist/launcher.d.ts",
+      "import": "./dist/launcher.js",
+      "require": "./dist/launcher.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "testing": [
+        "./dist/testing.d.ts"
+      ],
+      "launcher": [
+        "./dist/launcher.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/sdk/src/__tests__/launcher.test.ts
+++ b/packages/sdk/src/__tests__/launcher.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLauncherPlacement } from '../launcher';
+
+/**
+ * Contract for the framework-agnostic launcher resolver hoisted out of the
+ * adapters. Every adapter imports this single function, so the full
+ * variant/position matrix is pinned here once (the adapters keep only their
+ * own class/style-derivation tests on top of it).
+ */
+describe('resolveLauncherPlacement', () => {
+  it('defaults to the right-edge tab with no arguments', () => {
+    expect(resolveLauncherPlacement()).toEqual({ variant: 'tab', side: 'right' });
+  });
+
+  it('an explicit legacy corner without a variant implies the bubble', () => {
+    expect(resolveLauncherPlacement(undefined, 'bottom-right')).toEqual({
+      variant: 'bubble',
+      side: 'right',
+    });
+    expect(resolveLauncherPlacement(undefined, 'bottom-left')).toEqual({
+      variant: 'bubble',
+      side: 'left',
+    });
+  });
+
+  it('an explicit edge side without a variant stays the tab', () => {
+    expect(resolveLauncherPlacement(undefined, 'left')).toEqual({
+      variant: 'tab',
+      side: 'left',
+    });
+    expect(resolveLauncherPlacement(undefined, 'right')).toEqual({
+      variant: 'tab',
+      side: 'right',
+    });
+  });
+
+  it('an explicit variant always wins; position contributes only the side', () => {
+    // variant="tab" + a legacy corner: tab wins, corner gives the side only.
+    expect(resolveLauncherPlacement('tab', 'bottom-left')).toEqual({
+      variant: 'tab',
+      side: 'left',
+    });
+    // variant="bubble" + an edge side: bubble wins, side carried through.
+    expect(resolveLauncherPlacement('bubble', 'left')).toEqual({
+      variant: 'bubble',
+      side: 'left',
+    });
+    expect(resolveLauncherPlacement('bubble', 'right')).toEqual({
+      variant: 'bubble',
+      side: 'right',
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/launcher.test.ts
+++ b/packages/sdk/src/__tests__/launcher.test.ts
@@ -9,7 +9,10 @@ import { resolveLauncherPlacement } from '../launcher';
  */
 describe('resolveLauncherPlacement', () => {
   it('defaults to the right-edge tab with no arguments', () => {
-    expect(resolveLauncherPlacement()).toEqual({ variant: 'tab', side: 'right' });
+    expect(resolveLauncherPlacement()).toEqual({
+      variant: 'tab',
+      side: 'right',
+    });
   });
 
   it('an explicit legacy corner without a variant implies the bubble', () => {

--- a/packages/sdk/src/launcher.ts
+++ b/packages/sdk/src/launcher.ts
@@ -1,0 +1,71 @@
+/**
+ * Framework-agnostic launcher placement resolution.
+ *
+ * The `<FeedbackButton>` variant/position matrix is identical across every
+ * adapter (react, solid, vue, svelte, angular, react-native) — historically
+ * each shipped a byte-for-byte copy of `resolveLauncherPlacement`. That is a
+ * pure function with no DOM / React / Node dependency, so it lives here in
+ * core and every adapter imports it (CLAUDE.md: "shared utilities go in
+ * core"). Adapters keep their own public prop TYPES (so each can carry
+ * adapter-specific JSDoc, and the RN adapter can widen `position` with its
+ * offset-object form), but the resolution LOGIC has exactly one home.
+ *
+ * Shipped on its own `@tatlacas/brevwick-sdk/launcher` entry so it is fully
+ * tree-shakeable and never lands in the eager core bundle that has its own
+ * gzip ceiling (CLAUDE.md "Bundle Budget").
+ *
+ * @module
+ */
+
+/**
+ * Launcher presentation. `'tab'` (the default) is a vertical button flush
+ * against a viewport edge; `'bubble'` is the legacy floating corner pill.
+ */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement.
+ * - `'right' | 'left'` — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble). Passing one of these WITHOUT an explicit `variant` opts into
+ *   the bubble, preserving pre-2.x call sites byte-for-byte.
+ */
+export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — the single source of truth shared by an
+ * adapter's FAB class/style derivation and its panel anchor.
+ */
+export interface ResolvedLauncherPlacement {
+  variant: FeedbackButtonVariant;
+  side: 'right' | 'left';
+}
+
+/**
+ * Resolve the `variant` / `position` props into the concrete placement an
+ * adapter renders. See the resolution table in the design spec (SDD § 12):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component is ignored for the tab
+ *   — tabs are always vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner implies the bubble so
+ *   pre-existing call sites keep their corner pill; everything else is the
+ *   tab (the default), on the right edge unless `position` says otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+export function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): ResolvedLauncherPlacement {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -16,7 +16,7 @@ const pkg = JSON.parse(
  * `__tests__/chunk-split.test.ts`.
  */
 export default defineConfig({
-  entry: ['src/index.ts', 'src/testing.ts'],
+  entry: ['src/index.ts', 'src/testing.ts', 'src/launcher.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -30,6 +30,33 @@ export default function App() {
 }
 ```
 
+## Launcher presentation
+
+`<FeedbackButton>` defaults to a vertical tab flush against the right
+viewport edge, vertically centered (`variant="tab"`). The legacy floating
+corner bubble is still available:
+
+```tsx
+// Right-edge tab (the default). `offset` nudges it from the vertical
+// center in px (positive = down); `compact` renders an icon-only square
+// tab and the string `label` becomes the aria-label.
+<FeedbackButton compact offset={-120} label="Report a bug" />
+
+// Legacy floating corner bubble.
+<FeedbackButton variant="bubble" position="bottom-right" />
+```
+
+`position` accepts the edge sides `'right' | 'left'` (default `'right'`)
+plus the legacy corners `'bottom-right' | 'bottom-left'`. When `variant`
+and `position` disagree, `variant` wins and `position` contributes only
+its horizontal side.
+
+> **Migration:** the default presentation changed from the corner bubble
+> to the right-edge tab. Pass `position="bottom-right"` (or your previous
+> corner) to keep the old look — a legacy corner `position` without an
+> explicit `variant` still renders the bubble, so existing call sites are
+> unaffected.
+
 ## Imperative submit
 
 ```tsx

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -71,6 +71,7 @@ import {
   FeedbackButton,
   type FeedbackButtonProps,
 } from '../components/feedback-button';
+import { BREVWICK_CSS } from '../styles';
 
 beforeEach(() => {
   // jsdom lacks createObjectURL by default; stub both for the screenshot
@@ -126,6 +127,11 @@ describe('<FeedbackButton>', () => {
     expect(fab).toBeInTheDocument();
     expect(fab).toHaveAttribute('data-brevwick-skip');
     expect(fab.className).toMatch(/brw-fab/);
+    // Zero-config default changed in vNEXT: right-edge vertical tab, not
+    // the legacy bottom-right bubble.
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
   });
 
   it('renders the panel with data-brevwick-skip + greeting on open', () => {
@@ -154,15 +160,30 @@ describe('<FeedbackButton>', () => {
     expect(link).toHaveTextContent(`Brevwick v${pkg.version}`);
   });
 
-  it('applies the bottom-left position class to FAB and panel', () => {
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', () => {
+    // Legacy compat: an explicit corner without a `variant` must keep the
+    // pre-vNEXT presentation — the bubble at that corner, not a tab.
     mount({ position: 'bottom-left' });
     const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab--bubble/);
     expect(fab.className).toMatch(/brw-fab-bl/);
     expect(fab.className).not.toMatch(/brw-fab-br/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
     openPanel();
     const dialog = screen.getByRole('dialog');
     expect(dialog.className).toMatch(/brw-panel-bl/);
     expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', () => {
+    mount({ position: 'bottom-right' });
+    const fab = screen.getByRole('button', { name: /open feedback form/i });
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+    expect(fab.className).not.toMatch(/brw-fab-bl/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+    openPanel();
+    expect(screen.getByRole('dialog').className).toMatch(/brw-panel-br/);
   });
 
   it('opens the panel and submits a draft as title + raw description', async () => {
@@ -305,6 +326,134 @@ describe('<FeedbackButton>', () => {
     const input = submit.mock.calls[0]![0]!;
     expect(input.description).toBe('   hi there   \n');
     expect(input.title).toBe('hi there');
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner without a
+ * variant keeps the bubble. The zero-config default — right-edge tab —
+ * is asserted in the main describe block above.
+ */
+describe('<FeedbackButton> — launcher presentation (variant + position)', () => {
+  function getFab(name: RegExp | string = /open feedback form/i): HTMLElement {
+    return screen.getByRole('button', { name });
+  }
+
+  it('variant="bubble" without a position renders the bottom-right bubble', () => {
+    mount({ variant: 'bubble' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+  });
+
+  it('position="left" renders the tab on the left edge', () => {
+    mount({ position: 'left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
+  });
+
+  it('position="right" renders the tab on the right edge', () => {
+    mount({ position: 'right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    mount({ variant: 'tab', position: 'bottom-left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab.className).not.toMatch(/brw-fab-bl/);
+  });
+
+  it('variant="tab" + position="bottom-right" resolves to the right-edge tab', () => {
+    mount({ variant: 'tab', position: 'bottom-right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', () => {
+    mount({ variant: 'bubble', position: 'left' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-bl/);
+  });
+
+  it('variant="bubble" + position="right" renders the bubble at the bottom-right corner', () => {
+    mount({ variant: 'bubble', position: 'right' });
+    const fab = getFab();
+    expect(fab.className).toMatch(/brw-fab--bubble/);
+    expect(fab.className).toMatch(/brw-fab-br/);
+  });
+
+  it('left-edge tab opens the panel anchored bottom-left', () => {
+    mount({ position: 'left' });
+    openPanel();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toMatch(/brw-panel-bl/);
+    expect(dialog.className).not.toMatch(/brw-panel-br/);
+  });
+
+  it('compact drops the visible label and promotes the string label to aria-label', () => {
+    mount({ compact: true, label: 'Report a bug' });
+    const fab = getFab('Report a bug');
+    expect(fab.className).toMatch(/brw-fab--compact/);
+    // The label text must not render — compact is icon-only.
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+    expect(screen.queryByText('Report a bug')).toBeNull();
+  });
+
+  it('compact with a non-string JSX label falls back to aria-label="Feedback"', () => {
+    mount({ compact: true, label: <strong>Fancy</strong> });
+    const fab = getFab('Feedback');
+    expect(fab).toHaveAttribute('aria-label', 'Feedback');
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+  });
+
+  it('non-compact keeps aria-label="Open feedback form" and the visible label span', () => {
+    mount({ label: 'Report a bug' });
+    const fab = getFab();
+    expect(fab).toHaveAttribute('aria-label', 'Open feedback form');
+    const labelSpan = fab.querySelector('.brw-fab-label');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan!.textContent).toBe('Report a bug');
+  });
+
+  it('offset sets --brw-fab-tab-offset inline on the tab only when non-zero', () => {
+    mount({ offset: 120 });
+    const fab = getFab();
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('120px');
+  });
+
+  it('offset=0 sets no inline custom property on the tab', () => {
+    mount({ offset: 0 });
+    expect(getFab().style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('offset is ignored for the bubble (no inline custom property)', () => {
+    mount({ variant: 'bubble', offset: 120 });
+    expect(getFab().style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('emitted stylesheet declares the vertical tab + keeps the launcher chrome contract', () => {
+    // Tab geometry: writing-mode flips the inline axis vertical.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*writing-mode:\s*vertical-rl/,
+    );
+    // Shared launcher chrome keeps the max-ish stacking contract.
+    expect(BREVWICK_CSS).toMatch(/\.brw-fab\s*\{[^}]*z-index:\s*2147483000/);
+    // Bubble keeps the legacy pill geometry under its own class.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
+    );
   });
 });
 

--- a/packages/solid/src/__tests__/feedback-button.test.tsx
+++ b/packages/solid/src/__tests__/feedback-button.test.tsx
@@ -455,6 +455,24 @@ describe('<FeedbackButton> — launcher presentation (variant + position)', () =
       /\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
     );
   });
+
+  // Regression: the left-edge tab must stay vertically centred. The standalone
+  // `rotate: 180deg` property on `.brw-fab-l` is applied AFTER `transform`
+  // (CSS Transforms L2), flipping the centering `translateY(-50%)` into
+  // `+50%` and dropping the tab a full tab-height below centre. jsdom cannot
+  // compute composed transforms, so we assert the corrected stylesheet shape.
+  it('left-edge tab composes its 180° flip inside transform so centering survives', () => {
+    expect(BREVWICK_CSS).not.toMatch(/rotate:\s*180deg/);
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip/,
+    );
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab-l\s*\{[^}]*--brw-fab-tab-flip:\s*180deg/,
+    );
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab:hover[^{]*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip[^)]*\)\)\s*translateX\(-2px\)/,
+    );
+  });
 });
 
 describe('<FeedbackButton> — minimize / close / discard', () => {

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -20,6 +20,7 @@ import type {
   SubmitError,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
+import { resolveLauncherPlacement } from '@tatlacas/brevwick-sdk/launcher';
 import { useFeedback, type FeedbackPhase } from '../use-feedback';
 import { BrevwickContext } from '../provider';
 import {
@@ -121,31 +122,11 @@ export type FeedbackButtonPosition =
   | 'bottom-left';
 
 /**
- * Resolved launcher placement — the single source of truth shared by the
- * FAB class derivation and the panel anchor. See the resolution table in
- * the design spec (mirrored in every adapter):
- *
- * - Explicit `variant` always wins; `position` then only contributes its
- *   horizontal side (a corner's vertical component is ignored for the tab
- *   — tabs are always vertically centered, ± `offset`).
- * - With `variant` unset, an explicit legacy corner implies the bubble so
- *   pre-existing call sites keep their corner pill; everything else is
- *   the tab (the new default), on the right edge unless `position` says
- *   otherwise.
- *
- * Every combination is total — no throws, no dead states.
+ * The variant/position resolution table (`resolveLauncherPlacement`) is a
+ * pure, framework-agnostic function shared by every adapter, so it lives in
+ * `@tatlacas/brevwick-sdk/launcher` rather than being copied here. See the
+ * resolution semantics in that module (mirrored in SDD § 12).
  */
-function resolveLauncherPlacement(
-  variant?: FeedbackButtonVariant,
-  position?: FeedbackButtonPosition,
-): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner without a variant keeps the bubble.
-  const isCorner = position === 'bottom-right' || position === 'bottom-left';
-  return { variant: isCorner ? 'bubble' : 'tab', side };
-}
 
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the Solid contract.

--- a/packages/solid/src/components/feedback-button.tsx
+++ b/packages/solid/src/components/feedback-button.tsx
@@ -103,19 +103,93 @@ const STATUS_ROW_STAGGER_MS = 200;
  */
 export type BrevwickTheme = 'light' | 'dark' | 'system';
 
+/** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
+ *  against a viewport edge; `'bubble'` is the legacy floating corner pill. */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement.
+ * - `'right' | 'left'`        — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble). Passing one of these WITHOUT an explicit `variant` opts into
+ *   the bubble, preserving pre-2.x call sites byte-for-byte.
+ */
+export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — the single source of truth shared by the
+ * FAB class derivation and the panel anchor. See the resolution table in
+ * the design spec (mirrored in every adapter):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component is ignored for the tab
+ *   — tabs are always vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner implies the bubble so
+ *   pre-existing call sites keep their corner pill; everything else is
+ *   the tab (the new default), on the right edge unless `position` says
+ *   otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}
+
 /**
  * Props for {@link FeedbackButton}. See SDD § 12 for the Solid contract.
  */
 export interface FeedbackButtonProps {
-  /** Corner the FAB pins to. Default `'bottom-right'`. */
-  position?: 'bottom-right' | 'bottom-left';
-  /** When true, the FAB renders as disabled and cannot open the dialog. */
+  /**
+   * Launcher presentation. Default `'tab'` — **this changed in vNEXT**:
+   * the zero-config launcher is now a vertical tab on the right viewport
+   * edge. Pass `variant="bubble"` (or a legacy corner `position`) to keep
+   * the floating corner pill.
+   */
+  variant?: FeedbackButtonVariant;
+  /**
+   * Where the launcher sits. Defaults: `'right'` for the tab,
+   * `'bottom-right'` for the bubble.
+   *
+   * Compatibility: passing a legacy corner (`'bottom-right'` /
+   * `'bottom-left'`) without an explicit `variant` renders the BUBBLE at
+   * that corner — existing call sites keep their pre-vNEXT presentation.
+   * When `variant` and `position` disagree (e.g. `variant="tab"` +
+   * `position="bottom-left"`), `variant` wins and `position` contributes
+   * only its horizontal side.
+   */
+  position?: FeedbackButtonPosition;
+  /**
+   * Icon-only mode. Bubble → 48px circular icon button; tab → compact
+   * square edge tab with just the icon. The `label` is not rendered but
+   * (when it is a string) becomes the launcher's `aria-label`. Default
+   * `false`.
+   */
+  compact?: boolean;
+  /**
+   * Tab-only: vertical offset in px from the vertical center of the
+   * viewport. Positive moves the tab down, negative up. Ignored for the
+   * bubble. Default `0`.
+   */
+  offset?: number;
+  /** When true, the launcher renders as disabled and cannot open the dialog. */
   disabled?: boolean;
   /** When true, the component renders nothing. Useful for feature-flagging. */
   hidden?: boolean;
-  /** Additional class appended to the FAB and dialog root for styling overrides. */
+  /** Additional class appended to the launcher and dialog root for styling overrides. */
   class?: string;
-  /** FAB label. Default `'Feedback'`. */
+  /** Launcher label. Default `'Feedback'`. Hidden visually when `compact`. */
   label?: JSX.Element;
   /** Force a palette regardless of the OS `prefers-color-scheme` setting. */
   theme?: BrevwickTheme;
@@ -530,12 +604,54 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
     }
   };
 
-  const fabPosClass = (): string =>
-    props.position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
-  const panelPosClass = (): string =>
-    props.position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
+  // Lazy prop reads inside a derived accessor keep Solid's reactivity:
+  // changing `variant`/`position` re-runs every consumer below. The
+  // resolution itself lives in `resolveLauncherPlacement` — variant is
+  // intentionally NOT defaulted at the prop layer so the corner-implies-
+  // bubble compat rule can see "unset".
+  const placement = (): {
+    variant: FeedbackButtonVariant;
+    side: 'right' | 'left';
+  } => resolveLauncherPlacement(props.variant, props.position);
   const rootClass = (): string =>
     ['brw-root', props.class].filter(Boolean).join(' ');
+  const fabClass = (): string => {
+    const { variant: v, side } = placement();
+    return [
+      rootClass(),
+      'brw-fab',
+      v === 'tab' ? 'brw-fab--tab' : 'brw-fab--bubble',
+      v === 'tab'
+        ? side === 'left'
+          ? 'brw-fab-l'
+          : 'brw-fab-r'
+        : side === 'left'
+          ? 'brw-fab-bl'
+          : 'brw-fab-br',
+      props.compact ? 'brw-fab--compact' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  };
+  const panelPosClass = (): string =>
+    placement().side === 'left' ? 'brw-panel-bl' : 'brw-panel-br';
+  // Non-compact keeps the established accessible name (the visible label
+  // still supplements it). Compact removes the visible text, so the string
+  // `label` becomes the aria-label; a non-string JSX label falls back to
+  // 'Feedback'.
+  const fabAriaLabel = (): string =>
+    props.compact
+      ? typeof props.label === 'string'
+        ? props.label
+        : 'Feedback'
+      : 'Open feedback form';
+  // `--brw-fab-tab-offset` is a positioning input (like the inline
+  // animation-delay on status rows), not part of the public --brw-*
+  // theming contract — set only when it has an effect.
+  const fabStyle = (): JSX.CSSProperties | undefined =>
+    placement().variant === 'tab' && (props.offset ?? 0) !== 0
+      ? { '--brw-fab-tab-offset': `${props.offset}px` }
+      : undefined;
 
   return (
     <>
@@ -543,14 +659,18 @@ const FeedbackButtonInner: Component<FeedbackButtonProps> = (props) => {
         type="button"
         data-brevwick-skip=""
         data-brw-theme={props.theme ?? 'system'}
-        class={`${rootClass()} brw-fab ${fabPosClass()}`}
+        data-brw-variant={placement().variant}
+        class={fabClass()}
         disabled={props.disabled}
-        aria-label="Open feedback form"
+        aria-label={fabAriaLabel()}
         aria-expanded={open()}
+        style={fabStyle()}
         onClick={() => setOpen(true)}
       >
         <ChatIcon />
-        {props.label ?? 'Feedback'}
+        <Show when={!props.compact}>
+          <span class="brw-fab-label">{props.label ?? 'Feedback'}</span>
+        </Show>
       </button>
       <Show when={open()}>
         <div

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -17,7 +17,9 @@ export type {
 export { FeedbackButton } from './components/feedback-button';
 export type {
   BrevwickTheme,
+  FeedbackButtonPosition,
   FeedbackButtonProps,
+  FeedbackButtonVariant,
 } from './components/feedback-button';
 
 export type {

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -126,14 +126,10 @@ export const BREVWICK_CSS = `
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   color: var(--brw-fg, var(--brw-fg-base));
 }
+/* Shared launcher chrome — variant-independent. */
 .brw-fab {
   position: fixed;
   z-index: 2147483000;
-  bottom: 24px;
-  height: 48px;
-  min-width: 48px;
-  padding: 0 18px;
-  border-radius: 999px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-accent, var(--brw-accent-base));
   color: var(--brw-accent-fg, var(--brw-accent-fg-base));
@@ -144,15 +140,76 @@ export const BREVWICK_CSS = `
   gap: 8px;
   cursor: pointer;
   box-shadow: var(--brw-shadow, var(--brw-shadow-base));
+  /* Only transform animates; box-shadow intentionally static. */
   transition: transform 120ms ease-out;
 }
-.brw-fab:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
 .brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
-.brw-fab-br { right: 24px; }
-.brw-fab-bl { left: 24px; }
-.brw-fab-icon { width: 18px; height: 18px; }
+.brw-fab:focus-visible {
+  outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+  outline-offset: 2px;
+}
+.brw-fab-icon { width: 18px; height: 18px; flex-shrink: 0; }
+
+/* ── Bubble (legacy corner pill) ───────────────────────────────────── */
+.brw-fab--bubble {
+  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  height: 48px;
+  min-width: 48px;
+  padding: 0 18px;
+  border-radius: 999px;
+}
+.brw-fab--bubble:hover:not(:disabled) { transform: translateY(-1px); }
+.brw-fab-br { right: calc(24px + env(safe-area-inset-right, 0px)); }
+.brw-fab-bl { left: calc(24px + env(safe-area-inset-left, 0px)); }
+/* Compact bubble: 48px circle, icon only. */
+.brw-fab--bubble.brw-fab--compact {
+  width: 48px;
+  min-width: 48px;
+  padding: 0;
+  justify-content: center;
+}
+
+/* ── Tab (NEW DEFAULT: vertical edge tab) ──────────────────────────── */
+/* writing-mode flips the inline axis vertical: the flex row (icon, label)
+   stacks top→bottom and the label glyphs read top→bottom, rotated 90° cw.
+   The left tab adds \`rotate: 180deg\` (the standalone property, NOT
+   transform, so it composes with the hover translateX) — flat edge stays
+   against the viewport edge, radii mirror automatically, and the label
+   reads bottom→top, Userback-style. */
+.brw-fab--tab {
+  top: calc(50% + var(--brw-fab-tab-offset, 0px));
+  transform: translateY(-50%);
+  writing-mode: vertical-rl;
+  min-height: 48px;
+  width: 40px;
+  padding: 16px 0;
+  justify-content: center;
+  /* Rounded on the page-facing side, flat against the edge (right-tab
+     orientation; the left tab's rotate mirrors it). */
+  border-radius: 10px 0 0 10px;
+}
+.brw-fab-r {
+  right: env(safe-area-inset-right, 0px);
+  border-right: none;            /* flat edge: no hairline against the viewport */
+}
+.brw-fab-l {
+  left: env(safe-area-inset-left, 0px);
+  border-right: none;            /* pre-rotation right edge IS the viewport edge */
+  rotate: 180deg;
+}
+/* Hover pulls the tab 2px out of the edge (translateY(-50%) must be
+   restated — transform is overwritten, not merged). For .brw-fab-l the
+   180° rotate flips -2px into +2px visually: also away from its edge. */
+.brw-fab--tab:hover:not(:disabled) {
+  transform: translateY(-50%) translateX(-2px);
+}
+.brw-fab-label { letter-spacing: 0.02em; }
+/* Compact tab: square-ish icon-only edge chip. */
+.brw-fab--tab.brw-fab--compact {
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
+}
 .brw-panel {
   position: fixed;
   z-index: 2147483002;

--- a/packages/solid/src/styles.ts
+++ b/packages/solid/src/styles.ts
@@ -171,21 +171,23 @@ export const BREVWICK_CSS = `
 
 /* ── Tab (NEW DEFAULT: vertical edge tab) ──────────────────────────── */
 /* writing-mode flips the inline axis vertical: the flex row (icon, label)
-   stacks top→bottom and the label glyphs read top→bottom, rotated 90° cw.
-   The left tab adds \`rotate: 180deg\` (the standalone property, NOT
-   transform, so it composes with the hover translateX) — flat edge stays
-   against the viewport edge, radii mirror automatically, and the label
-   reads bottom→top, Userback-style. */
+   stacks top→bottom and the label glyphs read top→bottom, rotated 90° cw. */
+/* The left tab mirrors the flat edge / radii by rotating 180° — composed
+   INSIDE \`transform\` (after the centering translateY), via the
+   \`--brw-fab-tab-flip\` custom property, so the rotation never inverts the
+   centering. (The standalone \`rotate\` property applies AFTER \`transform\`
+   per CSS Transforms L2, which flipped \`translateY(-50%)\` into \`+50%\` and
+   dropped the left tab a full tab-height below centre.) */
 .brw-fab--tab {
   top: calc(50% + var(--brw-fab-tab-offset, 0px));
-  transform: translateY(-50%);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg));
   writing-mode: vertical-rl;
   min-height: 48px;
   width: 40px;
   padding: 16px 0;
   justify-content: center;
   /* Rounded on the page-facing side, flat against the edge (right-tab
-     orientation; the left tab's rotate mirrors it). */
+     orientation; the left tab's flip mirrors it). */
   border-radius: 10px 0 0 10px;
 }
 .brw-fab-r {
@@ -194,14 +196,15 @@ export const BREVWICK_CSS = `
 }
 .brw-fab-l {
   left: env(safe-area-inset-left, 0px);
-  border-right: none;            /* pre-rotation right edge IS the viewport edge */
-  rotate: 180deg;
+  border-right: none;            /* pre-flip right edge IS the viewport edge */
+  --brw-fab-tab-flip: 180deg;
 }
-/* Hover pulls the tab 2px out of the edge (translateY(-50%) must be
-   restated — transform is overwritten, not merged). For .brw-fab-l the
-   180° rotate flips -2px into +2px visually: also away from its edge. */
+/* Hover pulls the tab 2px out of the edge (the whole transform is restated —
+   transform is overwritten, not merged). translateX(-2px) is innermost so
+   the left tab's 180° flip turns it into +2px visually: also away from its
+   edge. */
 .brw-fab--tab:hover:not(:disabled) {
-  transform: translateY(-50%) translateX(-2px);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg)) translateX(-2px);
 }
 .brw-fab-label { letter-spacing: 0.02em; }
 /* Compact tab: square-ish icon-only edge chip. */

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -33,7 +33,7 @@ pnpm add @tatlacas/brevwick-svelte@beta @tatlacas/brevwick-sdk@beta
 <FeedbackButton />
 ```
 
-That's it. A floating action button appears in the bottom-right; clicking it opens a feedback dialog with screenshot capture and file attachments.
+That's it. A vertical feedback tab appears on the right edge of the viewport (pass `position="bottom-right"` for the legacy corner bubble); clicking it opens a feedback dialog with screenshot capture and file attachments.
 
 > **Place `setBrevwickContext` in `+layout.svelte`, NOT `+layout.server.ts`.** The SDK is browser-side; the context setter is a no-op during SSR and `<FeedbackButton>` mounts after hydration.
 
@@ -68,7 +68,7 @@ Returns the underlying SDK instance for advanced use, or `null` during SSR. The 
 
 ## `FeedbackButton`
 
-A floating action button + chat-style feedback dialog. Opens to a composer with:
+A feedback launcher + chat-style feedback dialog. The launcher renders as a vertical tab flush against the right viewport edge by default, or as the classic floating corner bubble via `variant="bubble"`. Opens to a composer with:
 
 - **Textarea** with Enter-to-send (Shift+Enter for newline).
 - **Screenshot** capture via the SDK's `captureScreenshot()`.
@@ -76,19 +76,32 @@ A floating action button + chat-style feedback dialog. Opens to a composer with:
 - **Inline error / success** states.
 
 ```svelte
-<FeedbackButton position="bottom-left" label="Report a bug" />
+<!-- Default: vertical tab on the right edge, vertically centered. -->
+<FeedbackButton label="Report a bug" />
+
+<!-- Legacy floating corner bubble. -->
+<FeedbackButton variant="bubble" position="bottom-left" label="Report a bug" />
+
+<!-- Icon-only tab, nudged 120px above the vertical center. The `label`
+     becomes the launcher's aria-label. -->
+<FeedbackButton compact offset={-120} label="Report a bug" />
 ```
+
+> **Migration:** the default presentation changed from the corner bubble to the right-edge tab. Pass `position="bottom-right"` (or your previous corner) to keep the old look — a legacy corner `position` without an explicit `variant` still renders the bubble, so existing call sites are unaffected.
 
 ### Props
 
-| Prop       | Type                              | Default          | Description                                              |
-| ---------- | --------------------------------- | ---------------- | -------------------------------------------------------- |
-| `position` | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Which corner the FAB pins to.                            |
-| `disabled` | `boolean`                         | `false`          | FAB renders as disabled and cannot open the dialog.      |
-| `hidden`   | `boolean`                         | `false`          | Component renders nothing — useful for feature flags.    |
-| `label`    | `string`                          | `'Feedback'`     | FAB label.                                               |
-| `theme`    | `'system' \| 'light' \| 'dark'`   | `'system'`       | Force a palette regardless of OS `prefers-color-scheme`. |
-| `onSubmit` | `(result: SubmitResult) => void`  | —                | Fired after every submit (success or failure).           |
+| Prop       | Type                                                   | Default                                     | Description                                                                                                                                                                          |
+| ---------- | ------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`  | `'tab' \| 'bubble'`                                    | `'tab'`                                     | Launcher presentation — vertical edge tab (the new default) or the legacy floating corner pill. A legacy corner `position` without an explicit `variant` implies `'bubble'`.         |
+| `position` | `'right' \| 'left' \| 'bottom-right' \| 'bottom-left'` | `'right'` (tab) / `'bottom-right'` (bubble) | Where the launcher sits. Edge sides are the tab's home, corners the bubble's. When `variant` and `position` disagree, `variant` wins and `position` contributes its horizontal side. |
+| `compact`  | `boolean`                                              | `false`                                     | Icon-only launcher (circular bubble / square edge tab). The `label` is not rendered but becomes the launcher's `aria-label`.                                                         |
+| `offset`   | `number`                                               | `0`                                         | Tab only: vertical offset in px from the viewport's vertical center. Positive moves the tab down, negative up. Ignored for the bubble.                                               |
+| `disabled` | `boolean`                                              | `false`                                     | Launcher renders as disabled and cannot open the dialog.                                                                                                                             |
+| `hidden`   | `boolean`                                              | `false`                                     | Component renders nothing — useful for feature flags.                                                                                                                                |
+| `label`    | `string`                                               | `'Feedback'`                                | Launcher label. Hidden visually when `compact`.                                                                                                                                      |
+| `theme`    | `'system' \| 'light' \| 'dark'`                        | `'system'`                                  | Force a palette regardless of OS `prefers-color-scheme`.                                                                                                                             |
+| `onSubmit` | `(result: SubmitResult) => void`                       | —                                           | Fired after every submit (success or failure).                                                                                                                                       |
 
 ### Theming via CSS custom properties
 

--- a/packages/svelte/src/__tests__/feedback-button.test.ts
+++ b/packages/svelte/src/__tests__/feedback-button.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   fireEvent,
   render,
@@ -121,6 +123,11 @@ describe('<FeedbackButton>', () => {
       name: /open feedback form/i,
     });
     expect(fab).toBeInTheDocument();
+    // Zero-config default changed in vNEXT: right-edge vertical tab, not
+    // the legacy bottom-right bubble.
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
     expect(
       screen.queryByRole('dialog', { name: /send feedback/i }),
     ).not.toBeInTheDocument();
@@ -161,19 +168,41 @@ describe('<FeedbackButton>', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('pins the FAB to the bottom-left corner when position="bottom-left"', async () => {
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', async () => {
+    // Legacy compat: an explicit corner without a `variant` must keep the
+    // pre-vNEXT presentation — the bubble at that corner, not a tab.
     mountFab(undefined, { position: 'bottom-left' });
     const fab = await screen.findByRole('button', {
       name: /open feedback form/i,
     });
+    expect(fab.className).toContain('brw-fab--bubble');
     expect(fab.className).toContain('brw-fab-bl');
     expect(fab.className).not.toContain('brw-fab-br');
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
 
     await act(async () => {
       await fireEvent.click(fab);
     });
     const panel = screen.getByRole('dialog', { name: /send feedback/i });
     expect(panel.className).toContain('brw-panel-bl');
+    expect(panel.className).not.toContain('brw-panel-br');
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', async () => {
+    mountFab(undefined, { position: 'bottom-right' });
+    const fab = await screen.findByRole('button', {
+      name: /open feedback form/i,
+    });
+    expect(fab.className).toContain('brw-fab--bubble');
+    expect(fab.className).toContain('brw-fab-br');
+    expect(fab.className).not.toContain('brw-fab-bl');
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+
+    await act(async () => {
+      await fireEvent.click(fab);
+    });
+    const panel = screen.getByRole('dialog', { name: /send feedback/i });
+    expect(panel.className).toContain('brw-panel-br');
   });
 
   it('forwards the theme prop onto the widget root via data-brw-theme', async () => {
@@ -1243,5 +1272,149 @@ describe('<FeedbackButton> — debug raw payload (config.debug)', () => {
     });
     await waitFor(() => expect(writeText).toHaveBeenCalled());
     expect(copyBtn.textContent?.trim()).toBe('Copy raw payload');
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner without a
+ * variant keeps the bubble. The zero-config default — right-edge tab —
+ * is asserted in the main describe block above. Mirrors the React
+ * adapter's matrix one-for-one.
+ */
+describe('<FeedbackButton> — launcher presentation (variant + position)', () => {
+  const findFab = (
+    name: RegExp | string = /open feedback form/i,
+  ): Promise<HTMLElement> => screen.findByRole('button', { name });
+
+  it('variant="bubble" without a position renders the bottom-right bubble', async () => {
+    mountFab(undefined, { variant: 'bubble' });
+    const fab = await findFab();
+    expect(fab.className).toContain('brw-fab--bubble');
+    expect(fab.className).toContain('brw-fab-br');
+    expect(fab).toHaveAttribute('data-brw-variant', 'bubble');
+  });
+
+  it('position="left" renders the tab on the left edge', async () => {
+    mountFab(undefined, { position: 'left' });
+    const fab = await findFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab).toHaveAttribute('data-brw-variant', 'tab');
+  });
+
+  it('position="right" renders the tab on the right edge', async () => {
+    mountFab(undefined, { position: 'right' });
+    const fab = await findFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', async () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    mountFab(undefined, { variant: 'tab', position: 'bottom-left' });
+    const fab = await findFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-l\b/);
+    expect(fab.className).not.toContain('brw-fab-bl');
+  });
+
+  it('variant="tab" + position="bottom-right" resolves to the right-edge tab', async () => {
+    mountFab(undefined, { variant: 'tab', position: 'bottom-right' });
+    const fab = await findFab();
+    expect(fab.className).toMatch(/brw-fab--tab/);
+    expect(fab.className).toMatch(/brw-fab-r\b/);
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', async () => {
+    mountFab(undefined, { variant: 'bubble', position: 'left' });
+    const fab = await findFab();
+    expect(fab.className).toContain('brw-fab--bubble');
+    expect(fab.className).toContain('brw-fab-bl');
+  });
+
+  it('variant="bubble" + position="right" renders the bubble at the bottom-right corner', async () => {
+    mountFab(undefined, { variant: 'bubble', position: 'right' });
+    const fab = await findFab();
+    expect(fab.className).toContain('brw-fab--bubble');
+    expect(fab.className).toContain('brw-fab-br');
+  });
+
+  it('left-edge tab opens the panel anchored bottom-left', async () => {
+    mountFab(undefined, { position: 'left' });
+    const fab = await findFab();
+    await act(async () => {
+      await fireEvent.click(fab);
+    });
+    const panel = screen.getByRole('dialog', { name: /send feedback/i });
+    expect(panel.className).toContain('brw-panel-bl');
+    expect(panel.className).not.toContain('brw-panel-br');
+  });
+
+  it('compact drops the visible label and promotes the label to aria-label', async () => {
+    mountFab(undefined, { compact: true, label: 'Report a bug' });
+    const fab = await findFab('Report a bug');
+    expect(fab.className).toContain('brw-fab--compact');
+    // The label text must not render — compact is icon-only.
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+    expect(screen.queryByText('Report a bug')).toBeNull();
+  });
+
+  it('compact with the default label falls back to aria-label="Feedback"', async () => {
+    mountFab(undefined, { compact: true });
+    const fab = await findFab('Feedback');
+    expect(fab).toHaveAttribute('aria-label', 'Feedback');
+    expect(fab.querySelector('.brw-fab-label')).toBeNull();
+  });
+
+  it('non-compact keeps aria-label="Open feedback form" and the visible label span', async () => {
+    mountFab(undefined, { label: 'Report a bug' });
+    const fab = await findFab();
+    expect(fab).toHaveAttribute('aria-label', 'Open feedback form');
+    const labelSpan = fab.querySelector('.brw-fab-label');
+    expect(labelSpan).not.toBeNull();
+    expect(labelSpan?.textContent).toBe('Report a bug');
+  });
+
+  it('offset sets --brw-fab-tab-offset inline on the tab only when non-zero', async () => {
+    mountFab(undefined, { offset: 120 });
+    const fab = await findFab();
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('120px');
+  });
+
+  it('offset=0 sets no inline custom property on the tab', async () => {
+    mountFab(undefined, { offset: 0 });
+    const fab = await findFab();
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('offset is ignored for the bubble (no inline custom property)', async () => {
+    mountFab(undefined, { variant: 'bubble', offset: 120 });
+    const fab = await findFab();
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('component stylesheet declares the vertical tab + keeps the launcher chrome contract', () => {
+    // The Svelte widget ships its CSS inside the SFC's <style> block (no
+    // exported BREVWICK_CSS string like React), so the regression guard
+    // reads the component source — same pre-runtime surface the React
+    // test pins.
+    // `import.meta.url` is an http:// URL under happy-dom, so resolve from
+    // the package root (vitest's cwd) instead.
+    const source = readFileSync(
+      join(process.cwd(), 'src', 'lib', 'components', 'FeedbackButton.svelte'),
+      'utf8',
+    );
+    // Tab geometry: writing-mode flips the inline axis vertical.
+    expect(source).toMatch(
+      /\.brw-svelte-fab\.brw-fab--tab\s*\{[^}]*writing-mode:\s*vertical-rl/,
+    );
+    // Shared launcher chrome keeps this adapter's stacking contract.
+    expect(source).toMatch(/\.brw-svelte-fab\s*\{[^}]*z-index:\s*2147483646/);
+    // Bubble keeps the legacy pill geometry under its own class.
+    expect(source).toMatch(
+      /\.brw-svelte-fab\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
+    );
   });
 });

--- a/packages/svelte/src/__tests__/feedback-button.test.ts
+++ b/packages/svelte/src/__tests__/feedback-button.test.ts
@@ -1417,4 +1417,26 @@ describe('<FeedbackButton> — launcher presentation (variant + position)', () =
       /\.brw-svelte-fab\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
     );
   });
+
+  // Regression: the left-edge tab must stay vertically centred. The standalone
+  // `rotate: 180deg` property on `.brw-fab-l` is applied AFTER `transform`
+  // (CSS Transforms L2), flipping the centering `translateY(-50%)` into
+  // `+50%` and dropping the tab a full tab-height below centre. happy-dom
+  // cannot compute composed transforms, so we assert the corrected SFC shape.
+  it('left-edge tab composes its 180° flip inside transform so centering survives', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src', 'lib', 'components', 'FeedbackButton.svelte'),
+      'utf8',
+    );
+    expect(source).not.toMatch(/rotate:\s*180deg/);
+    expect(source).toMatch(
+      /\.brw-svelte-fab\.brw-fab--tab\s*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip/,
+    );
+    expect(source).toMatch(
+      /\.brw-svelte-fab\.brw-fab-l\s*\{[^}]*--brw-fab-tab-flip:\s*180deg/,
+    );
+    expect(source).toMatch(
+      /\.brw-svelte-fab\.brw-fab--tab:hover[^{]*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip[^)]*\)\)\s*translateX\(-2px\)/,
+    );
+  });
 });

--- a/packages/svelte/src/__tests__/fixtures/App.svelte
+++ b/packages/svelte/src/__tests__/fixtures/App.svelte
@@ -5,10 +5,19 @@
   } from '@tatlacas/brevwick-sdk';
   import { setBrevwickContext } from '../../lib/context';
   import FeedbackButton from '../../lib/components/FeedbackButton.svelte';
+  import type {
+    FeedbackButtonPosition,
+    FeedbackButtonVariant,
+  } from '../../lib/launcher';
 
   export let config: BrevwickConfig;
   export let onSubmit: ((result: SubmitResult) => void) | undefined = undefined;
-  export let position: 'bottom-right' | 'bottom-left' = 'bottom-right';
+  // No defaults for variant/position — `resolveLauncherPlacement` must see
+  // "unset" so the corner-implies-bubble compat rule stays observable.
+  export let variant: FeedbackButtonVariant | undefined = undefined;
+  export let position: FeedbackButtonPosition | undefined = undefined;
+  export let compact: boolean = false;
+  export let offset: number = 0;
   export let disabled: boolean = false;
   export let hidden: boolean = false;
   export let label: string = 'Feedback';
@@ -19,7 +28,10 @@
 
 <FeedbackButton
   {onSubmit}
+  {variant}
   {position}
+  {compact}
+  {offset}
   {disabled}
   {hidden}
   {label}

--- a/packages/svelte/src/lib/components/FeedbackButton.svelte
+++ b/packages/svelte/src/lib/components/FeedbackButton.svelte
@@ -1071,10 +1071,13 @@
     flex-shrink: 0;
   }
 
-  /* Bubble — legacy corner pill. */
+  /* Bubble — legacy corner pill. Fixed 48px height + 48px compact circle
+     to stay a visual twin of the react/solid/vue/RN bubble. */
   .brw-svelte-fab.brw-fab--bubble {
     bottom: calc(24px + env(safe-area-inset-bottom, 0px));
-    padding: 10px 16px;
+    height: 48px;
+    min-width: 48px;
+    padding: 0 18px;
     border-radius: 999px;
   }
   .brw-svelte-fab.brw-fab--bubble:hover:not(:disabled) {
@@ -1087,19 +1090,22 @@
     left: calc(24px + env(safe-area-inset-left, 0px));
   }
   .brw-svelte-fab.brw-fab--bubble.brw-fab--compact {
-    width: 40px;
-    height: 40px;
+    width: 48px;
+    height: 48px;
     padding: 0;
     justify-content: center;
   }
 
   /* Tab — vertical edge tab, the new default. writing-mode stacks the
-     icon + label vertically; the left tab adds `rotate: 180deg` (the
-     standalone property, NOT transform, so it composes with the hover
-     translateX) to mirror the flat edge and radii automatically. */
+     icon + label vertically; the left tab mirrors the flat edge and radii
+     by rotating 180° composed INSIDE `transform` (after the centering
+     translateY) via `--brw-fab-tab-flip`. Composing in `transform` (not the
+     standalone `rotate` property, which applies AFTER `transform` per CSS
+     Transforms L2) keeps `translateY(-50%)` outermost, so it never inverts
+     into `+50%` and the left tab stays vertically centred. */
   .brw-svelte-fab.brw-fab--tab {
     top: calc(50% + var(--brw-fab-tab-offset, 0px));
-    transform: translateY(-50%);
+    transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg));
     writing-mode: vertical-rl;
     min-height: 48px;
     width: 40px;
@@ -1114,13 +1120,14 @@
   }
   .brw-svelte-fab.brw-fab-l {
     left: env(safe-area-inset-left, 0px);
-    border-right: none; /* pre-rotation right edge IS the viewport edge */
-    rotate: 180deg;
+    border-right: none; /* pre-flip right edge IS the viewport edge */
+    --brw-fab-tab-flip: 180deg;
   }
-  /* Hover pulls the tab 2px out of its edge (the left tab's rotate flips
-     the sign); translateY(-50%) must be restated, transform overwrites. */
+  /* Hover pulls the tab 2px out of its edge (the whole transform is
+     restated — transform overwrites). translateX(-2px) is innermost, so
+     the left tab's 180° flip turns it into +2px visually. */
   .brw-svelte-fab.brw-fab--tab:hover:not(:disabled) {
-    transform: translateY(-50%) translateX(-2px);
+    transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg)) translateX(-2px);
   }
   .brw-svelte-fab .brw-fab-label {
     letter-spacing: 0.02em;

--- a/packages/svelte/src/lib/components/FeedbackButton.svelte
+++ b/packages/svelte/src/lib/components/FeedbackButton.svelte
@@ -9,19 +9,42 @@
   } from '@tatlacas/brevwick-sdk';
   import { getFeedback } from '../context';
   import { BREVWICK_SVELTE_VERSION } from '../internal/version';
+  import {
+    resolveLauncherPlacement,
+    type FeedbackButtonPosition,
+    type FeedbackButtonVariant,
+  } from '../launcher';
 
-  // Props use Svelte's `export let` (legacy mode under Svelte 5) rather
-  // than `$props()` runes. This keeps the SFC compiling under both legacy
-  // and runes-mode hosts: Svelte 5 supports `export let` cleanly in legacy
-  // mode, and a runes-mode parent simply sees the same prop interface.
-  // We will revisit when Svelte 6 (rune-only) lands.
-  /** Corner the FAB pins to. Default `'bottom-right'`. */
-  export let position: 'bottom-right' | 'bottom-left' = 'bottom-right';
+  // Props use `export let` (not `$props()` runes) so the SFC compiles
+  // under both legacy and runes-mode hosts. Revisit at Svelte 6.
+  /**
+   * Launcher presentation. Default `'tab'` (new default). Intentionally no
+   * prop-level default — `resolveLauncherPlacement` must see "unset" so the
+   * corner-implies-bubble compat rule can fire.
+   */
+  export let variant: FeedbackButtonVariant | undefined = undefined;
+  /**
+   * Launcher placement. Defaults: `'right'` (tab), `'bottom-right'`
+   * (bubble). A legacy corner without an explicit `variant` keeps the
+   * bubble; when both are set, `variant` wins and `position` contributes
+   * only its horizontal side.
+   */
+  export let position: FeedbackButtonPosition | undefined = undefined;
+  /**
+   * Icon-only mode (circular bubble / square edge tab). The `label` is not
+   * rendered but becomes the `aria-label`. Default `false`.
+   */
+  export let compact: boolean = false;
+  /**
+   * Tab-only: vertical offset in px from the viewport's vertical center
+   * (positive = down). Ignored for the bubble. Default `0`.
+   */
+  export let offset: number = 0;
   /** When true, the FAB renders as disabled and cannot open the dialog. */
   export let disabled: boolean = false;
   /** When true, the component renders nothing. Useful for feature-flagging. */
   export let hidden: boolean = false;
-  /** FAB label. Default `'Feedback'`. */
+  /** Launcher label. Default `'Feedback'`. Hidden visually when `compact`. */
   export let label: string = 'Feedback';
   /** Force a palette regardless of the OS `prefers-color-scheme` setting. */
   export let theme: 'light' | 'dark' | 'system' = 'system';
@@ -29,24 +52,15 @@
   export let onSubmit: ((result: SubmitResult) => void) | undefined = undefined;
 
   // File attachment cap. Keep in sync with MAX_ATTACHMENT_COUNT in
-  // packages/sdk/src/submit.ts (not exported on the SDK's frozen public
-  // surface) and the matching constant in packages/react/src/feedback-button.tsx.
-  // Enforced in the UI so the user can't queue an attachment the SDK would
-  // reject downstream.
+  // packages/sdk/src/submit.ts and the React adapter's constant.
   const MAX_ATTACHMENTS = 5;
 
-  // Stagger between staged-status rows in milliseconds. Applied as
-  // `animation-delay` per row (the rows mount with a CSS @keyframes
-  // entrance, not a transition) so the rows fade in sequentially even
-  // when the underlying SDK phase events fire microseconds apart.
-  // Honoured only when the user has not requested reduced motion —
-  // see `prefersReducedMotion` below.
+  // Per-row `animation-delay` stagger (ms) so the staged-status rows fade
+  // in sequentially; skipped under prefers-reduced-motion.
   const STATUS_ROW_STAGGER_MS = 200;
 
-  // Phase ordinal mirrored from the React adapter (#74). Row 1 ("Captured")
-  // shows from `'sanitising'` onwards, row 2 ("Sanitised") from
-  // `'formatting'` onwards. Row 3 ("Formatting with AI") has its own
-  // exact-match rule and does not consult this table.
+  // Phase ordinal mirrored from the React adapter (#74). Row 3
+  // ("Formatting with AI") has its own exact-match rule.
   const PHASE_RANK: Record<string, number> = {
     idle: 0,
     capturing: 1,
@@ -64,11 +78,7 @@
   const phase = feedback.phase;
   const submitErrorTagged = feedback.error;
 
-  /**
-   * One bubble in the conversation thread. The greeting and submitted-issue
-   * receipt are `assistant` messages; submitted drafts become `user`
-   * messages. Mirrors the React adapter's Message shape.
-   */
+  /** One bubble in the conversation thread (React's Message shape). */
   type Message = {
     id: string;
     role: 'assistant' | 'user';
@@ -76,10 +86,8 @@
     sentAt?: number;
     issueSent?: boolean;
     /**
-     * The exact, post-redaction payload the SDK POSTed for this message —
-     * set only when the host enabled `config.debug`. When present, the bubble
-     * renders a "copy raw payload" affordance so a developer can inspect
-     * everything that left the device (rings/context the widget never shows).
+     * Exact post-redaction payload the SDK POSTed — set only under
+     * `config.debug`; renders a "copy raw payload" affordance.
      */
     rawPayload?: Record<string, unknown>;
   };
@@ -110,16 +118,11 @@
   let fileId = 0;
   let messageId = 0;
   let prefersReducedMotion = false;
-  // Bound to the composer textarea so the autogrow reactive block can
-  // measure scrollHeight and resize between min-height (one row) and
-  // COMPOSER_MAX_HEIGHT_PX without coupling to a CSS-only grow that
-  // would jump in row-sized increments.
+  // Bound to the composer textarea for scrollHeight-based autogrow.
   let textareaEl: HTMLTextAreaElement | undefined;
 
   // Project-config render-policy state. Mirrors React's `useProjectConfig`:
-  // lazy fetch on first panel open, cache the result for the lifetime of the
-  // component. The fetch is gated behind the open-state to preserve the
-  // widget's "zero-cost until opened" property.
+  // lazy fetch on first open, cached for the component's lifetime.
   type ProjectConfigStatus = 'idle' | 'loading' | 'ready' | 'error';
   let projectConfigStatus: ProjectConfigStatus = 'idle';
   let projectConfig: ProjectConfig | null = null;
@@ -134,22 +137,16 @@
     projectConfig?.ai_enabled === true &&
     projectConfig?.ai_submitter_choice_allowed === true;
 
-  // Last submitted FeedbackInput so the retry path can re-run the exact same
-  // payload without forcing the user to re-type the draft we cleared
-  // synchronously on Send.
+  // Last submitted FeedbackInput so retry re-runs the exact same payload.
   let lastSubmittedInput: FeedbackInput | null = null;
-  // Id of the user bubble for the most recent submit, so the retry path can
-  // re-attach a freshly composed `rawPayload` to the same bubble.
+  // User bubble id for the most recent submit, so retry can re-attach a
+  // freshly composed `rawPayload` to the same bubble.
   let lastUserMessageId: string | null = null;
-  // Id of the bubble whose copy button is showing "Copied!" feedback, plus
-  // the timer that clears it. A single id (not per-button state) keeps the
-  // dev-only affordance off the markup hot path.
+  // Bubble id showing "Copied!" feedback + the timer that clears it.
   let copiedRawId: string | null = null;
   let copiedRawTimeout: ReturnType<typeof setTimeout> | undefined;
 
-  // Receipt timestamps live in a writable so the relative-time formatter
-  // re-runs reactively without coupling to the message identity. Mirrors
-  // the React `formatRelativeTime` reading `Date.now()` once at render.
+  // Writable so the relative-time formatter re-runs reactively.
   const nowStore = writable<number>(Date.now());
 
   $: attachmentsAtCap = files.length >= MAX_ATTACHMENTS;
@@ -160,19 +157,15 @@
     files.length > 0;
   $: canSend = draft.trim().length > 0 && $status !== 'submitting';
 
-  // Autogrow the composer textarea between one row and
-  // COMPOSER_MAX_HEIGHT_PX as the user types. Mirrors the React adapter:
-  // reset to `auto` first so shrinking on backspace works, then size to
-  // `scrollHeight` capped at the ceiling.
+  // Autogrow the composer textarea up to COMPOSER_MAX_HEIGHT_PX. Reset to
+  // `auto` first so shrinking on backspace works (parity with React).
   $: if (textareaEl && draft !== undefined) {
     textareaEl.style.height = 'auto';
     textareaEl.style.height = `${Math.min(textareaEl.scrollHeight, COMPOSER_MAX_HEIGHT_PX)}px`;
   }
 
-  // Phase-driven row visibility. Parity with the React adapter — row 1
-  // shows from `sanitising` onwards, row 2 from `formatting` onwards, row
-  // 3 only during the exact `formatting` phase (and only when the project
-  // has AI enabled). The retry row owns the `error` phase exclusively.
+  // Phase-driven row visibility, parity with React. The retry row owns
+  // the `error` phase exclusively.
   $: phaseRank = PHASE_RANK[$phase] ?? 0;
   $: showCaptured = phaseRank >= PHASE_RANK.sanitising;
   $: showSanitised = phaseRank >= PHASE_RANK.formatting;
@@ -197,10 +190,8 @@
     if (copiedRawTimeout) clearTimeout(copiedRawTimeout);
   });
 
-  // Lazy project-config fetch on first panel open. Subsequent opens reuse
-  // the cached result. Mirrors the React adapter's useProjectConfig — the
-  // SDK itself caches per session, so the second call would no-op anyway,
-  // but tracking here avoids an extra awaited microtask on every open.
+  // Lazy project-config fetch on first panel open; later opens reuse the
+  // cached result (the SDK also caches per session).
   $: if (open && !projectConfigTriggered) {
     projectConfigTriggered = true;
     projectConfigStatus = 'loading';
@@ -546,10 +537,27 @@
     return `${days} d ago`;
   }
 
-  // Reactive so the FAB / panel CSS classes re-derive when `position` changes.
-  $: fabPosClass = position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br';
+  // resolveLauncherPlacement is the single source of truth for the
+  // variant/position matrix (shared shape with React).
+  $: placement = resolveLauncherPlacement(variant, position);
+  $: fabModifierClasses = [
+    placement.variant === 'tab' ? 'brw-fab--tab' : 'brw-fab--bubble',
+    placement.variant === 'tab'
+      ? placement.side === 'left'
+        ? 'brw-fab-l'
+        : 'brw-fab-r'
+      : placement.side === 'left'
+        ? 'brw-fab-bl'
+        : 'brw-fab-br',
+    compact ? 'brw-fab--compact' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
   $: panelPosClass =
-    position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br';
+    placement.side === 'left' ? 'brw-panel-bl' : 'brw-panel-br';
+  // Compact removes the visible text, so `label` becomes the aria-label;
+  // non-compact keeps the established accessible name (parity with React).
+  $: fabAriaLabel = compact ? label : 'Open feedback form';
 
   // Per-instance ID for the disclosure aria-controls relationship. Stays
   // stable across re-renders so AT focus tracking doesn't churn. Uses a
@@ -917,16 +925,23 @@
       </div>
     {/if}
 
+    <!-- --brw-fab-tab-offset is a positioning input, not part of the
+         public --brw-* theming contract — set only when it has an effect. -->
     <button
       type="button"
-      class="brw-svelte-fab {fabPosClass}"
+      class="brw-svelte-fab {fabModifierClasses}"
       data-brevwick-skip
       data-testid="brw-svelte-fab"
-      aria-label="Open feedback form"
+      data-brw-variant={placement.variant}
+      aria-label={fabAriaLabel}
+      style:--brw-fab-tab-offset={placement.variant === 'tab' && offset !== 0
+        ? `${offset}px`
+        : undefined}
       {disabled}
       on:click={toggleOpen}
     >
       <svg
+        class="brw-fab-icon"
         viewBox="0 0 24 24"
         width="18"
         height="18"
@@ -939,7 +954,7 @@
       >
         <path d="M21 12a8 8 0 0 1-11.6 7.1L4 20l1-4.6A8 8 0 1 1 21 12z" />
       </svg>
-      <span>{label}</span>
+      {#if !compact}<span class="brw-fab-label">{label}</span>{/if}
     </button>
   </div>
 {/if}
@@ -971,11 +986,8 @@
     --brw-accent: #4f46e5;
     --brw-accent-fg: #ffffff;
     --brw-error: #b91c1c;
-    /* Success / check colour for the staged-status checklist. Matches the
-       emerald used in the marketing AnimatedDemo so the in-widget checklist
-       reads as the same affordance the docs preview. Widget-internal: no
-       public --brw-success alias by design — host overrides flow through
-       --brw-accent for chrome and don't need a knob for the green tick. */
+    /* Checklist tick colour. Widget-internal by design — no public
+       --brw-success knob; host overrides flow through --brw-accent. */
     --brw-success: #10b981;
     --brw-shadow:
       0 1px 2px rgba(0, 0, 0, 0.06), 0 8px 24px rgba(0, 0, 0, 0.12);
@@ -1028,14 +1040,13 @@
     }
   }
 
+  /* Shared launcher chrome — variant geometry lives on .brw-fab--bubble /
+     .brw-fab--tab (mirrors the React adapter's .brw-fab split). */
   .brw-svelte-fab {
     position: fixed;
-    bottom: 24px;
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 10px 16px;
-    border-radius: 999px;
     border: 1px solid var(--brw-border);
     background: var(--brw-panel-bg);
     color: var(--brw-fg);
@@ -1043,23 +1054,90 @@
     cursor: pointer;
     font: inherit;
     z-index: 2147483646;
+    transition: transform 120ms ease-out;
   }
   .brw-svelte-fab:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
-  .brw-svelte-fab.brw-fab-br {
-    right: 24px;
+  /* Ring sits 2px outside the box so it clears the tab's flat edge. */
+  .brw-svelte-fab:focus-visible {
+    outline: 2px solid var(--brw-border-focus);
+    outline-offset: 2px;
   }
-  .brw-svelte-fab.brw-fab-bl {
-    left: 24px;
+  .brw-svelte-fab .brw-fab-icon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
   }
 
-  /* Anchor the panel at the same `bottom: 24px` / corner offset as the
-     FAB so the panel's higher z-index covers the FAB while it is open
-     (parity with the React adapter — Radix Dialog there mounts the
-     panel above the trigger at the same position, hiding the FAB
-     behind the panel rather than leaving them side-by-side). */
+  /* Bubble — legacy corner pill. */
+  .brw-svelte-fab.brw-fab--bubble {
+    bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+    padding: 10px 16px;
+    border-radius: 999px;
+  }
+  .brw-svelte-fab.brw-fab--bubble:hover:not(:disabled) {
+    transform: translateY(-1px);
+  }
+  .brw-svelte-fab.brw-fab-br {
+    right: calc(24px + env(safe-area-inset-right, 0px));
+  }
+  .brw-svelte-fab.brw-fab-bl {
+    left: calc(24px + env(safe-area-inset-left, 0px));
+  }
+  .brw-svelte-fab.brw-fab--bubble.brw-fab--compact {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  /* Tab — vertical edge tab, the new default. writing-mode stacks the
+     icon + label vertically; the left tab adds `rotate: 180deg` (the
+     standalone property, NOT transform, so it composes with the hover
+     translateX) to mirror the flat edge and radii automatically. */
+  .brw-svelte-fab.brw-fab--tab {
+    top: calc(50% + var(--brw-fab-tab-offset, 0px));
+    transform: translateY(-50%);
+    writing-mode: vertical-rl;
+    min-height: 48px;
+    width: 40px;
+    padding: 16px 0;
+    justify-content: center;
+    /* Rounded page-facing side, flat against the viewport edge. */
+    border-radius: 10px 0 0 10px;
+  }
+  .brw-svelte-fab.brw-fab-r {
+    right: env(safe-area-inset-right, 0px);
+    border-right: none; /* flat edge: no hairline against the viewport */
+  }
+  .brw-svelte-fab.brw-fab-l {
+    left: env(safe-area-inset-left, 0px);
+    border-right: none; /* pre-rotation right edge IS the viewport edge */
+    rotate: 180deg;
+  }
+  /* Hover pulls the tab 2px out of its edge (the left tab's rotate flips
+     the sign); translateY(-50%) must be restated, transform overwrites. */
+  .brw-svelte-fab.brw-fab--tab:hover:not(:disabled) {
+    transform: translateY(-50%) translateX(-2px);
+  }
+  .brw-svelte-fab .brw-fab-label {
+    letter-spacing: 0.02em;
+  }
+  .brw-svelte-fab.brw-fab--tab.brw-fab--compact {
+    width: 44px;
+    min-height: 44px;
+    padding: 0;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .brw-svelte-fab {
+      transition: none;
+    }
+  }
+
+  /* Anchored at the FAB's corner offset so the panel's higher z-index
+     covers the FAB while open (parity with React's Radix Dialog). */
   .brw-svelte-panel {
     position: fixed;
     bottom: 24px;
@@ -1278,18 +1356,11 @@
     min-height: 34px;
   }
 
-  /* Staged-status rows: progress indicators, not conversation bubbles.
-     They sit under a dashed top divider as a compact stacked checklist,
-     mirroring the marketing AnimatedDemo widget mock — and intentionally
-     stay outside the bubble class family so message-count queries ignore
-     them. .brw-svelte-status-rows is the grouping container that owns
-     the divider + stacking; .brw-svelte-status-row is one ticked line.
-     The animation-delay is set inline per row so the three rows fade in
-     sequentially under the shared @keyframes entrance even when the
-     underlying SDK phase events fire microseconds apart. The
-     reduced-motion media query collapses the entrance to an instant
-     fade, pairing with the inline 0ms delay the template emits when
-     prefers-reduced-motion: reduce. */
+  /* Staged-status rows: a stacked checklist under a dashed divider,
+     intentionally outside the bubble class family so message-count
+     queries ignore them. animation-delay is set inline per row so the
+     rows fade in sequentially even when SDK phase events fire
+     microseconds apart; reduced-motion collapses the entrance. */
   .brw-svelte-status-rows {
     align-self: stretch;
     display: flex;
@@ -1321,10 +1392,7 @@
     width: 12px;
     height: 12px;
   }
-  /* The shared .brw-svelte-spinner ships at 14px so it reads at full size
-     in the composer; inside the staged-status checklist it has to match
-     the 12px tick so the third row's indicator sits on the same baseline
-     as the first two. */
+  /* Downsize the shared 14px spinner to match the 12px ticks. */
   .brw-svelte-status-row .brw-svelte-spinner {
     width: 12px;
     height: 12px;
@@ -1332,11 +1400,8 @@
   .brw-svelte-status-row-label {
     flex: 1;
   }
-  /* The retry row is a standalone alert that sits outside the checklist
-     container, so it carries its own chrome — padding, radius, border —
-     instead of inheriting the checklist's tick-line minimalism. The
-     background stays transparent so the red border + red label read as
-     an alert overlay rather than a filled bubble surface. */
+  /* Retry row: a standalone alert outside the checklist container, with
+     its own chrome; transparent bg so it reads as an alert overlay. */
   .brw-svelte-status-row--error {
     align-self: stretch;
     padding: 10px 12px;
@@ -1426,15 +1491,9 @@
     }
   }
 
-  /* Outer composer is just the bottom strip — padding + bg + the
-     divider line above. The actual input affordance lives in
-     `.brw-svelte-composer-shell` so it reads as one unified chip
-     containing the attach button, textarea, optional AI toggle and
-     send button. Mirrors the React adapter's `.brw-composer` /
-     `.brw-composer-shell` split (#114 follow-up — the original Svelte
-     parity PR shipped a 3-row grid that put the textarea on its own
-     row; this shape lines everything up on one row to match the
-     React reference). */
+  /* Outer composer is the bottom strip; the unified input chip (attach,
+     textarea, AI toggle, send on one row) lives in -composer-shell.
+     Mirrors React's .brw-composer / .brw-composer-shell split (#114). */
   .brw-svelte-composer {
     flex-shrink: 0;
     padding: 8px 10px;
@@ -1505,12 +1564,9 @@
     pointer-events: none;
   }
 
-  /* AI toggle — track-and-thumb switch, parity with the React adapter's
-     iOS-style toggle (#65). The "AI" text sits outside the button so the
-     switch itself is an unambiguous track, not a pressed-button state. */
-  /* Wrap matches `.brw-svelte-send` height (34px) so the switch
-     centre and the send-button centre land on the same baseline
-     under the shell's `align-items: flex-end`. */
+  /* AI toggle — track-and-thumb switch, parity with React (#65). The
+     "AI" text sits outside the button; the wrap matches the send
+     button's 34px height so both centre on the same baseline. */
   .brw-svelte-aitoggle-wrap {
     flex-shrink: 0;
     display: inline-flex;

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -8,6 +8,7 @@ export { setBrevwickContext, getFeedback } from './context';
 export type { FeedbackHandle, FeedbackPhase, FeedbackStatus } from './context';
 
 export { default as FeedbackButton } from './components/FeedbackButton.svelte';
+export type { FeedbackButtonPosition, FeedbackButtonVariant } from './launcher';
 
 export { BREVWICK_SVELTE_VERSION } from './internal/version';
 

--- a/packages/svelte/src/lib/launcher.ts
+++ b/packages/svelte/src/lib/launcher.ts
@@ -1,0 +1,50 @@
+/**
+ * Launcher presentation types + placement resolution for the Svelte
+ * FeedbackButton. Mirrors the React adapter byte-for-byte (see
+ * packages/react/src/feedback-button.tsx) so every adapter resolves the
+ * variant/position matrix identically.
+ */
+
+/** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
+ *  against a viewport edge; `'bubble'` is the legacy floating corner pill. */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement.
+ * - `'right' | 'left'`        — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble). Passing one of these WITHOUT an explicit `variant` opts into
+ *   the bubble, preserving pre-2.x call sites byte-for-byte.
+ */
+export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — the single source of truth shared by the
+ * FAB class derivation and the panel anchor. See the resolution table in
+ * the design spec (mirrored in every adapter):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component is ignored for the tab
+ *   — tabs are always vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner implies the bubble so
+ *   pre-existing call sites keep their corner pill; everything else is
+ *   the tab (the new default), on the right edge unless `position` says
+ *   otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+export function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}

--- a/packages/svelte/src/lib/launcher.ts
+++ b/packages/svelte/src/lib/launcher.ts
@@ -1,9 +1,14 @@
 /**
- * Launcher presentation types + placement resolution for the Svelte
- * FeedbackButton. Mirrors the React adapter byte-for-byte (see
- * packages/react/src/feedback-button.tsx) so every adapter resolves the
- * variant/position matrix identically.
+ * Launcher presentation types for the Svelte FeedbackButton.
+ *
+ * The placement RESOLUTION (`resolveLauncherPlacement`) is a pure,
+ * framework-agnostic function shared by every adapter, so it is hoisted into
+ * `@tatlacas/brevwick-sdk/launcher` (CLAUDE.md: "shared utilities go in
+ * core") and re-exported here for the component. Only the public prop TYPES
+ * stay adapter-local so this package can carry its own JSDoc.
  */
+
+export { resolveLauncherPlacement } from '@tatlacas/brevwick-sdk/launcher';
 
 /** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
  *  against a viewport edge; `'bubble'` is the legacy floating corner pill. */
@@ -21,30 +26,3 @@ export type FeedbackButtonPosition =
   | 'left'
   | 'bottom-right'
   | 'bottom-left';
-
-/**
- * Resolved launcher placement — the single source of truth shared by the
- * FAB class derivation and the panel anchor. See the resolution table in
- * the design spec (mirrored in every adapter):
- *
- * - Explicit `variant` always wins; `position` then only contributes its
- *   horizontal side (a corner's vertical component is ignored for the tab
- *   — tabs are always vertically centered, ± `offset`).
- * - With `variant` unset, an explicit legacy corner implies the bubble so
- *   pre-existing call sites keep their corner pill; everything else is
- *   the tab (the new default), on the right edge unless `position` says
- *   otherwise.
- *
- * Every combination is total — no throws, no dead states.
- */
-export function resolveLauncherPlacement(
-  variant?: FeedbackButtonVariant,
-  position?: FeedbackButtonPosition,
-): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner without a variant keeps the bubble.
-  const isCorner = position === 'bottom-right' || position === 'bottom-left';
-  return { variant: isCorner ? 'bubble' : 'tab', side };
-}

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -42,7 +42,7 @@ import { FeedbackButton } from '@tatlacas/brevwick-vue';
 </template>
 ```
 
-That's it. A floating action button appears in the bottom-right; clicking it opens a feedback dialog with screenshot capture and submit.
+That's it. A vertical feedback tab appears on the right edge of the viewport (pass `position="bottom-right"` for the legacy corner bubble); clicking it opens a feedback dialog with screenshot capture and submit.
 
 ## `BrevwickPlugin`
 
@@ -60,23 +60,36 @@ The plugin calls `sdk.install()` after mount (attaches global ring listeners —
 
 ## `FeedbackButton`
 
-A floating action button + dialog. The dialog has a textarea, a screenshot capture button, and a send button.
+A feedback launcher + dialog. The launcher renders as a vertical tab flush against the right viewport edge by default, or as the classic floating corner bubble via `variant="bubble"`. The dialog has a textarea, a screenshot capture button, and a send button.
 
 ```vue
-<FeedbackButton position="bottom-right" label="Report a bug" />
+<!-- Default: vertical tab on the right edge, vertically centered. -->
+<FeedbackButton label="Report a bug" />
+
+<!-- Legacy floating corner bubble. -->
+<FeedbackButton variant="bubble" position="bottom-right" label="Report a bug" />
+
+<!-- Icon-only tab, nudged 120px above the vertical center. The label
+     becomes the launcher's aria-label. -->
+<FeedbackButton compact :offset="-120" label="Report a bug" />
 ```
+
+> **Migration:** the default presentation changed from the corner bubble to the right-edge tab. Pass `position="bottom-right"` (or your previous corner) to keep the old look — a legacy corner `position` without an explicit `variant` still renders the bubble, so existing call sites are unaffected.
 
 ### Props
 
-| Prop        | Type                              | Default          | Description                                                |
-| ----------- | --------------------------------- | ---------------- | ---------------------------------------------------------- |
-| `position`  | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Which corner the FAB pins to.                              |
-| `disabled`  | `boolean`                         | `false`          | FAB renders as disabled and cannot open the dialog.        |
-| `hidden`    | `boolean`                         | `false`          | Component renders nothing — useful for feature flags.      |
-| `className` | `string`                          | —                | Appended to the FAB and dialog root for styling overrides. |
-| `label`     | `string`                          | `'Feedback'`     | FAB label text.                                            |
-| `theme`     | `'system' \| 'light' \| 'dark'`   | `'system'`       | Force a palette regardless of OS `prefers-color-scheme`.   |
-| `onSubmit`  | `(result: SubmitResult) => void`  | —                | Fired after every submit (success or failure).             |
+| Prop        | Type                                                   | Default                                     | Description                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `variant`   | `'tab' \| 'bubble'`                                    | `'tab'`                                     | Launcher presentation — vertical edge tab (the new default) or the legacy floating corner pill. A legacy corner `position` without an explicit `variant` implies `'bubble'`.         |
+| `position`  | `'right' \| 'left' \| 'bottom-right' \| 'bottom-left'` | `'right'` (tab) / `'bottom-right'` (bubble) | Where the launcher sits. Edge sides are the tab's home, corners the bubble's. When `variant` and `position` disagree, `variant` wins and `position` contributes its horizontal side. |
+| `compact`   | `boolean`                                              | `false`                                     | Icon-only launcher (circular bubble / square edge tab). The `label` is not rendered but becomes the launcher's `aria-label`.                                                         |
+| `offset`    | `number`                                               | `0`                                         | Tab only: vertical offset in px from the viewport's vertical center. Positive moves the tab down, negative up. Ignored for the bubble.                                               |
+| `disabled`  | `boolean`                                              | `false`                                     | Launcher renders as disabled and cannot open the dialog.                                                                                                                             |
+| `hidden`    | `boolean`                                              | `false`                                     | Component renders nothing — useful for feature flags.                                                                                                                                |
+| `className` | `string`                                               | —                                           | Appended to the launcher and dialog root for styling overrides.                                                                                                                      |
+| `label`     | `string`                                               | `'Feedback'`                                | Launcher label text. Hidden visually when `compact`.                                                                                                                                 |
+| `theme`     | `'system' \| 'light' \| 'dark'`                        | `'system'`                                  | Force a palette regardless of OS `prefers-color-scheme`.                                                                                                                             |
+| `onSubmit`  | `(result: SubmitResult) => void`                       | —                                           | Fired after every submit (success or failure).                                                                                                                                       |
 
 ### Theming via CSS custom properties
 

--- a/packages/vue/src/__tests__/feedback-button.test.ts
+++ b/packages/vue/src/__tests__/feedback-button.test.ts
@@ -606,6 +606,24 @@ describe('<FeedbackButton> — launcher presentation (variant + position)', () =
       /\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
     );
   });
+
+  // Regression: the left-edge tab must stay vertically centred. The standalone
+  // `rotate: 180deg` property on `.brw-fab-l` is applied AFTER `transform`
+  // (CSS Transforms L2), flipping the centering `translateY(-50%)` into
+  // `+50%` and dropping the tab a full tab-height below centre. jsdom cannot
+  // compute composed transforms, so we assert the corrected stylesheet shape.
+  it('left-edge tab composes its 180° flip inside transform so centering survives', () => {
+    expect(BREVWICK_CSS).not.toMatch(/rotate:\s*180deg/);
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip/,
+    );
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab-l\s*\{[^}]*--brw-fab-tab-flip:\s*180deg/,
+    );
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab:hover[^{]*\{[^}]*transform:\s*translateY\(-50%\)\s*rotate\(var\(--brw-fab-tab-flip[^)]*\)\)\s*translateX\(-2px\)/,
+    );
+  });
 });
 
 describe('<FeedbackButton> — Use AI toggle', () => {

--- a/packages/vue/src/__tests__/feedback-button.test.ts
+++ b/packages/vue/src/__tests__/feedback-button.test.ts
@@ -69,6 +69,7 @@ vi.mock('@tatlacas/brevwick-sdk', async () => {
 
 import { BrevwickPlugin } from '../plugin';
 import { FeedbackButton } from '../components/feedback-button';
+import { BREVWICK_CSS } from '../styles';
 
 beforeEach(() => {
   // Default getConfig returns null so the AI toggle stays hidden unless a
@@ -131,6 +132,11 @@ describe('<FeedbackButton>', () => {
     expect(fab.exists()).toBe(true);
     expect(fab.attributes('data-brevwick-skip')).toBe('');
     expect(fab.classes()).toContain('brw-fab');
+    // Zero-config default changed in vNEXT: right-edge vertical tab, not
+    // the legacy bottom-right bubble.
+    expect(fab.classes()).toContain('brw-fab--tab');
+    expect(fab.classes()).toContain('brw-fab-r');
+    expect(fab.attributes('data-brw-variant')).toBe('tab');
     expect(wrapper.find('.brw-panel').exists()).toBe(false);
 
     await openPanel(wrapper);
@@ -163,15 +169,30 @@ describe('<FeedbackButton>', () => {
     expect(wrapper.find('button.brw-fab').exists()).toBe(false);
   });
 
-  it('applies the bottom-left position class to FAB and panel', async () => {
+  it('keeps the bubble at bottom-left for a legacy corner position (no variant)', async () => {
+    // Legacy compat: an explicit corner without a `variant` must keep the
+    // pre-vNEXT presentation — the bubble at that corner, not a tab.
     const wrapper = mountFab({ position: 'bottom-left' });
     const fab = wrapper.find('button.brw-fab');
+    expect(fab.classes()).toContain('brw-fab--bubble');
     expect(fab.classes()).toContain('brw-fab-bl');
     expect(fab.classes()).not.toContain('brw-fab-br');
+    expect(fab.attributes('data-brw-variant')).toBe('bubble');
     await openPanel(wrapper);
     const dialog = wrapper.find('[role="dialog"]');
     expect(dialog.classes()).toContain('brw-panel-bl');
     expect(dialog.classes()).not.toContain('brw-panel-br');
+  });
+
+  it('keeps the bubble at bottom-right for a legacy corner position (no variant)', async () => {
+    const wrapper = mountFab({ position: 'bottom-right' });
+    const fab = wrapper.find('button.brw-fab');
+    expect(fab.classes()).toContain('brw-fab--bubble');
+    expect(fab.classes()).toContain('brw-fab-br');
+    expect(fab.classes()).not.toContain('brw-fab-bl');
+    expect(fab.attributes('data-brw-variant')).toBe('bubble');
+    await openPanel(wrapper);
+    expect(wrapper.find('[role="dialog"]').classes()).toContain('brw-panel-br');
   });
 
   it('Enter submits, Shift+Enter does not (newline preserved)', async () => {
@@ -453,6 +474,137 @@ describe('<FeedbackButton>', () => {
   });
   it.skip('region-overlay confirm full crops to the viewport rectangle', () => {
     void captureScreenshot;
+  });
+});
+
+/**
+ * Launcher presentation (variant + position). Pins the full resolution
+ * table: explicit `variant` always wins, `position` contributes only its
+ * horizontal side to a mismatched variant, and a legacy corner without a
+ * variant keeps the bubble. The zero-config default — right-edge tab —
+ * is asserted in the main describe block above.
+ */
+describe('<FeedbackButton> — launcher presentation (variant + position)', () => {
+  function getFab(wrapper: VueWrapper<unknown>) {
+    return wrapper.find('button.brw-fab');
+  }
+
+  it('variant="bubble" without a position renders the bottom-right bubble', () => {
+    const wrapper = mountFab({ variant: 'bubble' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--bubble');
+    expect(fab.classes()).toContain('brw-fab-br');
+    expect(fab.attributes('data-brw-variant')).toBe('bubble');
+  });
+
+  it('position="left" renders the tab on the left edge', () => {
+    const wrapper = mountFab({ position: 'left' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--tab');
+    expect(fab.classes()).toContain('brw-fab-l');
+    expect(fab.attributes('data-brw-variant')).toBe('tab');
+  });
+
+  it('position="right" renders the tab on the right edge', () => {
+    const wrapper = mountFab({ position: 'right' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--tab');
+    expect(fab.classes()).toContain('brw-fab-r');
+  });
+
+  it('variant="tab" + corner position keeps the tab and takes only the horizontal side', () => {
+    // Conflict rule: variant wins; 'bottom-left' contributes only 'left'.
+    const wrapper = mountFab({ variant: 'tab', position: 'bottom-left' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--tab');
+    expect(fab.classes()).toContain('brw-fab-l');
+    expect(fab.classes()).not.toContain('brw-fab-bl');
+  });
+
+  it('variant="tab" + position="bottom-right" resolves to the right-edge tab', () => {
+    const wrapper = mountFab({ variant: 'tab', position: 'bottom-right' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--tab');
+    expect(fab.classes()).toContain('brw-fab-r');
+  });
+
+  it('variant="bubble" + position="left" renders the bubble at the bottom-left corner', () => {
+    const wrapper = mountFab({ variant: 'bubble', position: 'left' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--bubble');
+    expect(fab.classes()).toContain('brw-fab-bl');
+  });
+
+  it('variant="bubble" + position="right" renders the bubble at the bottom-right corner', () => {
+    const wrapper = mountFab({ variant: 'bubble', position: 'right' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--bubble');
+    expect(fab.classes()).toContain('brw-fab-br');
+  });
+
+  it('left-edge tab opens the panel anchored bottom-left', async () => {
+    const wrapper = mountFab({ position: 'left' });
+    await openPanel(wrapper);
+    const dialog = wrapper.find('[role="dialog"]');
+    expect(dialog.classes()).toContain('brw-panel-bl');
+    expect(dialog.classes()).not.toContain('brw-panel-br');
+  });
+
+  it('compact drops the visible label and promotes the label to aria-label', () => {
+    const wrapper = mountFab({ compact: true, label: 'Report a bug' });
+    const fab = getFab(wrapper);
+    expect(fab.classes()).toContain('brw-fab--compact');
+    expect(fab.attributes('aria-label')).toBe('Report a bug');
+    // The label text must not render — compact is icon-only.
+    expect(fab.find('.brw-fab-label').exists()).toBe(false);
+    expect(fab.text()).not.toContain('Report a bug');
+  });
+
+  it('compact without an explicit label falls back to aria-label="Feedback"', () => {
+    const wrapper = mountFab({ compact: true });
+    const fab = getFab(wrapper);
+    expect(fab.attributes('aria-label')).toBe('Feedback');
+    expect(fab.find('.brw-fab-label').exists()).toBe(false);
+  });
+
+  it('non-compact keeps aria-label="Open feedback form" and the visible label span', () => {
+    const wrapper = mountFab({ label: 'Report a bug' });
+    const fab = getFab(wrapper);
+    expect(fab.attributes('aria-label')).toBe('Open feedback form');
+    const labelSpan = fab.find('.brw-fab-label');
+    expect(labelSpan.exists()).toBe(true);
+    expect(labelSpan.text()).toBe('Report a bug');
+  });
+
+  it('offset sets --brw-fab-tab-offset inline on the tab only when non-zero', () => {
+    const wrapper = mountFab({ offset: 120 });
+    const fab = getFab(wrapper).element as HTMLElement;
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('120px');
+  });
+
+  it('offset=0 sets no inline custom property on the tab', () => {
+    const wrapper = mountFab({ offset: 0 });
+    const fab = getFab(wrapper).element as HTMLElement;
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('offset is ignored for the bubble (no inline custom property)', () => {
+    const wrapper = mountFab({ variant: 'bubble', offset: 120 });
+    const fab = getFab(wrapper).element as HTMLElement;
+    expect(fab.style.getPropertyValue('--brw-fab-tab-offset')).toBe('');
+  });
+
+  it('emitted stylesheet declares the vertical tab + keeps the launcher chrome contract', () => {
+    // Tab geometry: writing-mode flips the inline axis vertical.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--tab\s*\{[^}]*writing-mode:\s*vertical-rl/,
+    );
+    // Shared launcher chrome keeps the max-ish stacking contract.
+    expect(BREVWICK_CSS).toMatch(/\.brw-fab\s*\{[^}]*z-index:\s*2147483000/);
+    // Bubble keeps the legacy pill geometry under its own class.
+    expect(BREVWICK_CSS).toMatch(
+      /\.brw-fab--bubble\s*\{[^}]*border-radius:\s*999px/,
+    );
   });
 });
 

--- a/packages/vue/src/components/feedback-button.ts
+++ b/packages/vue/src/components/feedback-button.ts
@@ -18,6 +18,7 @@ import type {
   SubmitError,
   SubmitResult,
 } from '@tatlacas/brevwick-sdk';
+import { resolveLauncherPlacement } from '@tatlacas/brevwick-sdk/launcher';
 import { useFeedback, type FeedbackPhase } from '../composables/use-feedback';
 import {
   BREVWICK_CSS,
@@ -52,31 +53,11 @@ export type FeedbackButtonPosition =
   | 'bottom-left';
 
 /**
- * Resolved launcher placement — the single source of truth shared by the
- * FAB class derivation and the panel anchor. See the resolution table in
- * the design spec (mirrored in every adapter):
- *
- * - Explicit `variant` always wins; `position` then only contributes its
- *   horizontal side (a corner's vertical component is ignored for the tab
- *   — tabs are always vertically centered, ± `offset`).
- * - With `variant` unset, an explicit legacy corner implies the bubble so
- *   pre-existing call sites keep their corner pill; everything else is
- *   the tab (the new default), on the right edge unless `position` says
- *   otherwise.
- *
- * Every combination is total — no throws, no dead states.
+ * The variant/position resolution table (`resolveLauncherPlacement`) is a
+ * pure, framework-agnostic function shared by every adapter, so it lives in
+ * `@tatlacas/brevwick-sdk/launcher` rather than being copied here. See the
+ * resolution semantics in that module (mirrored in SDD § 12).
  */
-function resolveLauncherPlacement(
-  variant?: FeedbackButtonVariant,
-  position?: FeedbackButtonPosition,
-): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
-  const side: 'right' | 'left' =
-    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
-  if (variant !== undefined) return { variant, side };
-  // Legacy compat: an explicit corner without a variant keeps the bubble.
-  const isCorner = position === 'bottom-right' || position === 'bottom-left';
-  return { variant: isCorner ? 'bubble' : 'tab', side };
-}
 
 /**
  * Stable snapshot of one attachment that rode along with a submit. We store

--- a/packages/vue/src/components/feedback-button.ts
+++ b/packages/vue/src/components/feedback-button.ts
@@ -34,6 +34,50 @@ import { BREVWICK_INJECTION_KEY } from '../plugin';
  */
 export type BrevwickTheme = 'light' | 'dark' | 'system';
 
+/** Launcher presentation. `'tab'` (NEW DEFAULT) is a vertical button flush
+ *  against a viewport edge; `'bubble'` is the legacy floating corner pill. */
+export type FeedbackButtonVariant = 'bubble' | 'tab';
+
+/**
+ * Launcher placement.
+ * - `'right' | 'left'`        — edge sides (natural home of the tab).
+ * - `'bottom-right' | 'bottom-left'` — legacy corners (natural home of the
+ *   bubble). Passing one of these WITHOUT an explicit `variant` opts into
+ *   the bubble, preserving pre-2.x call sites byte-for-byte.
+ */
+export type FeedbackButtonPosition =
+  | 'right'
+  | 'left'
+  | 'bottom-right'
+  | 'bottom-left';
+
+/**
+ * Resolved launcher placement — the single source of truth shared by the
+ * FAB class derivation and the panel anchor. See the resolution table in
+ * the design spec (mirrored in every adapter):
+ *
+ * - Explicit `variant` always wins; `position` then only contributes its
+ *   horizontal side (a corner's vertical component is ignored for the tab
+ *   — tabs are always vertically centered, ± `offset`).
+ * - With `variant` unset, an explicit legacy corner implies the bubble so
+ *   pre-existing call sites keep their corner pill; everything else is
+ *   the tab (the new default), on the right edge unless `position` says
+ *   otherwise.
+ *
+ * Every combination is total — no throws, no dead states.
+ */
+function resolveLauncherPlacement(
+  variant?: FeedbackButtonVariant,
+  position?: FeedbackButtonPosition,
+): { variant: FeedbackButtonVariant; side: 'right' | 'left' } {
+  const side: 'right' | 'left' =
+    position === 'left' || position === 'bottom-left' ? 'left' : 'right';
+  if (variant !== undefined) return { variant, side };
+  // Legacy compat: an explicit corner without a variant keeps the bubble.
+  const isCorner = position === 'bottom-right' || position === 'bottom-left';
+  return { variant: isCorner ? 'bubble' : 'tab', side };
+}
+
 /**
  * Stable snapshot of one attachment that rode along with a submit. We store
  * only the underlying `Blob`, mirroring the React adapter's `MessageAttachment`
@@ -160,12 +204,49 @@ function formatRelativeTime(ms: number | undefined): string {
 export const FeedbackButton = defineComponent({
   name: 'BrevwickFeedbackButton',
   props: {
-    position: {
-      type: String as PropType<'bottom-right' | 'bottom-left'>,
-      default: 'bottom-right',
+    /**
+     * Launcher presentation. Default `'tab'` — **this changed in vNEXT**:
+     * the zero-config launcher is now a vertical tab on the right viewport
+     * edge. Pass `variant="bubble"` (or a legacy corner `position`) to keep
+     * the floating corner pill.
+     *
+     * No prop-layer default on purpose — `resolveLauncherPlacement` must
+     * see "unset" so the corner-implies-bubble compat rule can apply.
+     */
+    variant: {
+      type: String as PropType<FeedbackButtonVariant>,
+      default: undefined,
     },
+    /**
+     * Where the launcher sits. Defaults: `'right'` for the tab,
+     * `'bottom-right'` for the bubble.
+     *
+     * Compatibility: passing a legacy corner (`'bottom-right'` /
+     * `'bottom-left'`) without an explicit `variant` renders the BUBBLE at
+     * that corner — existing call sites keep their pre-vNEXT presentation.
+     * When `variant` and `position` disagree (e.g. `variant="tab"` +
+     * `position="bottom-left"`), `variant` wins and `position` contributes
+     * only its horizontal side.
+     */
+    position: {
+      type: String as PropType<FeedbackButtonPosition>,
+      default: undefined,
+    },
+    /**
+     * Icon-only mode. Bubble → 48px circular icon button; tab → compact
+     * square edge tab with just the icon. The `label` is not rendered but
+     * becomes the launcher's `aria-label`. Default `false`.
+     */
+    compact: { type: Boolean, default: false },
+    /**
+     * Tab-only: vertical offset in px from the vertical center of the
+     * viewport. Positive moves the tab down, negative up. Ignored for the
+     * bubble. Default `0`.
+     */
+    offset: { type: Number, default: 0 },
     disabled: { type: Boolean, default: false },
     hidden: { type: Boolean, default: false },
+    /** Launcher label. Default `'Feedback'`. Hidden visually when `compact`. */
     label: { type: String, default: 'Feedback' },
     theme: { type: String as PropType<BrevwickTheme>, default: 'system' },
     className: { type: String, default: '' },
@@ -274,14 +355,38 @@ export const FeedbackButton = defineComponent({
         files.value.length > 0,
     );
 
-    const fabPosClass = computed(() =>
-      props.position === 'bottom-left' ? 'brw-fab-bl' : 'brw-fab-br',
-    );
-    const panelPosClass = computed(() =>
-      props.position === 'bottom-left' ? 'brw-panel-bl' : 'brw-panel-br',
-    );
     const rootClassName = computed(() =>
       ['brw-root', props.className].filter(Boolean).join(' '),
+    );
+    const placement = computed(() =>
+      resolveLauncherPlacement(props.variant, props.position),
+    );
+    const fabClasses = computed(() => {
+      const { variant: v, side } = placement.value;
+      return [
+        rootClassName.value,
+        'brw-fab',
+        v === 'tab' ? 'brw-fab--tab' : 'brw-fab--bubble',
+        v === 'tab'
+          ? side === 'left'
+            ? 'brw-fab-l'
+            : 'brw-fab-r'
+          : side === 'left'
+            ? 'brw-fab-bl'
+            : 'brw-fab-br',
+        props.compact ? 'brw-fab--compact' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+    });
+    const panelPosClass = computed(() =>
+      placement.value.side === 'left' ? 'brw-panel-bl' : 'brw-panel-br',
+    );
+    // Non-compact keeps the established accessible name (the visible label
+    // still supplements it). Compact removes the visible text, so the
+    // `label` string becomes the aria-label.
+    const fabAriaLabel = computed(() =>
+      props.compact ? props.label : 'Open feedback form',
     );
 
     function maybeFetchConfig(): void {
@@ -567,18 +672,32 @@ export const FeedbackButton = defineComponent({
     };
 
     function renderFab(): VNode {
+      const { variant: v } = placement.value;
       return h(
         'button',
         {
           type: 'button',
           'data-brevwick-skip': '',
           'data-brw-theme': props.theme,
-          class: [rootClassName.value, 'brw-fab', fabPosClass.value],
+          'data-brw-variant': v,
+          class: fabClasses.value,
           disabled: props.disabled,
-          'aria-label': 'Open feedback form',
+          'aria-label': fabAriaLabel.value,
+          // `--brw-fab-tab-offset` is a positioning input (like the inline
+          // animation-delay on status rows), not part of the public
+          // --brw-* theming contract — set only when it has an effect.
+          style:
+            v === 'tab' && props.offset !== 0
+              ? { '--brw-fab-tab-offset': `${props.offset}px` }
+              : undefined,
           onClick: handleOpen,
         },
-        [renderChatIcon(), props.label],
+        [
+          renderChatIcon(),
+          props.compact
+            ? null
+            : h('span', { class: 'brw-fab-label' }, props.label),
+        ],
       );
     }
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -14,7 +14,11 @@ export type {
   UseFeedbackResult,
 } from './composables/use-feedback';
 export { FeedbackButton } from './components/feedback-button';
-export type { BrevwickTheme } from './components/feedback-button';
+export type {
+  BrevwickTheme,
+  FeedbackButtonPosition,
+  FeedbackButtonVariant,
+} from './components/feedback-button';
 export { BREVWICK_VUE_VERSION } from './internal/version';
 export type {
   BrevwickPluginOptions,

--- a/packages/vue/src/styles.ts
+++ b/packages/vue/src/styles.ts
@@ -37,7 +37,33 @@ export const BREVWICK_STYLE_ID = 'brevwick-vue-styles';
  */
 export const COMPOSER_MAX_HEIGHT_PX = 120;
 
-export const BREVWICK_CSS = `
+// Launcher (`.brw-fab`) notes — kept OUTSIDE the template literal because
+// CSS comments inside `BREVWICK_CSS` ship in the bundle and the Vue package
+// budget (< 10 kB gzip) has no room for prose. The React adapter carries the
+// same notes inline; the rules below are byte-identical to its stylesheet.
+//
+// - `.brw-fab` is the variant-independent chrome; pill geometry lives under
+//   `.brw-fab--bubble` (legacy corner pill, safe-area-inset corners, compact
+//   48px circle). Only transform animates; box-shadow intentionally static.
+// - `.brw-fab--tab` (NEW DEFAULT): `writing-mode: vertical-rl` flips the
+//   inline axis vertical — the flex row (icon, label) stacks top→bottom and
+//   the label glyphs read top→bottom, rotated 90° cw. The left tab adds
+//   `rotate: 180deg` (the standalone property, NOT transform, so it composes
+//   with the hover translateX) — flat edge stays against the viewport edge,
+//   radii mirror automatically, and the label reads bottom→top,
+//   Userback-style. Rounded on the page-facing side, flat against the edge
+//   (right-tab orientation; the left tab's rotate mirrors it); `border-right:
+//   none` removes the hairline on the flat edge (for `.brw-fab-l` the
+//   pre-rotation right edge IS the viewport edge).
+// - Tab hover pulls the tab 2px out of the edge (`translateY(-50%)` must be
+//   restated — transform is overwritten, not merged). For `.brw-fab-l` the
+//   180° rotate flips -2px into +2px visually: also away from its edge.
+// - Compact tab: square-ish icon-only edge chip.
+// - `--brw-fab-tab-offset` is set inline by the adapter only when
+//   `offset !== 0`; it is a positioning input, not part of the public
+//   `--brw-*` theming contract (no `-base` twin).
+export const BREVWICK_CSS =
+  `
 :where(:root) {
   /* Surfaces */
   --brw-panel-bg-base: #ffffff;
@@ -98,17 +124,19 @@ export const BREVWICK_CSS = `
     --brw-success-base: #34d399;
   }
 }
-/* Forced palettes via <FeedbackButton theme="light|dark">. These rewrite
-   --brw-*-base on .brw-root, so they replace the OS-driven defaults for
-   the widget subtree without ever writing to the public --brw-* names.
-   That preserves host-level :root overrides (the widget consumer path
-   always asks for --brw-X first, with --brw-X-base only as fallback —
-   see the BREVWICK_STYLE_ID jsdoc above). theme="system" deliberately
-   has no rule; the :where(:root) defaults plus the media query already
-   do the right thing. Values duplicated rather than extracted because
-   the stylesheet ships as a literal template string with zero build
-   tooling. */
-.brw-root[data-brw-theme='light'] {
+` +
+  // Forced palettes via <FeedbackButton theme="light|dark">. These rewrite
+  // --brw-*-base on .brw-root, so they replace the OS-driven defaults for
+  // the widget subtree without ever writing to the public --brw-* names.
+  // That preserves host-level :root overrides (the widget consumer path
+  // always asks for --brw-X first, with --brw-X-base only as fallback —
+  // see the BREVWICK_STYLE_ID jsdoc above). theme="system" deliberately
+  // has no rule; the :where(:root) defaults plus the media query already
+  // do the right thing. Values duplicated rather than extracted because
+  // the stylesheet ships as a literal template string with zero build
+  // tooling. (TS comment, not a CSS comment, so it does not ship in the
+  // bundle — see the budget note above BREVWICK_CSS.)
+  `.brw-root[data-brw-theme='light'] {
   --brw-panel-bg-base: #ffffff;
   --brw-bubble-assistant-bg-base: #f1f5f9;
   --brw-bubble-user-bg-base: #0f172a;
@@ -149,11 +177,6 @@ export const BREVWICK_CSS = `
 .brw-fab {
   position: fixed;
   z-index: 2147483000;
-  bottom: 24px;
-  height: 48px;
-  min-width: 48px;
-  padding: 0 18px;
-  border-radius: 999px;
   border: 1px solid var(--brw-border, var(--brw-border-base));
   background: var(--brw-accent, var(--brw-accent-base));
   color: var(--brw-accent-fg, var(--brw-accent-fg-base));
@@ -164,17 +187,58 @@ export const BREVWICK_CSS = `
   gap: 8px;
   cursor: pointer;
   box-shadow: var(--brw-shadow, var(--brw-shadow-base));
-  /* Only transform animates on hover; box-shadow is static so it is
-     intentionally excluded from the transition list. */
   transition: transform 120ms ease-out;
 }
-.brw-fab:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
 .brw-fab:disabled { cursor: not-allowed; opacity: 0.5; }
-.brw-fab-br { right: 24px; }
-.brw-fab-bl { left: 24px; }
-.brw-fab-icon { width: 18px; height: 18px; }
+.brw-fab:focus-visible {
+  outline: 2px solid var(--brw-border-focus, var(--brw-border-focus-base));
+  outline-offset: 2px;
+}
+.brw-fab-icon { width: 18px; height: 18px; flex-shrink: 0; }
+.brw-fab--bubble {
+  bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  height: 48px;
+  min-width: 48px;
+  padding: 0 18px;
+  border-radius: 999px;
+}
+.brw-fab--bubble:hover:not(:disabled) { transform: translateY(-1px); }
+.brw-fab-br { right: calc(24px + env(safe-area-inset-right, 0px)); }
+.brw-fab-bl { left: calc(24px + env(safe-area-inset-left, 0px)); }
+.brw-fab--bubble.brw-fab--compact {
+  width: 48px;
+  min-width: 48px;
+  padding: 0;
+  justify-content: center;
+}
+.brw-fab--tab {
+  top: calc(50% + var(--brw-fab-tab-offset, 0px));
+  transform: translateY(-50%);
+  writing-mode: vertical-rl;
+  min-height: 48px;
+  width: 40px;
+  padding: 16px 0;
+  justify-content: center;
+  border-radius: 10px 0 0 10px;
+}
+.brw-fab-r {
+  right: env(safe-area-inset-right, 0px);
+  border-right: none;
+}
+.brw-fab-l {
+  left: env(safe-area-inset-left, 0px);
+  border-right: none;
+  rotate: 180deg;
+}
+.brw-fab--tab:hover:not(:disabled) {
+  transform: translateY(-50%) translateX(-2px);
+}
+.brw-fab-label { letter-spacing: 0.02em; }
+.brw-fab--tab.brw-fab--compact {
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
+}
 .brw-panel {
   position: fixed;
   z-index: 2147483002;
@@ -536,19 +600,21 @@ export const BREVWICK_CSS = `
   border-color: var(--brw-accent, var(--brw-accent-base));
 }
 .brw-error { color: var(--brw-error-base); font-size: 12px; align-self: stretch; }
-/* Staged-status rows: progress indicators, not conversation bubbles.
-   They sit under a dashed top divider as a compact stacked checklist,
-   mirroring the marketing AnimatedDemo widget mock — and intentionally
-   stay outside the .brw-bubble class family so message-count queries
-   ignore them. .brw-status-rows is the grouping container that owns the
-   divider + stacking; .brw-status-row is one ticked line. The
-   animation-delay is set inline per row so the three rows fade in
-   sequentially under the shared @keyframes entrance even when the
-   underlying SDK phase events fire microseconds apart. The
-   reduced-motion media query collapses the entrance to an instant fade,
-   pairing with the inline 0ms delay the adapter passes when the user
-   has prefers-reduced-motion: reduce. */
-.brw-status-rows {
+` +
+  // Staged-status rows: progress indicators, not conversation bubbles.
+  // They sit under a dashed top divider as a compact stacked checklist,
+  // mirroring the marketing AnimatedDemo widget mock — and intentionally
+  // stay outside the .brw-bubble class family so message-count queries
+  // ignore them. .brw-status-rows is the grouping container that owns the
+  // divider + stacking; .brw-status-row is one ticked line. The
+  // animation-delay is set inline per row so the three rows fade in
+  // sequentially under the shared @keyframes entrance even when the
+  // underlying SDK phase events fire microseconds apart. The
+  // reduced-motion media query collapses the entrance to an instant fade,
+  // pairing with the inline 0ms delay the adapter passes when the user
+  // has prefers-reduced-motion: reduce. (TS comment, not a CSS comment, so
+  // it does not ship in the bundle — see the budget note above BREVWICK_CSS.)
+  `.brw-status-rows {
   align-self: stretch;
   display: flex;
   flex-direction: column;

--- a/packages/vue/src/styles.ts
+++ b/packages/vue/src/styles.ts
@@ -47,17 +47,21 @@ export const COMPOSER_MAX_HEIGHT_PX = 120;
 //   48px circle). Only transform animates; box-shadow intentionally static.
 // - `.brw-fab--tab` (NEW DEFAULT): `writing-mode: vertical-rl` flips the
 //   inline axis vertical — the flex row (icon, label) stacks top→bottom and
-//   the label glyphs read top→bottom, rotated 90° cw. The left tab adds
-//   `rotate: 180deg` (the standalone property, NOT transform, so it composes
-//   with the hover translateX) — flat edge stays against the viewport edge,
-//   radii mirror automatically, and the label reads bottom→top,
-//   Userback-style. Rounded on the page-facing side, flat against the edge
-//   (right-tab orientation; the left tab's rotate mirrors it); `border-right:
-//   none` removes the hairline on the flat edge (for `.brw-fab-l` the
-//   pre-rotation right edge IS the viewport edge).
-// - Tab hover pulls the tab 2px out of the edge (`translateY(-50%)` must be
-//   restated — transform is overwritten, not merged). For `.brw-fab-l` the
-//   180° rotate flips -2px into +2px visually: also away from its edge.
+//   the label glyphs read top→bottom, rotated 90° cw. The left tab mirrors
+//   the flat edge / radii by rotating 180° via the `--brw-fab-tab-flip`
+//   custom property composed INSIDE `transform` (after the centering
+//   translateY) — flat edge stays against the viewport edge, radii mirror,
+//   and the label reads bottom→top, Userback-style. Composing the rotate in
+//   `transform` (not the standalone `rotate` property, which applies AFTER
+//   `transform` per CSS Transforms L2) keeps `translateY(-50%)` the
+//   outermost transform, so it never inverts into `+50%` and the left tab
+//   stays vertically centred. `border-right: none` removes the hairline on
+//   the flat edge (for `.brw-fab-l` the pre-flip right edge IS the
+//   viewport edge).
+// - Tab hover pulls the tab 2px out of the edge (the whole transform is
+//   restated — transform is overwritten, not merged). translateX(-2px) is
+//   innermost, so `.brw-fab-l`'s 180° flip turns it into +2px visually:
+//   also away from its edge.
 // - Compact tab: square-ish icon-only edge chip.
 // - `--brw-fab-tab-offset` is set inline by the adapter only when
 //   `offset !== 0`; it is a positioning input, not part of the public
@@ -213,7 +217,7 @@ export const BREVWICK_CSS =
 }
 .brw-fab--tab {
   top: calc(50% + var(--brw-fab-tab-offset, 0px));
-  transform: translateY(-50%);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg));
   writing-mode: vertical-rl;
   min-height: 48px;
   width: 40px;
@@ -228,10 +232,10 @@ export const BREVWICK_CSS =
 .brw-fab-l {
   left: env(safe-area-inset-left, 0px);
   border-right: none;
-  rotate: 180deg;
+  --brw-fab-tab-flip: 180deg;
 }
 .brw-fab--tab:hover:not(:disabled) {
-  transform: translateY(-50%) translateX(-2px);
+  transform: translateY(-50%) rotate(var(--brw-fab-tab-flip, 0deg)) translateX(-2px);
 }
 .brw-fab-label { letter-spacing: 0.02em; }
 .brw-fab--tab.brw-fab--compact {


### PR DESCRIPTION
## Summary

Adds a second launcher presentation to the `FeedbackButton` across all six adapters, plus an icon-only compact mode.

### New API

- **`variant: 'tab' | 'bubble'`** — `'tab'` renders a vertical tab flush against the viewport edge (host-view edge on React Native), vertically centered; `'bubble'` is the legacy floating corner pill.
- **`compact: boolean`** — icon-only mode for either variant (circular bubble / square edge tab). The `label` is not rendered visually but becomes the launcher's `aria-label`.
- **`offset: number`** — nudges the tab up/down from vertical center, in px (tab variant only).
- **`position`** — gains the edge sides `'right' | 'left'` alongside the legacy corners. Defaults: `'right'` for the tab, `'bottom-right'` for the bubble.

### Intentional default change

A no-config `<FeedbackButton />` now renders the **right-edge tab** instead of the bottom-right bubble. This is deliberate.

**Backwards compatibility rule:** passing a legacy corner `position` (`'bottom-right'` / `'bottom-left'`, or the offset-object form on React Native) without an explicit `variant` implies `variant="bubble"`, so existing call sites that configured a corner render exactly as before. When both are set, `variant` wins and `position` contributes only its horizontal side.

### Per-adapter coverage

Implemented with matching behavior and tests in every adapter:

- `@tatlacas/brevwick-react`
- `@tatlacas/brevwick-solid`
- `@tatlacas/brevwick-vue`
- `@tatlacas/brevwick-svelte` (new `src/lib/launcher.ts` placement helper)
- `@tatlacas/brevwick-angular`
- `@tatlacas/brevwick-react-native`

Changeset: `.changeset/launcher-tab-compact.md` — minor bump for the six adapters (the `fixed` group moves `sdk` along automatically).

### Test results

- `pnpm lint` — PASS
- `pnpm type-check` — PASS
- `pnpm test` — PASS (837 tests across packages; the only skips are pre-existing legacy `.skip` markers unrelated to the launcher)
- `pnpm build` — PASS
- `pnpm size` — PASS. Two budgets initially regressed and were fixed by condensing comments only — **no budget in `.size-limit.js` was raised**, and no runtime code/CSS/test changes were needed:
  - `@tatlacas/brevwick-svelte` FeedbackButton SFC: 15.8 kB → **13.54 kB** gzip (limit 14 kB; svelte-package ships the raw SFC, so source comments count)
  - `@tatlacas/brevwick-angular` FESM2022: 18.5 kB → **17.84 kB** gzip (limit 18 kB; TS comments survive into the ng-packagr bundle)