### PR TITLE
fix: strip control chars from captures, elide binary responses

### DIFF
--- a/.changeset/strip-control-chars.md
+++ b/.changeset/strip-control-chars.md
@@ -1,0 +1,20 @@
+---
+'@tatlacas/brevwick-sdk': patch
+'@tatlacas/brevwick-react': patch
+'@tatlacas/brevwick-solid': patch
+'@tatlacas/brevwick-vue': patch
+'@tatlacas/brevwick-svelte': patch
+'@tatlacas/brevwick-angular': patch
+'@tatlacas/brevwick-react-native': patch
+---
+
+fix: strip control chars from captured bodies and elide binary responses
+
+The network ring read binary response bodies as text whenever the content-type slipped past the binary gate — most commonly a `font/woff2` download. A WOFF2 font read via `Response.text()` carries NUL (U+0000) bytes, which the ingest API cannot store in its `text`/`jsonb` columns: every such submission failed the server-side `INSERT` and came back **500** (and the oversized bodies also tripped occasional **413**s).
+
+Two layers of fix:
+
+- `redact()` — the mandatory pre-send chokepoint every ring and the submit pipeline pass through — now strips C0 control characters (NUL et al., keeping `\t` `\n` `\r`) and DEL as an unconditional final pass, so no captured string can carry a NUL regardless of which ring produced it.
+- The network ring's binary content-type gate now also covers `font/*` and `application/wasm|pdf|zip|gzip|x-protobuf|font-*`, so those bodies are recorded as `[binary N bytes]` instead of being read as text — fixing the payload bloat behind the 413s.
+
+The server adds the same NUL-stripping as defence-in-depth, but this stops the bad bytes at the source.

--- a/packages/sdk/src/core/internal/__tests__/redact.test.ts
+++ b/packages/sdk/src/core/internal/__tests__/redact.test.ts
@@ -155,3 +155,50 @@ describe('redactValue', () => {
     expect(redactValue(true)).toBe(true);
   });
 });
+
+describe('redact (control chars)', () => {
+  const NUL = String.fromCharCode(0);
+
+  it('strips NUL bytes', () => {
+    expect(redact('a' + NUL + 'b')).toBe('ab');
+  });
+
+  it('strips the WOFF2-as-text shape that 500d ingest', () => {
+    // A font body read via Response.text() — magic header + NUL bytes.
+    expect(redact('wOF2' + NUL + NUL + 'bin')).toBe('wOF2bin');
+  });
+
+  it('strips C0 control chars and DEL', () => {
+    const controls =
+      String.fromCharCode(1) +
+      String.fromCharCode(7) +
+      String.fromCharCode(0x1f) +
+      String.fromCharCode(0x7f);
+    expect(redact('x' + controls + 'y')).toBe('xy');
+  });
+
+  it('preserves tab, newline, and carriage return', () => {
+    expect(redact('a\tb\nc\rd')).toBe('a\tb\nc\rd');
+  });
+
+  it('strips control chars even when redaction is fully disabled', () => {
+    const r = createRedactor(
+      new Set([
+        'auth',
+        'cookie',
+        'bearer',
+        'jwt',
+        'email',
+        'card',
+        'ip',
+        'ssn',
+        'phone',
+        'aws',
+        'github',
+        'base64',
+      ]),
+      [],
+    );
+    expect(r('keep' + NUL + 'me')).toBe('keepme');
+  });
+});

--- a/packages/sdk/src/core/internal/redact.ts
+++ b/packages/sdk/src/core/internal/redact.ts
@@ -184,6 +184,21 @@ function buildPatterns(
 
 const DEFAULT_PATTERNS = buildPatterns(new Set(), []);
 
+/**
+ * C0 control characters that must never ride out on the wire, minus the three
+ * whitespace controls a captured text body legitimately contains (`\t`, `\n`,
+ * `\r`) plus DEL (U+007F). The critical one is **NUL (U+0000)**: Postgres
+ * rejects U+0000 in `text` and `jsonb` columns, so a single NUL in a captured
+ * console line or network response body fails the server-side `INSERT` and
+ * 500s the whole submission. These bytes show up when a ring reads a binary
+ * payload as text (e.g. a WOFF2 font served with a non-binary content-type).
+ * Stripping them here — at the mandatory redaction chokepoint every ring and
+ * the submit pipeline pass through — guarantees no payload leaves the device
+ * carrying one, regardless of which ring captured it.
+ */
+// eslint-disable-next-line no-control-regex -- stripping control chars is the point
+const CONTROL_CHARS = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
 export interface Redactor {
   (input: string): string;
 }
@@ -221,7 +236,12 @@ export function createRedactor(
       }
       out = out.replace(pattern, replacement);
     }
-    return out;
+    // Final, unconditional pass: drop control chars (NUL et al.) that a ring
+    // may have captured from a binary body read as text. Runs after the
+    // redaction patterns and is not gated by `disable`/`custom` — a NUL on
+    // the wire is a correctness bug (server-side INSERT 500), not a
+    // tunable redaction preference.
+    return out.replace(CONTROL_CHARS, '');
   };
 }
 

--- a/packages/sdk/src/rings/__tests__/network.test.ts
+++ b/packages/sdk/src/rings/__tests__/network.test.ts
@@ -508,6 +508,31 @@ describe('network ring — fetch', () => {
     expect(entry?.responseBody).toBe(`[binary ${payload.byteLength} bytes]`);
   });
 
+  it('records font responses as [binary N bytes] (the WOFF2 ingest-500 fix)', async () => {
+    // Regression: a WOFF2 font (content-type font/woff2) used to fall through
+    // BINARY_CONTENT_TYPE and get read via .text(), smuggling NUL bytes into
+    // responseBody that 500d the server-side INSERT. font/* now elides to the
+    // synthetic marker — no body bytes, no NUL.
+    const payload = new Uint8Array([
+      0x77, 0x4f, 0x46, 0x32, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    window.fetch = vi.fn(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { 'content-type': 'font/woff2' },
+        }),
+    ) as unknown as typeof window.fetch;
+
+    const instance = createBrevwick({ projectKey: KEY });
+    await installAndReady(instance);
+
+    await window.fetch('/fonts/inter.woff2');
+    const [entry] = networkEntries(instance);
+    expect(entry?.responseBody).toBe(`[binary ${payload.byteLength} bytes]`);
+    expect(entry?.responseBody).not.toContain(String.fromCharCode(0));
+  });
+
   it('omits the request body for unknown body types (ReadableStream)', async () => {
     // Exercises the `return { kind: 'empty' }` fallback in stringifyBody —
     // a body that is not string / URLSearchParams / Blob / ArrayBuffer /

--- a/packages/sdk/src/rings/network.ts
+++ b/packages/sdk/src/rings/network.ts
@@ -43,7 +43,17 @@ const HEADER_ALLOWLIST: ReadonlySet<string> = new Set([
   'x-trace-id',
 ]);
 
-const BINARY_CONTENT_TYPE = /(^image\/)|(^audio\/)|(^video\/)|octet-stream/i;
+// Content-types whose body we elide to a `[binary N bytes]` marker instead of
+// reading as text. Reading binary as text both bloats the payload (a font or
+// image runs to MiB — the source of the 413s) and, worse, smuggles NUL bytes
+// into the capture: a WOFF2 font read via `.text()` carries U+0000, which the
+// server cannot store in a text/jsonb column and 500s the whole submission.
+// `font/*` and `application/wasm|pdf|zip|gzip|x-protobuf` join the original
+// image/audio/video/octet-stream set so the common asset types are caught at
+// the content-type gate; the control-char strip in `redact()` is the catch-all
+// for anything served with a misleading text content-type.
+const BINARY_CONTENT_TYPE =
+  /(^image\/)|(^audio\/)|(^video\/)|(^font\/)|octet-stream|application\/(wasm|pdf|zip|gzip|x-protobuf|font-)/i;
 
 function sanitiseHeaders(
   pairs: Iterable<readonly [string, string]>,

--- a/packages/solid/src/__tests__/chunk-split.test.ts
+++ b/packages/solid/src/__tests__/chunk-split.test.ts
@@ -20,17 +20,19 @@ describe('@tatlacas/brevwick-solid bundle ceiling', () => {
   const hasDist = existsSync(baseEsm) && existsSync(baseCjs);
   const suite = hasDist ? describe : describe.skip;
 
-  // 12 kB gzip ceiling, expressed in 1000-based bytes the way size-limit
-  // reads it. Bumped from 5 kB → 12 kB in issue #113 when the Solid widget
-  // reached UX parity with the React adapter — kept in lockstep with the
-  // entries in `.size-limit.js` and the `CLAUDE.md` budget table.
-  const LIMIT_BYTES = 12_000;
+  // 13 kB gzip ceiling, expressed in 1000-based bytes the way size-limit
+  // reads it. Bumped 5 kB → 12 kB in issue #113 (Solid UX parity with React),
+  // then 12 kB → 13 kB when the launcher redesign (PR #157) landed on top of
+  // the restored screenshot button. This constant had lagged that last bump;
+  // realigned to match the authoritative `.size-limit.js` entries and the
+  // `CLAUDE.md` budget table, both of which already read 13 kB.
+  const LIMIT_BYTES = 13_000;
 
   suite('dist/ exists', () => {
     it.each([
       ['ESM', baseEsm],
       ['CJS', baseCjs],
-    ])('%s bundle is under the 12 kB gzip budget', async (_label, path) => {
+    ])('%s bundle is under the 13 kB gzip budget', async (_label, path) => {
       const { gzipSync } = await import('node:zlib');
       const raw = readFileSync(path);
       const gzipped = gzipSync(raw).length;


### PR DESCRIPTION
## Problem

Every `POST /v1/ingest/issues` from the beta dashboard widget was returning **500**, with occasional **413**s. Traced from the beta Postgres logs:

```
ERROR:  unsupported Unicode escape sequence
DETAIL:    cannot be converted to text.
CONTEXT: JSON data, line 1: ...,"responseBody":"wOF2 ...
```

The network ring captured a **WOFF2 font** response (`wOF2...`) as `network_calls[].responseBody`. The body's content-type (`font/woff2`) slipped past `BINARY_CONTENT_TYPE` (which only matched `image|audio|video|octet-stream`), so the ring read it via `Response.text()`. A binary font read as text carries **NUL (U+0000)** bytes — and Postgres cannot store U+0000 in `text`/`jsonb`, so the server-side `INSERT` failed and the whole submission 500d. The same oversized binary bodies also produced the 413s.

## Fix (two layers)

1. **`redact()` strips control chars.** The mandatory pre-send chokepoint every ring and the submit pipeline pass through now drops C0 control characters (NUL et al., preserving `\t` `\n` `\r`) and DEL as an unconditional final pass — not gated by `disable`/`custom`, because a NUL on the wire is a correctness bug, not a tunable preference. No captured string can carry a NUL regardless of which ring produced it.
2. **The network ring elides more binary types.** `BINARY_CONTENT_TYPE` now also matches `font/*` and `application/wasm|pdf|zip|gzip|x-protobuf|font-*`, so those bodies are recorded as `[binary N bytes]` instead of read as text — this is what fixes the 413 bloat.

The ingest API adds the same NUL-stripping as defence-in-depth (brevwick-api#344), but this stops the bad bytes at the source.

## Also in this PR

- `packages/solid/src/__tests__/chunk-split.test.ts` — the gzip-budget constant had drifted: `.size-limit.js` and the `CLAUDE.md` budget table both read **13 kB** (bumped when the launcher redesign landed, PR #157), but this vitest constant still read `12_000`. Realigned to `13_000` so the test matches the authoritative budget. The Solid CJS bundle is ~12.1 kB — within budget; the few bytes added by the `redact()` strip tipped it past the stale 12 kB constant.

## Test plan

- `redact.test.ts` — strips NUL, the WOFF2-as-text shape, and C0/DEL controls; preserves tab/newline/CR; strips even when all redaction patterns are disabled.
- `network.test.ts` — a `font/woff2` response is recorded as `[binary N bytes]` with no NUL.
- Full gauntlet green locally: `pnpm format:check && pnpm lint && pnpm type-check && pnpm test && pnpm build` across all seven packages.

Changeset: `fix` (patch) across the fixed package group.
